### PR TITLE
Day 05/manual entry subscription mgmt

### DIFF
--- a/backend/alembic/versions/20260406_0003_add_subscription_website_url.py
+++ b/backend/alembic/versions/20260406_0003_add_subscription_website_url.py
@@ -1,0 +1,18 @@
+"""Add website URL support to subscriptions."""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260406_0003"
+down_revision = "20260404_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("subscriptions", sa.Column("website_url", sa.String(length=500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("subscriptions", "website_url")

--- a/backend/src/models/subscription.py
+++ b/backend/src/models/subscription.py
@@ -23,6 +23,7 @@ class Subscription(TimestampMixin, Base):
     name: Mapped[str] = mapped_column(String(150))
     vendor: Mapped[str] = mapped_column(String(150))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    website_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
     currency: Mapped[str] = mapped_column(String(3), nullable=False)
     cadence: Mapped[str] = mapped_column(String(20), nullable=False)

--- a/backend/src/schemas/subscription.py
+++ b/backend/src/schemas/subscription.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
@@ -25,10 +26,26 @@ def _normalize_choice(value: str, field_name: str) -> str:
     return normalized
 
 
+def _normalize_url(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        return None
+
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Website URL must be a valid http or https URL.")
+
+    return normalized
+
+
 class SubscriptionCreate(BaseModel):
     name: str
     vendor: str
     description: str | None = None
+    website_url: str | None = None
     amount: Decimal
     currency: str
     cadence: str
@@ -59,6 +76,11 @@ class SubscriptionCreate(BaseModel):
             return None
         normalized = value.strip()
         return normalized or None
+
+    @field_validator("website_url")
+    @classmethod
+    def validate_website_url(cls, value: str | None) -> str | None:
+        return _normalize_url(value)
 
     @field_validator("amount")
     @classmethod
@@ -102,6 +124,7 @@ class SubscriptionUpdate(BaseModel):
     name: str | None = None
     vendor: str | None = None
     description: str | None = None
+    website_url: str | None = None
     amount: Decimal | None = None
     currency: str | None = None
     cadence: str | None = None
@@ -136,6 +159,11 @@ class SubscriptionUpdate(BaseModel):
             return None
         normalized = value.strip()
         return normalized or None
+
+    @field_validator("website_url")
+    @classmethod
+    def validate_website_url(cls, value: str | None) -> str | None:
+        return _normalize_url(value)
 
     @field_validator("amount")
     @classmethod
@@ -185,6 +213,7 @@ class SubscriptionResponse(BaseModel):
     name: str
     vendor: str
     description: str | None
+    website_url: str | None
     amount: Decimal
     currency: str
     cadence: str

--- a/backend/tests/api/test_subscriptions.py
+++ b/backend/tests/api/test_subscriptions.py
@@ -47,6 +47,7 @@ def test_subscriptions_support_crud_and_filters(client) -> None:
             "name": "Netflix",
             "vendor": "Netflix",
             "description": "Primary streaming service",
+            "website_url": "https://www.netflix.com",
             "amount": "15.49",
             "currency": "usd",
             "cadence": "monthly",
@@ -66,6 +67,7 @@ def test_subscriptions_support_crud_and_filters(client) -> None:
     assert created["currency"] == "USD"
     assert created["status"] == "active"
     assert created["payment_method_id"] == payment_method_id
+    assert created["website_url"] == "https://www.netflix.com"
 
     second_response = client.post(
         "/api/v1/subscriptions",
@@ -105,6 +107,7 @@ def test_subscriptions_support_crud_and_filters(client) -> None:
             "amount": "17.99",
             "status": "cancelled",
             "end_date": "2026-06-01",
+            "website_url": "https://www.netflix.com/account",
             "notes": "Cancelled after price increase",
         },
     )
@@ -113,6 +116,7 @@ def test_subscriptions_support_crud_and_filters(client) -> None:
     assert updated["amount"] == "17.99"
     assert updated["status"] == "cancelled"
     assert updated["end_date"] == "2026-06-01"
+    assert updated["website_url"] == "https://www.netflix.com/account"
 
     delete_response = client.delete(f"/api/v1/subscriptions/{created['id']}", headers=owner_headers)
     assert delete_response.status_code == 204
@@ -192,3 +196,18 @@ def test_subscriptions_enforce_validation_and_ownership(client) -> None:
     )
     assert invalid_dates_response.status_code == 422
     assert invalid_dates_response.json()["detail"] == "end_date must be on or after start_date."
+
+    invalid_url_response = client.post(
+        "/api/v1/subscriptions",
+        headers=owner_headers,
+        json={
+            "name": "Bad URL Service",
+            "vendor": "Bad URL Service",
+            "amount": "12.00",
+            "currency": "USD",
+            "cadence": "monthly",
+            "start_date": "2026-04-01",
+            "website_url": "notaurl",
+        },
+    )
+    assert invalid_url_response.status_code == 422

--- a/frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  ExternalLink,
+  LoaderCircle,
+  PencilLine,
+  Power,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import { SubscriptionForm } from "@/components/subscriptions/subscription-form";
+import { StatusBadge } from "@/components/subscriptions/status-badge";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import { CurrencyDisplay } from "@/components/ui/currency-display";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  useDeleteSubscription,
+  useSubscription,
+  useSubscriptionCatalog,
+  useUpdateSubscription,
+} from "@/hooks/use-subscriptions";
+import { subscriptionStatusOptions } from "@/lib/validators";
+import type { SubscriptionStatus } from "@/types";
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "Not set";
+  }
+
+  const parts = value.split("-").map((part) => Number(part));
+  const date =
+    parts.length === 3 && parts.every((part) => Number.isFinite(part))
+      ? new Date(parts[0], parts[1] - 1, parts[2])
+      : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+export default function SubscriptionDetailPage() {
+  const params = useParams<{ subscriptionId: string }>();
+  const router = useRouter();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const subscriptionId = Number(params.subscriptionId);
+  const { categoriesQuery, paymentMethodsQuery } = useSubscriptionCatalog();
+  const subscriptionQuery = useSubscription(subscriptionId);
+  const updateSubscription = useUpdateSubscription(subscriptionId);
+  const deleteSubscription = useDeleteSubscription(subscriptionId);
+
+  if (!Number.isFinite(subscriptionId)) {
+    return (
+      <EmptyState
+        description="The requested subscription id is invalid. Return to the list and choose a valid plan."
+        title="Invalid subscription route"
+      />
+    );
+  }
+
+  const subscription = subscriptionQuery.data;
+  const categories = categoriesQuery.data?.items ?? [];
+  const paymentMethods = paymentMethodsQuery.data?.items ?? [];
+  const categoryName = categories.find((category) => category.id === subscription?.category_id)?.name;
+  const paymentMethod = paymentMethods.find(
+    (entry) => entry.id === subscription?.payment_method_id,
+  );
+
+  if (subscriptionQuery.isLoading) {
+    return (
+      <div className="flex min-h-72 items-center justify-center rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
+        <div className="flex items-center gap-3 text-sm text-black/58">
+          <LoaderCircle className="size-4 animate-spin" />
+          Loading subscription detail...
+        </div>
+      </div>
+    );
+  }
+
+  if (!subscription) {
+    return (
+      <EmptyState
+        action={
+          <Button asChild className="rounded-full px-5" variant="outline">
+            <Link href="/subscriptions">
+              Return to subscriptions
+              <ArrowLeft className="ml-2 size-4" />
+            </Link>
+          </Button>
+        }
+        description="This subscription could not be loaded. It may have been deleted or the route is stale."
+        title="Subscription not found"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-8 animate-page-enter">
+      <PageHeader
+        action={
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Button asChild className="rounded-full px-5" variant="outline">
+              <Link href="/subscriptions">
+                <ArrowLeft className="mr-2 size-4" />
+                Back to list
+              </Link>
+            </Button>
+            <Button className="rounded-full px-5" onClick={() => setIsEditing((open) => !open)} variant="outline">
+              <PencilLine className="mr-2 size-4" />
+              {isEditing ? "Close editor" : "Edit subscription"}
+            </Button>
+          </div>
+        }
+        description="Review billing terms, change lifecycle status, update details, or remove the plan from the Day 5 management surface."
+        eyebrow="Subscription detail"
+        title={subscription.name}
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(360px,0.95fr)]">
+        <section className="space-y-5 rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+          <div className="flex flex-col gap-5 border-b border-black/10 pb-6 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.32em] text-black/45">
+                {categoryName ?? "Uncategorized"}
+              </p>
+              <div>
+                <h2 className="text-3xl font-semibold text-ink">{subscription.name}</h2>
+                <p className="mt-2 text-base text-black/58">{subscription.vendor}</p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <StatusBadge className="w-fit" status={subscription.status} />
+              <CurrencyDisplay
+                className="block text-3xl font-semibold text-ink"
+                currency={subscription.currency}
+                value={Number(subscription.amount)}
+              />
+              <p className="text-sm capitalize text-black/52">{subscription.cadence} billing</p>
+            </div>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <div className="rounded-[1.5rem] border border-black/10 bg-stone/60 p-5">
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Lifecycle</p>
+              <dl className="mt-4 space-y-3 text-sm text-black/64">
+                <div>
+                  <dt className="font-medium text-ink">Start date</dt>
+                  <dd>{formatDate(subscription.start_date)}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-ink">Next charge</dt>
+                  <dd>{formatDate(subscription.next_charge_date)}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-ink">End date</dt>
+                  <dd>{formatDate(subscription.end_date)}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-ink">Auto renew</dt>
+                  <dd>{subscription.auto_renew ? "Enabled" : "Disabled"}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="rounded-[1.5rem] border border-black/10 bg-stone/60 p-5">
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Metadata</p>
+              <dl className="mt-4 space-y-3 text-sm text-black/64">
+                <div>
+                  <dt className="font-medium text-ink">Billing day</dt>
+                  <dd>{subscription.day_of_month ?? "Not set"}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-ink">Payment method</dt>
+                  <dd>
+                    {paymentMethod
+                      ? `${paymentMethod.label}${paymentMethod.last4 ? ` •••• ${paymentMethod.last4}` : ""}`
+                      : "Not assigned"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-ink">Website</dt>
+                  <dd>
+                    {subscription.website_url ? (
+                      <a
+                        className="inline-flex items-center gap-1.5 font-medium text-ink transition hover:text-ember"
+                        href={subscription.website_url}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        Open website
+                        <ExternalLink className="size-4" />
+                      </a>
+                    ) : (
+                      "Not set"
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <section className="rounded-[1.5rem] border border-black/10 bg-white/88 p-5">
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Description</p>
+              <p className="mt-4 text-sm leading-7 text-black/66">
+                {subscription.description || "No description captured for this subscription yet."}
+              </p>
+            </section>
+
+            <section className="rounded-[1.5rem] border border-black/10 bg-white/88 p-5">
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Notes</p>
+              <p className="mt-4 text-sm leading-7 text-black/66">
+                {subscription.notes || "No operator notes captured for this subscription yet."}
+              </p>
+            </section>
+          </div>
+        </section>
+
+        <div className="space-y-5">
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-xs uppercase tracking-[0.32em] text-black/45">Lifecycle actions</p>
+                <h2 className="mt-2 text-2xl font-semibold text-ink">Change status</h2>
+              </div>
+              <Power className="size-5 text-black/45" />
+            </div>
+
+            <div className="mt-5 grid gap-3">
+              {subscriptionStatusOptions.map((status) => (
+                <Button
+                  className="justify-between rounded-[1.2rem] px-4"
+                  disabled={updateSubscription.isPending || status === subscription.status}
+                  key={status}
+                  onClick={() => {
+                    void updateSubscription.mutateAsync({ status: status as SubscriptionStatus });
+                  }}
+                  type="button"
+                  variant={status === subscription.status ? "default" : "outline"}
+                >
+                  <span className="capitalize">{status}</span>
+                  {status === subscription.status ? "Current" : "Apply"}
+                </Button>
+              ))}
+            </div>
+
+            <Button
+              className="mt-5 w-full rounded-[1.2rem] bg-ember text-white hover:bg-ember/92"
+              disabled={deleteSubscription.isPending}
+              onClick={() => setIsDeleteDialogOpen(true)}
+              type="button"
+            >
+              <Trash2 className="mr-2 size-4" />
+              Delete subscription
+            </Button>
+          </section>
+
+          {isEditing ? (
+            <SubscriptionForm
+              categories={categories}
+              description="Update billing details, dates, status, URL, and notes from the dedicated subscription route."
+              disabled={categoriesQuery.isLoading || paymentMethodsQuery.isLoading}
+              initialSubscription={subscription}
+              onCancel={() => setIsEditing(false)}
+              onSubmit={async (payload) => {
+                await updateSubscription.mutateAsync(payload);
+                setIsEditing(false);
+              }}
+              paymentMethods={paymentMethods}
+              submitLabel="Save changes"
+              title="Edit subscription"
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <ConfirmDialog
+        confirmLabel={deleteSubscription.isPending ? "Deleting..." : "Delete subscription"}
+        description="This removes the subscription from the Day 5 management workspace and returns you to the list."
+        onConfirm={() => {
+          void deleteSubscription.mutateAsync().then(() => {
+            router.replace("/subscriptions");
+          });
+        }}
+        onOpenChange={setIsDeleteDialogOpen}
+        open={isDeleteDialogOpen}
+        title="Delete this subscription?"
+        tone="danger"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/subscriptions/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/page.tsx
@@ -1,33 +1,182 @@
-import Link from "next/link";
-import { ArrowRight, Sparkles } from "lucide-react";
+"use client";
 
+import Link from "next/link";
+import { useDeferredValue, useState } from "react";
+import { ArrowRight, LayoutGrid, List, LoaderCircle, Search, Sparkles } from "lucide-react";
+
+import { SubscriptionCard } from "@/components/subscriptions/subscription-card";
+import { SubscriptionForm } from "@/components/subscriptions/subscription-form";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { useCreateSubscription, useSubscriptionCatalog, useSubscriptionList } from "@/hooks/use-subscriptions";
+import { subscriptionStatusOptions } from "@/lib/validators";
+import type { SubscriptionStatus } from "@/types";
 
 export default function SubscriptionsPage() {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<"all" | SubscriptionStatus>("all");
+  const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const deferredSearch = useDeferredValue(search);
+
+  const createSubscription = useCreateSubscription();
+  const { categoriesQuery, paymentMethodsQuery } = useSubscriptionCatalog();
+  const subscriptionsQuery = useSubscriptionList({
+    limit: 100,
+    search: deferredSearch.trim() || undefined,
+    status: statusFilter === "all" ? undefined : statusFilter,
+  });
+
+  const categories = categoriesQuery.data?.items ?? [];
+  const paymentMethods = paymentMethodsQuery.data?.items ?? [];
+  const subscriptions = subscriptionsQuery.data?.items ?? [];
+
+  const categoryMap = new Map(categories.map((category) => [category.id, category.name]));
+  const paymentMethodMap = new Map(
+    paymentMethods.map((paymentMethod) => [paymentMethod.id, paymentMethod.label]),
+  );
+
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 animate-page-enter">
       <PageHeader
         action={
-          <Button asChild className="rounded-full px-5" variant="outline">
-            <Link href="/dashboard">
-              Back to dashboard
-              <ArrowRight className="ml-2 size-4" />
-            </Link>
-          </Button>
+          subscriptions[0] ? (
+            <Button asChild className="rounded-full px-5" variant="outline">
+              <Link href={`/subscriptions/${subscriptions[0].id}`}>
+                Open latest detail
+                <ArrowRight className="ml-2 size-4" />
+              </Link>
+            </Button>
+          ) : undefined
         }
-        description="This shell destination is ready for the Day 5 subscription management flows. The layout, navigation, and shared UI foundation are already in place."
-        eyebrow="Subscriptions"
-        title="Plan management is staged"
+        description="Track recurring plans, save manual entries, and move straight into lifecycle controls without leaving the workspace."
+        eyebrow="Day 5 live surface"
+        title="Subscription management"
       />
 
-      <EmptyState
-        description="Manual entry, subscription editing, and richer status controls belong in the next milestone. For Day 4, the goal is a working shell with a credible destination for those flows."
-        eyebrow="Day 5 handoff"
-        icon={<Sparkles className="size-5" />}
-        title="No editable plans yet."
-      />
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(340px,0.95fr)]">
+        <div className="space-y-5">
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs uppercase tracking-[0.32em] text-black/45">Browse plans</p>
+                <h2 className="text-2xl font-semibold text-ink">
+                  {subscriptionsQuery.data?.total ?? subscriptions.length} subscriptions in view
+                </h2>
+                <p className="text-sm leading-6 text-black/62">
+                  Filter by status, switch the density, and open a detail route for edits,
+                  cancellation, or lifecycle review.
+                </p>
+              </div>
+
+              <div className="flex items-center gap-2 self-start rounded-full border border-black/10 bg-stone/70 p-1">
+                <button
+                  aria-pressed={viewMode === "grid"}
+                  className={`inline-flex h-10 items-center gap-2 rounded-full px-4 text-sm font-medium transition ${
+                    viewMode === "grid" ? "bg-[#101922] text-white" : "text-black/58 hover:text-ink"
+                  }`}
+                  onClick={() => setViewMode("grid")}
+                  type="button"
+                >
+                  <LayoutGrid className="size-4" />
+                  Grid
+                </button>
+                <button
+                  aria-pressed={viewMode === "list"}
+                  className={`inline-flex h-10 items-center gap-2 rounded-full px-4 text-sm font-medium transition ${
+                    viewMode === "list" ? "bg-[#101922] text-white" : "text-black/58 hover:text-ink"
+                  }`}
+                  onClick={() => setViewMode("list")}
+                  type="button"
+                >
+                  <List className="size-4" />
+                  List
+                </button>
+              </div>
+            </div>
+
+            <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
+              <label className="relative flex items-center">
+                <Search className="pointer-events-none absolute left-4 size-4 text-black/38" />
+                <input
+                  className="h-12 w-full rounded-full border border-black/10 bg-white/88 pl-11 pr-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search plans, vendors, notes"
+                  type="search"
+                  value={search}
+                />
+              </label>
+
+              <select
+                className="h-12 rounded-full border border-black/10 bg-white/88 px-4 text-sm capitalize text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                onChange={(event) => setStatusFilter(event.target.value as "all" | SubscriptionStatus)}
+                value={statusFilter}
+              >
+                <option value="all">All statuses</option>
+                {subscriptionStatusOptions.map((status) => (
+                  <option className="capitalize" key={status} value={status}>
+                    {status}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </section>
+
+          {subscriptionsQuery.isLoading ? (
+            <div className="flex min-h-64 items-center justify-center rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
+              <div className="flex items-center gap-3 text-sm text-black/58">
+                <LoaderCircle className="size-4 animate-spin" />
+                Loading subscriptions...
+              </div>
+            </div>
+          ) : subscriptions.length === 0 ? (
+            <EmptyState
+              action={
+                <Button className="rounded-full px-5" onClick={() => setSearch("")} variant="outline">
+                  Clear filters
+                </Button>
+              }
+              description="No plans match the current search or filter. Save a new subscription on the right to populate the workspace."
+              eyebrow="Empty state"
+              icon={<Sparkles className="size-5" />}
+              title="No subscriptions in view."
+            />
+          ) : (
+            <section
+              className={viewMode === "grid" ? "grid gap-4 md:grid-cols-2" : "space-y-3"}
+            >
+              {subscriptions.map((subscription) => (
+                <SubscriptionCard
+                  categoryName={
+                    subscription.category_id ? categoryMap.get(subscription.category_id) : undefined
+                  }
+                  href={`/subscriptions/${subscription.id}`}
+                  key={subscription.id}
+                  paymentMethodLabel={
+                    subscription.payment_method_id
+                      ? paymentMethodMap.get(subscription.payment_method_id)
+                      : undefined
+                  }
+                  subscription={subscription}
+                  viewMode={viewMode}
+                />
+              ))}
+            </section>
+          )}
+        </div>
+
+        <SubscriptionForm
+          categories={categories}
+          description="Capture plan terms, billing cadence, category, payment method, dates, URL, and operator notes in one pass."
+          disabled={categoriesQuery.isLoading || paymentMethodsQuery.isLoading}
+          onSubmit={async (payload) => {
+            await createSubscription.mutateAsync(payload);
+          }}
+          paymentMethods={paymentMethods}
+          submitLabel="Save subscription"
+          title="Add a subscription"
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/app-shell/app-shell.tsx
+++ b/frontend/src/components/app-shell/app-shell.tsx
@@ -90,8 +90,8 @@ const routeMeta: Record<string, { description: string; searchPlaceholder: string
     title: "Settings",
   },
   "/subscriptions": {
-    description: "Manual entry, plan editing, and lifecycle controls will grow in this surface.",
-    searchPlaceholder: "Search plans, categories, shared households",
+    description: "Manual entry, plan editing, and lifecycle controls are now active in this workspace.",
+    searchPlaceholder: "Search plans, vendors, categories, payment methods",
     title: "Subscriptions",
   },
 };
@@ -119,7 +119,9 @@ export function AppShell({ children }: AppShellProps) {
     setIsUserMenuOpen(false);
   }, [pathname]);
 
-  const meta = routeMeta[pathname] ?? routeMeta["/dashboard"];
+  const meta =
+    Object.entries(routeMeta).find(([href]) => isActivePath(pathname, href))?.[1] ??
+    routeMeta["/dashboard"];
   const currentNavItem = navItems.find((item) => isActivePath(pathname, item.href)) ?? navItems[0];
   const displayName = user?.full_name || user?.email?.split("@")[0] || "Workspace operator";
 
@@ -224,10 +226,10 @@ export function AppShell({ children }: AppShellProps) {
                 isSidebarExpanded ? "block" : "hidden xl:block",
               )}
             >
-              <p className="text-xs uppercase tracking-[0.3em] text-white/40">Day 4 status</p>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/40">Day 5 status</p>
               <p className="mt-3 text-sm leading-6 text-white/75">
-                Shared shell navigation is live. The next milestones can now add working surfaces
-                without rebuilding layout chrome every day.
+                Subscription management is live with manual entry, detail routes, and lifecycle
+                edits layered onto the shared shell.
               </p>
             </div>
           </div>

--- a/frontend/src/components/subscriptions/status-badge.tsx
+++ b/frontend/src/components/subscriptions/status-badge.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+
+type StatusBadgeProps = {
+  className?: string;
+  status: string;
+};
+
+const toneMap: Record<string, string> = {
+  active: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  cancelled: "border-rose-200 bg-rose-50 text-rose-700",
+  paused: "border-amber-200 bg-amber-50 text-amber-700",
+};
+
+function formatStatus(status: string) {
+  return status
+    .trim()
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function StatusBadge({ className, status }: StatusBadgeProps) {
+  const normalizedStatus = status.trim().toLowerCase();
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]",
+        toneMap[normalizedStatus] ?? "border-black/10 bg-white/70 text-black/60",
+        className,
+      )}
+      data-status={normalizedStatus}
+    >
+      {formatStatus(normalizedStatus)}
+    </span>
+  );
+}

--- a/frontend/src/components/subscriptions/subscription-card.tsx
+++ b/frontend/src/components/subscriptions/subscription-card.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+import { ArrowRight, Globe2 } from "lucide-react";
+
+import { StatusBadge } from "@/components/subscriptions/status-badge";
+import { Button } from "@/components/ui/button";
+import { CurrencyDisplay } from "@/components/ui/currency-display";
+import { cn } from "@/lib/utils";
+import type { Subscription } from "@/types";
+
+type SubscriptionCardProps = {
+  categoryName?: string;
+  href?: string;
+  paymentMethodLabel?: string;
+  subscription: Subscription;
+  viewMode?: "grid" | "list";
+};
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "No date set";
+  }
+
+  const parts = value.split("-").map((part) => Number(part));
+  const date =
+    parts.length === 3 && parts.every((part) => Number.isFinite(part))
+      ? new Date(parts[0], parts[1] - 1, parts[2])
+      : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function getHostLabel(url: string | null) {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+export function SubscriptionCard({
+  categoryName,
+  href,
+  paymentMethodLabel,
+  subscription,
+  viewMode = "grid",
+}: SubscriptionCardProps) {
+  const hostLabel = getHostLabel(subscription.website_url);
+  const amount = Number(subscription.amount);
+
+  return (
+    <article
+      className={cn(
+        "rounded-[2rem] border border-black/10 bg-white/72 p-5 shadow-line backdrop-blur transition duration-200 hover:-translate-y-0.5 hover:border-black/20 hover:bg-white",
+        viewMode === "list" && "flex flex-col gap-5 md:flex-row md:items-center md:p-4",
+      )}
+      data-view-mode={viewMode}
+      style={{ contentVisibility: "auto" }}
+    >
+      <div className="inline-flex size-14 shrink-0 items-center justify-center rounded-[1.35rem] bg-[#101922] text-lg font-semibold text-white">
+        {subscription.name.slice(0, 1).toUpperCase()}
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="min-w-0 space-y-2">
+            <p className="text-xs uppercase tracking-[0.32em] text-black/42">
+              {categoryName ?? "Uncategorized"}
+            </p>
+            <div>
+              <h3 className="truncate text-xl font-semibold text-ink">{subscription.name}</h3>
+              <p className="truncate text-sm text-black/58">{subscription.vendor}</p>
+            </div>
+          </div>
+
+          <div className="shrink-0 text-left md:text-right">
+            <CurrencyDisplay
+              className="text-2xl font-semibold text-ink"
+              currency={subscription.currency}
+              value={Number.isFinite(amount) ? amount : 0}
+            />
+            <p className="mt-1 text-sm capitalize text-black/48">{subscription.cadence} billing</p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 text-sm text-black/58">
+          <StatusBadge status={subscription.status} />
+          <span>Renews {formatDate(subscription.next_charge_date ?? subscription.start_date)}</span>
+          {paymentMethodLabel ? <span>Paid with {paymentMethodLabel}</span> : null}
+          {hostLabel ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Globe2 className="size-4" />
+              {hostLabel}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <p className="line-clamp-2 text-sm leading-6 text-black/62">
+            {subscription.notes || subscription.description || "Manual plan entry ready for lifecycle edits and detail review."}
+          </p>
+
+          {href ? (
+            <Button asChild className="shrink-0 rounded-full px-4" size="sm" variant="ghost">
+              <Link href={href}>
+                Open detail
+                <ArrowRight className="ml-2 size-4" />
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/subscriptions/subscription-form.tsx
+++ b/frontend/src/components/subscriptions/subscription-form.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { LoaderCircle } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+
+import { Button } from "@/components/ui/button";
+import {
+  buildSubscriptionFormValues,
+  subscriptionCadenceOptions,
+  subscriptionFormSchema,
+  subscriptionStatusOptions,
+  toSubscriptionPayload,
+  type SubscriptionFormValues,
+} from "@/lib/validators";
+import type { Category, PaymentMethod, Subscription, SubscriptionUpsertInput } from "@/types";
+
+type SubscriptionFormProps = {
+  categories: Category[];
+  description: string;
+  disabled?: boolean;
+  initialSubscription?: Subscription | null;
+  onCancel?: () => void;
+  onSubmit: (payload: SubscriptionUpsertInput) => Promise<void>;
+  paymentMethods: PaymentMethod[];
+  submitLabel: string;
+  title: string;
+};
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) {
+    return null;
+  }
+
+  return <p className="text-sm text-ember">{message}</p>;
+}
+
+export function SubscriptionForm({
+  categories,
+  description,
+  disabled = false,
+  initialSubscription,
+  onCancel,
+  onSubmit,
+  paymentMethods,
+  submitLabel,
+  title,
+}: SubscriptionFormProps) {
+  const {
+    formState: { errors, isSubmitting },
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<SubscriptionFormValues>({
+    defaultValues: buildSubscriptionFormValues(initialSubscription),
+    resolver: zodResolver(subscriptionFormSchema),
+  });
+
+  useEffect(() => {
+    reset(buildSubscriptionFormValues(initialSubscription));
+  }, [initialSubscription, reset]);
+
+  const isWorking = disabled || isSubmitting;
+
+  return (
+    <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+      <div className="space-y-3 border-b border-black/10 pb-5">
+        <p className="text-xs uppercase tracking-[0.32em] text-black/45">
+          {initialSubscription ? "Edit subscription" : "Manual entry"}
+        </p>
+        <h2 className="text-2xl font-semibold text-ink">{title}</h2>
+        <p className="text-sm leading-6 text-black/62">{description}</p>
+      </div>
+
+      <form
+        className="space-y-6 pt-6"
+        onSubmit={handleSubmit(async (values) => {
+          await onSubmit(toSubscriptionPayload(values));
+          if (!initialSubscription) {
+            reset(buildSubscriptionFormValues());
+          }
+        })}
+      >
+        <div className="grid gap-5 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-name">
+              Subscription name
+            </label>
+            <input
+              id="subscription-name"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              placeholder="Netflix Family"
+              {...register("name")}
+            />
+            <FieldError message={errors.name?.message} />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-vendor">
+              Vendor
+            </label>
+            <input
+              id="subscription-vendor"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              placeholder="Netflix"
+              {...register("vendor")}
+            />
+            <FieldError message={errors.vendor?.message} />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-amount">
+              Amount
+            </label>
+            <input
+              id="subscription-amount"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              inputMode="decimal"
+              placeholder="15.49"
+              {...register("amount")}
+            />
+            <FieldError message={errors.amount?.message} />
+          </div>
+
+          <div className="grid gap-5 grid-cols-[120px_minmax(0,1fr)]">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-ink" htmlFor="subscription-currency">
+                Currency
+              </label>
+              <input
+                id="subscription-currency"
+                className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm uppercase text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                maxLength={3}
+                placeholder="USD"
+                {...register("currency")}
+              />
+              <FieldError message={errors.currency?.message} />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-ink" htmlFor="subscription-cadence">
+                Frequency
+              </label>
+              <select
+                id="subscription-cadence"
+                className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm capitalize text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                {...register("cadence")}
+              >
+                {subscriptionCadenceOptions.map((option) => (
+                  <option className="capitalize" key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-status">
+              Status
+            </label>
+            <select
+              id="subscription-status"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm capitalize text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              {...register("status")}
+            >
+              {subscriptionStatusOptions.map((option) => (
+                <option className="capitalize" key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-day-of-month">
+              Billing day
+            </label>
+            <input
+              id="subscription-day-of-month"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              inputMode="numeric"
+              placeholder="1"
+              {...register("day_of_month")}
+            />
+            <FieldError message={errors.day_of_month?.message} />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-start-date">
+              Start date
+            </label>
+            <input
+              id="subscription-start-date"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              type="date"
+              {...register("start_date")}
+            />
+            <FieldError message={errors.start_date?.message} />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-next-charge-date">
+              Next charge date
+            </label>
+            <input
+              id="subscription-next-charge-date"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              type="date"
+              {...register("next_charge_date")}
+            />
+            <FieldError message={errors.next_charge_date?.message} />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-end-date">
+              End date
+            </label>
+            <input
+              id="subscription-end-date"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              type="date"
+              {...register("end_date")}
+            />
+            <FieldError message={errors.end_date?.message} />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-category">
+              Category
+            </label>
+            <select
+              id="subscription-category"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              {...register("category_id")}
+            >
+              <option value="">No category</option>
+              {categories.map((category) => (
+                <option key={category.id} value={String(category.id)}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-payment-method">
+              Payment method
+            </label>
+            <select
+              id="subscription-payment-method"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              {...register("payment_method_id")}
+            >
+              <option value="">No payment method</option>
+              {paymentMethods.map((paymentMethod) => (
+                <option key={paymentMethod.id} value={String(paymentMethod.id)}>
+                  {paymentMethod.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-website-url">
+              Website URL
+            </label>
+            <input
+              id="subscription-website-url"
+              className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              placeholder="https://www.netflix.com"
+              type="url"
+              {...register("website_url")}
+            />
+            <FieldError message={errors.website_url?.message} />
+          </div>
+
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-description">
+              Description
+            </label>
+            <textarea
+              id="subscription-description"
+              className="min-h-24 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 py-3 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              placeholder="What this plan covers, household usage, or why it exists."
+              {...register("description")}
+            />
+          </div>
+
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium text-ink" htmlFor="subscription-notes">
+              Notes
+            </label>
+            <textarea
+              id="subscription-notes"
+              className="min-h-28 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 py-3 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              placeholder="Capture support info, family sharing notes, or cancellation context."
+              {...register("notes")}
+            />
+          </div>
+        </div>
+
+        <label className="flex items-start gap-3 rounded-[1.2rem] border border-black/10 bg-stone/65 px-4 py-4 text-sm text-black/70">
+          <input className="mt-1 size-4 rounded border-black/20" type="checkbox" {...register("auto_renew")} />
+          <span>
+            <span className="block font-medium text-ink">Auto renew enabled</span>
+            <span className="mt-1 block">Keep this on when the subscription renews automatically each cycle.</span>
+          </span>
+        </label>
+
+        {errors.root ? <FieldError message={errors.root.message} /> : null}
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-black/52">
+            {categories.length === 0 && paymentMethods.length === 0
+              ? "Categories and payment methods are optional until those catalogs are populated."
+              : "Use the detail page after save to change status or remove a plan."}
+          </p>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            {onCancel ? (
+              <Button onClick={onCancel} type="button" variant="outline">
+                Cancel
+              </Button>
+            ) : null}
+            <Button className="rounded-full px-6" disabled={isWorking} type="submit">
+              {isWorking ? (
+                <>
+                  <LoaderCircle className="mr-2 size-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                submitLabel
+              )}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/hooks/use-subscriptions.ts
+++ b/frontend/src/hooks/use-subscriptions.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useAuth } from "@/hooks/use-auth";
+import { apiClient } from "@/lib/api-client";
+import type { SubscriptionFilters, SubscriptionUpsertInput } from "@/types";
+
+const subscriptionKeys = {
+  categories: ["categories"] as const,
+  detail: (subscriptionId: number) => ["subscriptions", "detail", subscriptionId] as const,
+  lists: () => ["subscriptions", "list"] as const,
+  list: (filters: SubscriptionFilters) => ["subscriptions", "list", filters] as const,
+  paymentMethods: ["payment-methods"] as const,
+};
+
+function useRequiredToken() {
+  const { accessToken } = useAuth();
+
+  if (!accessToken) {
+    throw new Error("You must be signed in to manage subscriptions.");
+  }
+
+  return accessToken;
+}
+
+export function useSubscriptionCatalog() {
+  const { accessToken } = useAuth();
+  const enabled = Boolean(accessToken);
+
+  const categoriesQuery = useQuery({
+    enabled,
+    queryFn: () => apiClient.getCategories(accessToken!),
+    queryKey: subscriptionKeys.categories,
+  });
+
+  const paymentMethodsQuery = useQuery({
+    enabled,
+    queryFn: () => apiClient.getPaymentMethods(accessToken!),
+    queryKey: subscriptionKeys.paymentMethods,
+  });
+
+  return {
+    categoriesQuery,
+    paymentMethodsQuery,
+  };
+}
+
+export function useSubscriptionList(filters: SubscriptionFilters) {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken),
+    queryFn: () => apiClient.getSubscriptions(accessToken!, filters),
+    queryKey: subscriptionKeys.list(filters),
+  });
+}
+
+export function useSubscription(subscriptionId: number) {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken) && Number.isFinite(subscriptionId),
+    queryFn: () => apiClient.getSubscription(accessToken!, subscriptionId),
+    queryKey: subscriptionKeys.detail(subscriptionId),
+  });
+}
+
+export function useCreateSubscription() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: SubscriptionUpsertInput) => apiClient.createSubscription(token, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+  });
+}
+
+export function useUpdateSubscription(subscriptionId: number) {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: Partial<SubscriptionUpsertInput>) =>
+      apiClient.updateSubscription(token, subscriptionId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.detail(subscriptionId) });
+    },
+  });
+}
+
+export function useDeleteSubscription(subscriptionId: number) {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => apiClient.deleteSubscription(token, subscriptionId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+      queryClient.removeQueries({ queryKey: subscriptionKeys.detail(subscriptionId) });
+    },
+  });
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,16 +1,46 @@
 import { API_BASE_URL } from "@/lib/constants";
-import type { AuthResponse, HealthResponse, LoginInput, RegisterInput, User } from "@/types";
+import type {
+  AuthResponse,
+  CategoryListResponse,
+  HealthResponse,
+  LoginInput,
+  PaymentMethodListResponse,
+  RegisterInput,
+  Subscription,
+  SubscriptionFilters,
+  SubscriptionListResponse,
+  SubscriptionUpsertInput,
+  User,
+} from "@/types";
 
 type RequestOptions = {
+  query?: Record<string, boolean | number | string | undefined>;
   token?: string;
 };
+
+function buildUrl(path: string, query?: RequestOptions["query"]) {
+  const url = new URL(`${API_BASE_URL}${path}`);
+
+  if (!query) {
+    return url.toString();
+  }
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === "") {
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+
+  return url.toString();
+}
 
 async function request<T>(
   path: string,
   init?: RequestInit,
   options?: RequestOptions,
 ): Promise<T> {
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  const response = await fetch(buildUrl(path, options?.query), {
     ...init,
     headers: {
       "Content-Type": "application/json",
@@ -21,6 +51,15 @@ async function request<T>(
 
   if (!response.ok) {
     throw new Error(`Request failed with ${response.status}`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (!contentType.includes("application/json")) {
+    return undefined as T;
   }
 
   return response.json() as Promise<T>;
@@ -50,5 +89,37 @@ export const apiClient = {
       body: JSON.stringify(payload),
       method: "POST",
     });
+  },
+  getCategories(token: string) {
+    return request<CategoryListResponse>("/categories", undefined, { token });
+  },
+  getPaymentMethods(token: string) {
+    return request<PaymentMethodListResponse>("/payment-methods", undefined, { token });
+  },
+  getSubscriptions(token: string, filters?: SubscriptionFilters) {
+    return request<SubscriptionListResponse>("/subscriptions", undefined, {
+      query: filters,
+      token,
+    });
+  },
+  getSubscription(token: string, subscriptionId: number) {
+    return request<Subscription>(`/subscriptions/${subscriptionId}`, undefined, { token });
+  },
+  createSubscription(token: string, payload: SubscriptionUpsertInput) {
+    return request<Subscription>("/subscriptions", {
+      body: JSON.stringify(payload),
+      method: "POST",
+    }, { token });
+  },
+  updateSubscription(token: string, subscriptionId: number, payload: Partial<SubscriptionUpsertInput>) {
+    return request<Subscription>(`/subscriptions/${subscriptionId}`, {
+      body: JSON.stringify(payload),
+      method: "PATCH",
+    }, { token });
+  },
+  deleteSubscription(token: string, subscriptionId: number) {
+    return request<void>(`/subscriptions/${subscriptionId}`, {
+      method: "DELETE",
+    }, { token });
   },
 };

--- a/frontend/src/lib/validators.ts
+++ b/frontend/src/lib/validators.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+
+import type {
+  Subscription,
+  SubscriptionCadence,
+  SubscriptionStatus,
+  SubscriptionUpsertInput,
+} from "@/types";
+
+export const subscriptionCadenceOptions: SubscriptionCadence[] = [
+  "weekly",
+  "monthly",
+  "quarterly",
+  "yearly",
+];
+
+export const subscriptionStatusOptions: SubscriptionStatus[] = [
+  "active",
+  "paused",
+  "cancelled",
+];
+
+const optionalDateField = z.union([z.literal(""), z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD.")]);
+const optionalNumberField = z
+  .string()
+  .trim()
+  .refine((value) => value === "" || (/^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 31), {
+    message: "Choose a day between 1 and 31.",
+  });
+const optionalSelectField = z.string().trim().refine((value) => value === "" || /^\d+$/.test(value), {
+  message: "Select a valid option.",
+});
+const optionalUrlField = z.string().trim().refine((value) => value === "" || z.url().safeParse(value).success, {
+  message: "Enter a valid URL.",
+});
+
+export const subscriptionFormSchema = z
+  .object({
+    amount: z.string().trim().refine((value) => !Number.isNaN(Number(value)) && Number(value) > 0, {
+      message: "Amount must be greater than zero.",
+    }),
+    auto_renew: z.boolean(),
+    cadence: z.enum(subscriptionCadenceOptions),
+    category_id: optionalSelectField,
+    currency: z.string().trim().length(3, "Use a 3-letter currency code."),
+    day_of_month: optionalNumberField,
+    description: z.string().trim(),
+    end_date: optionalDateField,
+    name: z.string().trim().min(2, "Name must be at least 2 characters."),
+    next_charge_date: optionalDateField,
+    notes: z.string().trim(),
+    payment_method_id: optionalSelectField,
+    start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Choose a start date."),
+    status: z.enum(subscriptionStatusOptions),
+    vendor: z.string().trim().min(2, "Vendor must be at least 2 characters."),
+    website_url: optionalUrlField,
+  })
+  .superRefine((values, context) => {
+    if (values.end_date !== "" && values.end_date < values.start_date) {
+      context.addIssue({
+        code: "custom",
+        message: "End date must be on or after the start date.",
+        path: ["end_date"],
+      });
+    }
+
+    if (values.next_charge_date !== "" && values.next_charge_date < values.start_date) {
+      context.addIssue({
+        code: "custom",
+        message: "Next charge date must be on or after the start date.",
+        path: ["next_charge_date"],
+      });
+    }
+  });
+
+export type SubscriptionFormValues = z.infer<typeof subscriptionFormSchema>;
+
+export function buildSubscriptionFormValues(subscription?: Subscription | null): SubscriptionFormValues {
+  if (!subscription) {
+    const today = new Date().toISOString().slice(0, 10);
+    return {
+      amount: "",
+      auto_renew: true,
+      cadence: "monthly",
+      category_id: "",
+      currency: "USD",
+      day_of_month: "",
+      description: "",
+      end_date: "",
+      name: "",
+      next_charge_date: "",
+      notes: "",
+      payment_method_id: "",
+      start_date: today,
+      status: "active",
+      vendor: "",
+      website_url: "",
+    };
+  }
+
+  return {
+    amount: subscription.amount,
+    auto_renew: subscription.auto_renew,
+    cadence: (subscription.cadence as SubscriptionCadence) ?? "monthly",
+    category_id: subscription.category_id ? String(subscription.category_id) : "",
+    currency: subscription.currency,
+    day_of_month: subscription.day_of_month ? String(subscription.day_of_month) : "",
+    description: subscription.description ?? "",
+    end_date: subscription.end_date ?? "",
+    name: subscription.name,
+    next_charge_date: subscription.next_charge_date ?? "",
+    notes: subscription.notes ?? "",
+    payment_method_id: subscription.payment_method_id ? String(subscription.payment_method_id) : "",
+    start_date: subscription.start_date,
+    status: (subscription.status as SubscriptionStatus) ?? "active",
+    vendor: subscription.vendor,
+    website_url: subscription.website_url ?? "",
+  };
+}
+
+export function toSubscriptionPayload(values: SubscriptionFormValues): SubscriptionUpsertInput {
+  const categoryId = values.category_id === "" ? undefined : Number(values.category_id);
+  const paymentMethodId = values.payment_method_id === "" ? undefined : Number(values.payment_method_id);
+  const dayOfMonth = values.day_of_month === "" ? undefined : Number(values.day_of_month);
+
+  return {
+    amount: Number(values.amount).toFixed(2),
+    auto_renew: values.auto_renew,
+    cadence: values.cadence,
+    category_id: categoryId,
+    currency: values.currency.trim().toUpperCase(),
+    day_of_month: dayOfMonth,
+    description: values.description || undefined,
+    end_date: values.end_date || undefined,
+    name: values.name.trim(),
+    next_charge_date: values.next_charge_date || undefined,
+    notes: values.notes || undefined,
+    payment_method_id: paymentMethodId,
+    start_date: values.start_date,
+    status: values.status,
+    vendor: values.vendor.trim(),
+    website_url: values.website_url || undefined,
+  };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -29,3 +29,94 @@ export type AuthResponse = {
   refresh_token_expires_at: string;
   user: User;
 };
+
+export type Category = {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CategoryListResponse = {
+  items: Category[];
+  total: number;
+};
+
+export type PaymentMethod = {
+  id: number;
+  user_id: number | null;
+  label: string;
+  provider: string;
+  last4: string | null;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PaymentMethodListResponse = {
+  items: PaymentMethod[];
+  total: number;
+};
+
+export type SubscriptionStatus = "active" | "paused" | "cancelled";
+export type SubscriptionCadence = "weekly" | "monthly" | "quarterly" | "yearly";
+
+export type Subscription = {
+  id: number;
+  user_id: number;
+  category_id: number | null;
+  payment_method_id: number | null;
+  name: string;
+  vendor: string;
+  description: string | null;
+  website_url: string | null;
+  amount: string;
+  currency: string;
+  cadence: string;
+  status: string;
+  start_date: string;
+  end_date: string | null;
+  next_charge_date: string | null;
+  day_of_month: number | null;
+  auto_renew: boolean;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type SubscriptionListResponse = {
+  items: Subscription[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+export type SubscriptionFilters = {
+  category_id?: number;
+  limit?: number;
+  offset?: number;
+  payment_method_id?: number;
+  search?: string;
+  status?: string;
+};
+
+export type SubscriptionUpsertInput = {
+  amount: string;
+  auto_renew: boolean;
+  cadence: string;
+  category_id?: number;
+  currency: string;
+  day_of_month?: number;
+  description?: string;
+  end_date?: string;
+  name: string;
+  next_charge_date?: string;
+  notes?: string;
+  payment_method_id?: number;
+  start_date: string;
+  status: string;
+  vendor: string;
+  website_url?: string;
+};

--- a/frontend/tests/unit/components/status-badge.test.tsx
+++ b/frontend/tests/unit/components/status-badge.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StatusBadge } from "@/components/subscriptions/status-badge";
+
+describe("StatusBadge", () => {
+  it("renders a readable label for active subscriptions", () => {
+    render(<StatusBadge status="active" />);
+
+    expect(screen.getByText("Active")).toBeVisible();
+    expect(screen.getByText("Active")).toHaveAttribute("data-status", "active");
+  });
+
+  it("normalizes paused and cancelled states", () => {
+    render(
+      <div>
+        <StatusBadge status="paused" />
+        <StatusBadge status="cancelled" />
+      </div>,
+    );
+
+    expect(screen.getByText("Paused")).toBeVisible();
+    expect(screen.getByText("Cancelled")).toBeVisible();
+  });
+});

--- a/frontend/tests/unit/components/subscription-card.test.tsx
+++ b/frontend/tests/unit/components/subscription-card.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SubscriptionCard } from "@/components/subscriptions/subscription-card";
+import type { Subscription } from "@/types";
+
+const subscription: Subscription = {
+  amount: "15.49",
+  auto_renew: true,
+  cadence: "monthly",
+  category_id: 1,
+  created_at: "2026-04-06T00:00:00Z",
+  currency: "USD",
+  day_of_month: 1,
+  description: "Primary streaming plan",
+  end_date: null,
+  id: 7,
+  name: "Netflix Family",
+  next_charge_date: "2026-05-01",
+  notes: "Shared with household",
+  payment_method_id: 9,
+  start_date: "2026-04-01",
+  status: "active",
+  updated_at: "2026-04-06T00:00:00Z",
+  user_id: 1,
+  vendor: "Netflix",
+  website_url: "https://www.netflix.com",
+};
+
+describe("SubscriptionCard", () => {
+  it("shows core subscription details and the detail link", () => {
+    render(
+      <SubscriptionCard
+        categoryName="Streaming"
+        href="/subscriptions/7"
+        paymentMethodLabel="Visa ending in 4242"
+        subscription={subscription}
+      />,
+    );
+
+    expect(screen.getByText("Netflix Family")).toBeVisible();
+    expect(screen.getByText("Streaming")).toBeVisible();
+    expect(screen.getByText("Paid with Visa ending in 4242")).toBeVisible();
+    expect(screen.getByRole("link", { name: /open detail/i })).toHaveAttribute(
+      "href",
+      "/subscriptions/7",
+    );
+  });
+
+  it("supports the compact list layout", () => {
+    render(<SubscriptionCard subscription={subscription} viewMode="list" />);
+
+    expect(screen.getByText("Renews May 1, 2026")).toBeVisible();
+    expect(screen.getByText("$15.49")).toBeVisible();
+  });
+});

--- a/frontend/tests/unit/lib/api-client.test.ts
+++ b/frontend/tests/unit/lib/api-client.test.ts
@@ -73,4 +73,55 @@ describe("apiClient", () => {
       }),
     );
   });
+
+  it("adds query params for subscription list requests", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          items: [],
+          limit: 25,
+          offset: 0,
+          total: 0,
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      ),
+    );
+
+    await apiClient.getSubscriptions("access-token", {
+      limit: 25,
+      search: "netflix",
+      status: "active",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/v1/subscriptions?limit=25&search=netflix&status=active",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer access-token",
+        }),
+      }),
+    );
+  });
+
+  it("supports delete requests that return no JSON body", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, {
+        status: 204,
+      }),
+    );
+
+    await expect(apiClient.deleteSubscription("access-token", 4)).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/v1/subscriptions/4",
+      expect.objectContaining({
+        method: "DELETE",
+      }),
+    );
+  });
 });

--- a/frontend/tests/unit/lib/validators.test.ts
+++ b/frontend/tests/unit/lib/validators.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  subscriptionFormSchema,
+  toSubscriptionPayload,
+} from "@/lib/validators";
+
+describe("subscription validators", () => {
+  it("accepts a valid manual entry payload and normalizes it for the API", () => {
+    const parsed = subscriptionFormSchema.parse({
+      amount: "15.4",
+      auto_renew: true,
+      cadence: "monthly",
+      category_id: "3",
+      currency: "usd",
+      day_of_month: "1",
+      description: "Primary streaming plan",
+      end_date: "",
+      name: "Netflix",
+      next_charge_date: "2026-05-01",
+      notes: "Family plan",
+      payment_method_id: "9",
+      start_date: "2026-04-01",
+      status: "active",
+      vendor: "Netflix",
+      website_url: "https://www.netflix.com",
+    });
+
+    expect(toSubscriptionPayload(parsed)).toEqual({
+      amount: "15.40",
+      auto_renew: true,
+      cadence: "monthly",
+      category_id: 3,
+      currency: "USD",
+      day_of_month: 1,
+      description: "Primary streaming plan",
+      name: "Netflix",
+      next_charge_date: "2026-05-01",
+      notes: "Family plan",
+      payment_method_id: 9,
+      start_date: "2026-04-01",
+      status: "active",
+      vendor: "Netflix",
+      website_url: "https://www.netflix.com",
+    });
+  });
+
+  it("rejects invalid website URLs", () => {
+    const result = subscriptionFormSchema.safeParse({
+      amount: "9.99",
+      auto_renew: true,
+      cadence: "monthly",
+      category_id: "",
+      currency: "USD",
+      day_of_month: "",
+      description: "",
+      end_date: "",
+      name: "Spotify",
+      next_charge_date: "",
+      notes: "",
+      payment_method_id: "",
+      start_date: "2026-04-01",
+      status: "active",
+      vendor: "Spotify",
+      website_url: "notaurl",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.website_url).toContain("Enter a valid URL.");
+  });
+
+  it("rejects end dates before the start date", () => {
+    const result = subscriptionFormSchema.safeParse({
+      amount: "9.99",
+      auto_renew: true,
+      cadence: "monthly",
+      category_id: "",
+      currency: "USD",
+      day_of_month: "",
+      description: "",
+      end_date: "2026-03-01",
+      name: "Spotify",
+      next_charge_date: "",
+      notes: "",
+      payment_method_id: "",
+      start_date: "2026-04-01",
+      status: "active",
+      vendor: "Spotify",
+      website_url: "",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.flatten().fieldErrors.end_date).toContain(
+      "End date must be on or after the start date.",
+    );
+  });
+});


### PR DESCRIPTION
# What Happened

From April 6, 2026, this automation kept failing for different reasons at different stages. It was not one bug; it was a chain of separate problems in the local Codex automation state, the automation-owned Git repo, the preflight script, and the automation execution mode.

The sequence was:

- Earlier, scheduled/manual runs were getting accepted and then immediately archived before a real run started.
- After that was fixed, runs started reaching preflight but failed because the launched checkout was missing the real project files.
- After that was fixed, preflight itself failed because it tried to write into Git's internal worktree metadata.
- After that was fixed, the run got past preflight but still failed on the first real Git write (`git checkout -B ...`) for the same metadata-path reason.
- After that, I found the deeper cause: the automation was still launching in **linked git worktree mode**, and this sandbox does not allow the Git admin writes that linked worktrees need.

---

# Challenges And Fixes

## 1. Stale Automation Thread State

The thread database in `state_5.sqlite` still had old automation threads marked active, while the run database in `codex-dev.db` showed them archived.

**Fix:** I re-archived the stale threads and cleaned placeholder/failed run rows so the scheduler stopped thinking an old run was still alive.

---

## 2. Wrong Base Branch in the Automation-Owned Repo

The canonical repo at `repo` had local `main` pointing at the old README-only init commit, so new worktrees sometimes launched with no `backend/` or `frontend/`.

**Fix:** I repointed local `main` to the full Day 4 project base, corrected repo metadata, and verified fresh worktrees had the real project structure.

---

## 3. Fragile Preflight Script

`preflight.sh` used a write probe inside `.git/worktrees/...`. That is exactly the path the sandbox denied.

**Fix:** I removed the write probe and replaced it with non-mutating Git checks. I also normalized real paths so `/tmp/...` and `/private/tmp/...` would not false-fail on macOS.

---

## 4. Bootstrap Safety

`bootstrap.sh` could move the automation-owned `main` ref too aggressively.

**Fix:** I restricted that sync logic so it only realigns `main` when bootstrapping from an actual linked worktree, not from the canonical repo itself.

---

## 5. Wrong Execution Mode

This was the **final root cause**. Even after prompt changes, the automation launcher still created linked worktrees like `/Users/work/.codex/worktrees/...`. I checked the installed Codex app and confirmed automations only avoid linked worktrees when `automation.toml` explicitly sets:
```toml
execution_environment = "local"
```

**Fix:** I set that explicitly. I also updated the prompt in `automation.toml` to read/write `memory.md` by absolute path instead of relying on `$CODEX_HOME`, because one failed run incorrectly thought memory was missing.

---

# Current State

*As of April 6, 2026:*

- The automation config is now set to run directly in the **canonical repo**, not a linked worktree.
- The canonical repo has no extra attached worktrees.
- Local automation history is back to the two archived successful runs from **April 2, 2026** and **April 3, 2026**.
- The stale failed run records were cleaned out.
- The repair notes are recorded in `memory.md`.

> **Important remaining truth:** The configuration and local state have been fixed, but the app's manual-run button has not been pressed to confirm end-to-end. The final change, `execution_environment = "local"`, is strongly supported and locally verified by config inspection — but it still needs **one manual or scheduled run** to confirm end to end.