### PR TITLE
Day 08/subscription detection engine

### DIFF
--- a/backend/src/services/confidence.py
+++ b/backend/src/services/confidence.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def calculate_amount_consistency(amounts: list[Decimal]) -> float:
+    absolute_amounts = [abs(amount) for amount in amounts]
+    if not absolute_amounts:
+        return 0.0
+    if len(absolute_amounts) == 1:
+        return 0.5
+
+    maximum = max(absolute_amounts)
+    minimum = min(absolute_amounts)
+    if maximum == 0:
+        return 0.0
+
+    spread = float((maximum - minimum) / maximum)
+    return max(0.0, min(1.0, 1.0 - spread))
+
+
+def score_subscription_confidence(
+    *,
+    transaction_count: int,
+    amount_consistency: float,
+    interval_consistency: float,
+    is_known_service: bool,
+) -> int:
+    score = 10
+    score += min(20, max(0, transaction_count - 1) * 5)
+    score += round(max(0.0, min(1.0, amount_consistency)) * 25)
+    score += round(max(0.0, min(1.0, interval_consistency)) * 25)
+    if is_known_service:
+        score += 20
+    return max(0, min(100, score))

--- a/backend/src/services/detection_engine.py
+++ b/backend/src/services/detection_engine.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from decimal import Decimal
+from statistics import median
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core import database as database_module
+from src.core.logging import get_logger
+from src.models.category import Category
+from src.models.payment_history import PaymentHistory
+from src.models.raw_transaction import RawTransaction
+from src.models.subscription import Subscription
+from src.services.confidence import calculate_amount_consistency, score_subscription_confidence
+from src.services.frequency import analyze_frequency
+
+logger = get_logger(__name__)
+MIN_DETECTION_CONFIDENCE = 70
+
+
+@dataclass(frozen=True, slots=True)
+class DetectedSubscription:
+    name: str
+    vendor: str
+    amount: Decimal
+    currency: str
+    cadence: str
+    status: str
+    confidence: int
+    category: str | None
+    next_charge_date: date
+    day_of_month: int | None
+    start_date: date
+    end_date: date | None
+    transaction_count: int
+    raw_transaction_ids: list[int]
+
+
+def _merchant_key(transaction: RawTransaction) -> str:
+    merchant = transaction.merchant.strip() or transaction.description.strip() or "Unknown merchant"
+    return merchant.lower()
+
+
+def _display_merchant(transactions: list[RawTransaction]) -> str:
+    counts = Counter(
+        transaction.merchant.strip() or transaction.description.strip() or "Unknown merchant"
+        for transaction in transactions
+    )
+    return counts.most_common(1)[0][0]
+
+
+def _category_for_group(transactions: list[RawTransaction]) -> str | None:
+    counts = Counter(
+        str(transaction.raw_payload.get("service_category", "")).strip().lower()
+        for transaction in transactions
+        if str(transaction.raw_payload.get("service_category", "")).strip()
+    )
+    if not counts:
+        return None
+    return counts.most_common(1)[0][0]
+
+
+def _is_known_service_group(transactions: list[RawTransaction]) -> bool:
+    return any(
+        transaction.subscription_candidate
+        or transaction.raw_payload.get("is_known_service") is True
+        for transaction in transactions
+    )
+
+
+def determine_subscription_status(
+    *,
+    last_charge_date: date,
+    interval_days: int,
+    as_of: date | None = None,
+) -> tuple[str, date]:
+    reference_date = as_of or datetime.now(UTC).date()
+    next_charge_date = last_charge_date + timedelta(days=interval_days)
+    grace_period_days = max(3, interval_days // 2)
+    active_until = next_charge_date + timedelta(days=grace_period_days)
+    paused_until = next_charge_date + timedelta(days=interval_days + grace_period_days)
+
+    if reference_date <= active_until:
+        return "active", next_charge_date
+    if reference_date <= paused_until:
+        return "paused", next_charge_date
+    return "cancelled", next_charge_date
+
+
+def detect_subscriptions(
+    transactions: list[RawTransaction],
+    *,
+    as_of: date | None = None,
+) -> list[DetectedSubscription]:
+    grouped_transactions: dict[str, list[RawTransaction]] = defaultdict(list)
+    for transaction in transactions:
+        if transaction.transaction_type.lower() != "debit":
+            continue
+        if transaction.amount >= 0:
+            continue
+        grouped_transactions[_merchant_key(transaction)].append(transaction)
+
+    detections: list[DetectedSubscription] = []
+    for merchant_key, merchant_transactions in grouped_transactions.items():
+        del merchant_key
+        ordered_transactions = sorted(
+            merchant_transactions,
+            key=lambda transaction: (transaction.posted_at, transaction.id or 0),
+        )
+        if len(ordered_transactions) < 2:
+            continue
+
+        frequency = analyze_frequency(
+            [transaction.posted_at for transaction in ordered_transactions]
+        )
+        if frequency is None:
+            continue
+
+        amount_consistency = calculate_amount_consistency(
+            [transaction.amount for transaction in ordered_transactions]
+        )
+        known_service = _is_known_service_group(ordered_transactions)
+        confidence = score_subscription_confidence(
+            transaction_count=len(ordered_transactions),
+            amount_consistency=amount_consistency,
+            interval_consistency=frequency.interval_consistency,
+            is_known_service=known_service,
+        )
+        if confidence < MIN_DETECTION_CONFIDENCE:
+            continue
+
+        last_charge_date = ordered_transactions[-1].posted_at
+        status, next_charge_date = determine_subscription_status(
+            last_charge_date=last_charge_date,
+            interval_days=frequency.interval_days,
+            as_of=as_of,
+        )
+        display_name = _display_merchant(ordered_transactions)
+        absolute_amounts = [abs(transaction.amount) for transaction in ordered_transactions]
+        representative_amount = median(absolute_amounts).quantize(Decimal("0.01"))
+        monthly_like = {"monthly", "quarterly", "semiannual", "annual"}
+        day_of_month = last_charge_date.day if frequency.cadence in monthly_like else None
+
+        detections.append(
+            DetectedSubscription(
+                name=display_name,
+                vendor=display_name,
+                amount=representative_amount,
+                currency=ordered_transactions[-1].currency,
+                cadence=frequency.cadence,
+                status=status,
+                confidence=confidence,
+                category=_category_for_group(ordered_transactions),
+                next_charge_date=next_charge_date,
+                day_of_month=day_of_month,
+                start_date=ordered_transactions[0].posted_at,
+                end_date=last_charge_date if status == "cancelled" else None,
+                transaction_count=len(ordered_transactions),
+                raw_transaction_ids=[
+                    transaction.id
+                    for transaction in ordered_transactions
+                    if transaction.id is not None
+                ],
+            )
+        )
+
+    return sorted(detections, key=lambda detection: (-detection.confidence, detection.vendor))
+
+
+def _slugify_category(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "category"
+
+
+def _display_category_name(name: str) -> str:
+    normalized = re.sub(r"[_-]+", " ", name).strip()
+    return " ".join(part.capitalize() for part in normalized.split()) or "General"
+
+
+async def _get_or_create_category(session: AsyncSession, category_name: str) -> Category:
+    slug = _slugify_category(category_name)
+    statement = select(Category).where(func.lower(Category.slug) == slug)
+    category = await session.scalar(statement)
+    if category is not None:
+        return category
+
+    category = Category(
+        name=_display_category_name(category_name),
+        slug=slug,
+        description="Auto-created from detected subscription imports.",
+    )
+    session.add(category)
+    await session.flush()
+    return category
+
+
+def _should_replace_text(value: str | None) -> bool:
+    if value is None:
+        return True
+    stripped = value.strip()
+    return not stripped or stripped.startswith("Auto-detected")
+
+
+def _apply_detection_to_subscription(
+    subscription: Subscription,
+    detection: DetectedSubscription,
+    *,
+    category_id: int | None,
+) -> None:
+    subscription.amount = detection.amount
+    subscription.currency = detection.currency
+    subscription.cadence = detection.cadence
+    subscription.status = detection.status
+    subscription.start_date = min(subscription.start_date, detection.start_date)
+    subscription.end_date = detection.end_date
+    subscription.next_charge_date = detection.next_charge_date
+    subscription.day_of_month = detection.day_of_month
+    subscription.auto_renew = detection.status != "cancelled"
+    if category_id is not None:
+        subscription.category_id = category_id
+    if _should_replace_text(subscription.description):
+        subscription.description = "Auto-detected from uploaded transaction history."
+    if _should_replace_text(subscription.notes):
+        subscription.notes = (
+            f"Auto-detected from {detection.transaction_count} payments "
+            f"with confidence {detection.confidence}/100."
+        )
+
+
+async def sync_detected_subscriptions(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    as_of: date | None = None,
+) -> list[DetectedSubscription]:
+    transactions = list(
+        (
+            await session.scalars(
+                select(RawTransaction)
+                .where(RawTransaction.user_id == user_id)
+                .order_by(RawTransaction.posted_at.asc(), RawTransaction.id.asc())
+            )
+        ).all()
+    )
+    detections = detect_subscriptions(transactions, as_of=as_of)
+    logger.info(
+        "subscription_detection.started",
+        user_id=user_id,
+        transaction_count=len(transactions),
+        detected_count=len(detections),
+    )
+    if not detections:
+        return []
+
+    subscriptions = list(
+        (await session.scalars(select(Subscription).where(Subscription.user_id == user_id))).all()
+    )
+    subscriptions_by_vendor = {
+        subscription.vendor.strip().lower(): subscription for subscription in subscriptions
+    }
+    transaction_lookup = {
+        transaction.id: transaction for transaction in transactions if transaction.id is not None
+    }
+    raw_transaction_ids = [
+        raw_transaction_id
+        for detection in detections
+        for raw_transaction_id in detection.raw_transaction_ids
+    ]
+    payment_history_by_raw_id: dict[int, PaymentHistory] = {}
+    if raw_transaction_ids:
+        existing_history = list(
+            (
+                await session.scalars(
+                    select(PaymentHistory).where(PaymentHistory.raw_transaction_id.in_(raw_transaction_ids))
+                )
+            ).all()
+        )
+        payment_history_by_raw_id = {
+            history.raw_transaction_id: history
+            for history in existing_history
+            if history.raw_transaction_id is not None
+        }
+
+    created_count = 0
+    updated_count = 0
+    for detection in detections:
+        category = (
+            await _get_or_create_category(session, detection.category)
+            if detection.category is not None
+            else None
+        )
+        subscription = subscriptions_by_vendor.get(detection.vendor.strip().lower())
+        if subscription is None:
+            subscription = Subscription(
+                user_id=user_id,
+                category_id=category.id if category is not None else None,
+                payment_method_id=None,
+                name=detection.name,
+                vendor=detection.vendor,
+                description="Auto-detected from uploaded transaction history.",
+                website_url=None,
+                amount=detection.amount,
+                currency=detection.currency,
+                cadence=detection.cadence,
+                status=detection.status,
+                start_date=detection.start_date,
+                end_date=detection.end_date,
+                next_charge_date=detection.next_charge_date,
+                day_of_month=detection.day_of_month,
+                auto_renew=detection.status != "cancelled",
+                notes=(
+                    f"Auto-detected from {detection.transaction_count} payments "
+                    f"with confidence {detection.confidence}/100."
+                ),
+            )
+            session.add(subscription)
+            await session.flush()
+            subscriptions_by_vendor[detection.vendor.strip().lower()] = subscription
+            created_count += 1
+        else:
+            _apply_detection_to_subscription(
+                subscription,
+                detection,
+                category_id=category.id if category is not None else None,
+            )
+            updated_count += 1
+
+        for raw_transaction_id in detection.raw_transaction_ids:
+            transaction = transaction_lookup.get(raw_transaction_id)
+            if transaction is None:
+                continue
+            payment_history = payment_history_by_raw_id.get(raw_transaction_id)
+            if payment_history is None:
+                payment_history = PaymentHistory(
+                    subscription_id=subscription.id,
+                    payment_method_id=subscription.payment_method_id,
+                    raw_transaction_id=raw_transaction_id,
+                    paid_at=datetime.combine(transaction.posted_at, time.min, tzinfo=UTC),
+                    amount=abs(transaction.amount).quantize(Decimal("0.01")),
+                    currency=transaction.currency,
+                    payment_status="settled",
+                    reference=transaction.external_id,
+                )
+                session.add(payment_history)
+                payment_history_by_raw_id[raw_transaction_id] = payment_history
+            else:
+                payment_history.subscription_id = subscription.id
+                payment_history.payment_method_id = subscription.payment_method_id
+                payment_history.paid_at = datetime.combine(
+                    transaction.posted_at,
+                    time.min,
+                    tzinfo=UTC,
+                )
+                payment_history.amount = abs(transaction.amount).quantize(Decimal("0.01"))
+                payment_history.currency = transaction.currency
+                payment_history.payment_status = "settled"
+                payment_history.reference = transaction.external_id
+
+        logger.info(
+            "subscription_detection.subscription_synced",
+            user_id=user_id,
+            vendor=detection.vendor,
+            cadence=detection.cadence,
+            status=detection.status,
+            confidence=detection.confidence,
+            category=detection.category,
+        )
+
+    await session.commit()
+    logger.info(
+        "subscription_detection.completed",
+        user_id=user_id,
+        detected_count=len(detections),
+        created_count=created_count,
+        updated_count=updated_count,
+    )
+    return detections
+
+
+async def sync_user_subscriptions(
+    *,
+    user_id: int,
+    as_of: date | None = None,
+) -> list[DetectedSubscription]:
+    async with database_module.SessionLocal() as session:
+        return await sync_detected_subscriptions(session, user_id=user_id, as_of=as_of)

--- a/backend/src/services/frequency.py
+++ b/backend/src/services/frequency.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from statistics import median
+from typing import Final
+
+
+@dataclass(frozen=True, slots=True)
+class FrequencyWindow:
+    cadence: str
+    interval_days: int
+    minimum_days: int
+    maximum_days: int
+
+
+@dataclass(frozen=True, slots=True)
+class FrequencyAnalysis:
+    cadence: str
+    interval_days: int
+    interval_consistency: float
+
+
+FREQUENCY_WINDOWS: Final[tuple[FrequencyWindow, ...]] = (
+    FrequencyWindow("weekly", 7, 6, 8),
+    FrequencyWindow("biweekly", 14, 13, 15),
+    FrequencyWindow("monthly", 30, 26, 33),
+    FrequencyWindow("quarterly", 91, 80, 100),
+    FrequencyWindow("semiannual", 182, 170, 195),
+    FrequencyWindow("annual", 365, 350, 380),
+)
+
+
+def analyze_frequency(posted_dates: list[date]) -> FrequencyAnalysis | None:
+    unique_dates = sorted(set(posted_dates))
+    if len(unique_dates) < 2:
+        return None
+
+    intervals = [
+        (current - previous).days
+        for previous, current in zip(unique_dates, unique_dates[1:], strict=False)
+    ]
+    if not intervals:
+        return None
+
+    median_interval = float(median(intervals))
+    best_window: FrequencyWindow | None = None
+    best_ratio = 0.0
+    best_distance = float("inf")
+
+    for window in FREQUENCY_WINDOWS:
+        matches = sum(
+            window.minimum_days <= interval <= window.maximum_days for interval in intervals
+        )
+        ratio = matches / len(intervals)
+        distance = abs(median_interval - window.interval_days)
+        if ratio > best_ratio or (ratio == best_ratio and distance < best_distance):
+            best_window = window
+            best_ratio = ratio
+            best_distance = distance
+
+    if best_window is None or best_ratio < 0.6:
+        return None
+
+    return FrequencyAnalysis(
+        cadence=best_window.cadence,
+        interval_days=best_window.interval_days,
+        interval_consistency=best_ratio,
+    )

--- a/backend/src/services/parsing/pipeline.py
+++ b/backend/src/services/parsing/pipeline.py
@@ -9,6 +9,7 @@ from src.core import database as database_module
 from src.core.logging import get_logger
 from src.models.data_source import DataSource
 from src.models.raw_transaction import RawTransaction
+from src.services.detection_engine import sync_user_subscriptions
 from src.services.parsing.csv_extractor import extract_csv_transactions
 from src.services.parsing.normalizer import normalize_extraction
 from src.services.parsing.pdf_extractor import ScannedPdfError, extract_pdf_transactions
@@ -95,10 +96,13 @@ async def process_stored_upload(upload_id: int) -> None:
                 file_bytes=Path(upload.storage_path).read_bytes(),
             )
             candidate_count = await _store_transactions(upload, extraction)
+            detections = await sync_user_subscriptions(user_id=upload.user_id)
             logger.info(
-                "parsing.pipeline.detection_triggered",
+                "parsing.pipeline.detection_completed",
                 upload_id=upload.id,
                 candidate_count=candidate_count,
+                detected_count=len(detections),
+                detected_vendors=[detection.vendor for detection in detections],
             )
         except ScannedPdfError as exc:
             upload.status = "failed"

--- a/backend/tests/api/test_uploads.py
+++ b/backend/tests/api/test_uploads.py
@@ -49,6 +49,34 @@ def test_upload_endpoints_process_csv_history_status_and_delete(client) -> None:
     assert missing_response.status_code == 404
 
 
+def test_upload_processing_triggers_subscription_detection(client) -> None:
+    headers = _auth_headers(client, "detection@example.com")
+    csv_content = (
+        "Posting Date,Details,Amount\n"
+        "01/01/2026,NETFLIX,-15.49\n"
+        "02/01/2026,NETFLIX,-15.49\n"
+        "03/01/2026,NETFLIX,-15.49\n"
+    )
+
+    create_response = client.post(
+        "/api/v1/uploads",
+        headers=headers,
+        files={"file": ("netflix.csv", csv_content, "text/csv")},
+    )
+
+    assert create_response.status_code == 201
+
+    subscriptions_response = client.get("/api/v1/subscriptions", headers=headers)
+    assert subscriptions_response.status_code == 200
+    subscriptions = subscriptions_response.json()
+
+    assert subscriptions["total"] == 1
+    detected = subscriptions["items"][0]
+    assert detected["vendor"] == "Netflix"
+    assert detected["cadence"] == "monthly"
+    assert detected["status"] == "active"
+
+
 def test_upload_rejects_unsupported_files(client) -> None:
     headers = _auth_headers(client, "rejector@example.com")
 

--- a/backend/tests/services/test_confidence.py
+++ b/backend/tests/services/test_confidence.py
@@ -1,0 +1,34 @@
+from src.services.confidence import calculate_amount_consistency, score_subscription_confidence
+
+
+def test_confidence_scores_high_for_known_service_with_clean_pattern() -> None:
+    score = score_subscription_confidence(
+        transaction_count=4,
+        amount_consistency=calculate_amount_consistency([15.49, 15.49, 15.49, 15.49]),
+        interval_consistency=1.0,
+        is_known_service=True,
+    )
+
+    assert score >= 90
+
+
+def test_confidence_scores_midrange_for_unknown_service_with_small_variance() -> None:
+    score = score_subscription_confidence(
+        transaction_count=3,
+        amount_consistency=calculate_amount_consistency([49.99, 51.99, 50.49]),
+        interval_consistency=1.0,
+        is_known_service=False,
+    )
+
+    assert 65 <= score < 90
+
+
+def test_confidence_scores_low_for_sparse_irregular_pattern() -> None:
+    score = score_subscription_confidence(
+        transaction_count=2,
+        amount_consistency=calculate_amount_consistency([12.99, 39.99]),
+        interval_consistency=0.5,
+        is_known_service=False,
+    )
+
+    assert score < 60

--- a/backend/tests/services/test_detection_engine.py
+++ b/backend/tests/services/test_detection_engine.py
@@ -1,0 +1,203 @@
+import asyncio
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from src.core import database as database_module
+from src.models.category import Category
+from src.models.payment_history import PaymentHistory
+from src.models.raw_transaction import RawTransaction
+from src.models.subscription import Subscription
+from src.models.user import User
+from src.services.detection_engine import (
+    detect_subscriptions,
+    determine_subscription_status,
+    sync_user_subscriptions,
+)
+
+
+def test_determine_subscription_status_transitions_from_active_to_cancelled() -> None:
+    active_status, active_next_charge = determine_subscription_status(
+        last_charge_date=date(2026, 3, 1),
+        interval_days=30,
+        as_of=date(2026, 4, 10),
+    )
+    paused_status, _ = determine_subscription_status(
+        last_charge_date=date(2026, 3, 1),
+        interval_days=30,
+        as_of=date(2026, 5, 5),
+    )
+    cancelled_status, _ = determine_subscription_status(
+        last_charge_date=date(2026, 3, 1),
+        interval_days=30,
+        as_of=date(2026, 6, 20),
+    )
+
+    assert active_status == "active"
+    assert active_next_charge == date(2026, 3, 31)
+    assert paused_status == "paused"
+    assert cancelled_status == "cancelled"
+
+
+def test_detect_subscriptions_filters_low_confidence_groups() -> None:
+    detections = detect_subscriptions(
+        [
+            RawTransaction(
+                posted_at=date(2026, 1, 1),
+                merchant="Neighborhood Cafe",
+                description="Neighborhood Cafe",
+                amount=Decimal("-8.00"),
+                currency="USD",
+                transaction_type="debit",
+                raw_payload={},
+            ),
+            RawTransaction(
+                posted_at=date(2026, 2, 1),
+                merchant="Neighborhood Cafe",
+                description="Neighborhood Cafe",
+                amount=Decimal("-18.00"),
+                currency="USD",
+                transaction_type="debit",
+                raw_payload={},
+            ),
+        ],
+        as_of=date(2026, 2, 15),
+    )
+
+    assert detections == []
+
+
+def test_sync_user_subscriptions_creates_detected_subscriptions_and_payment_history(app) -> None:
+    async def exercise() -> None:
+        async with database_module.SessionLocal() as session:
+            user = User(
+                email="detector@example.com",
+                full_name="Detector",
+                hashed_password="hashed",
+            )
+            session.add(user)
+            await session.flush()
+
+            session.add_all(
+                [
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="nf-1",
+                        posted_at=date(2026, 1, 1),
+                        merchant="Netflix",
+                        description="NETFLIX COM LOS GATOS",
+                        amount=Decimal("-15.49"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=True,
+                        raw_payload={"is_known_service": True, "service_category": "entertainment"},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="nf-2",
+                        posted_at=date(2026, 2, 1),
+                        merchant="Netflix",
+                        description="NETFLIX COM LOS GATOS",
+                        amount=Decimal("-15.49"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=True,
+                        raw_payload={"is_known_service": True, "service_category": "entertainment"},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="nf-3",
+                        posted_at=date(2026, 3, 1),
+                        merchant="Netflix",
+                        description="NETFLIX COM LOS GATOS",
+                        amount=Decimal("-15.49"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=True,
+                        raw_payload={"is_known_service": True, "service_category": "entertainment"},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="gym-1",
+                        posted_at=date(2026, 1, 5),
+                        merchant="Local Gym",
+                        description="LOCAL GYM MEMBERSHIP",
+                        amount=Decimal("-39.99"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=False,
+                        raw_payload={},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="gym-2",
+                        posted_at=date(2026, 2, 5),
+                        merchant="Local Gym",
+                        description="LOCAL GYM MEMBERSHIP",
+                        amount=Decimal("-39.99"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=False,
+                        raw_payload={},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="gym-3",
+                        posted_at=date(2026, 3, 6),
+                        merchant="Local Gym",
+                        description="LOCAL GYM MEMBERSHIP",
+                        amount=Decimal("-39.99"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=False,
+                        raw_payload={},
+                    ),
+                ]
+            )
+            await session.commit()
+
+        detections = await sync_user_subscriptions(user_id=1, as_of=date(2026, 4, 10))
+        assert {detection.vendor for detection in detections} == {"Local Gym", "Netflix"}
+
+        async with database_module.SessionLocal() as session:
+            subscriptions = list(
+                (
+                    await session.scalars(
+                        select(Subscription)
+                        .where(Subscription.user_id == 1)
+                        .order_by(Subscription.vendor.asc())
+                    )
+                ).all()
+            )
+            categories = list((await session.scalars(select(Category))).all())
+            payment_history = list((await session.scalars(select(PaymentHistory))).all())
+
+        assert len(subscriptions) == 2
+        assert {subscription.vendor for subscription in subscriptions} == {"Local Gym", "Netflix"}
+        assert len(payment_history) == 6
+        assert len(categories) == 1
+        assert categories[0].slug == "entertainment"
+
+        netflix = next(
+            subscription for subscription in subscriptions if subscription.vendor == "Netflix"
+        )
+        gym = next(
+            subscription for subscription in subscriptions if subscription.vendor == "Local Gym"
+        )
+
+        assert netflix.cadence == "monthly"
+        assert netflix.status == "active"
+        assert netflix.category_id == categories[0].id
+        assert netflix.next_charge_date == date(2026, 3, 31)
+        assert gym.cadence == "monthly"
+        assert gym.status == "active"
+        assert gym.category_id is None
+
+    asyncio.run(exercise())

--- a/backend/tests/services/test_frequency.py
+++ b/backend/tests/services/test_frequency.py
@@ -1,0 +1,35 @@
+from datetime import date
+
+import pytest
+
+from src.services.frequency import analyze_frequency
+
+
+@pytest.mark.parametrize(
+    ("posted_dates", "expected_cadence"),
+    [
+        ([date(2026, 4, 1), date(2026, 4, 8), date(2026, 4, 15)], "weekly"),
+        ([date(2026, 4, 1), date(2026, 4, 15), date(2026, 4, 29)], "biweekly"),
+        ([date(2026, 1, 1), date(2026, 2, 1), date(2026, 3, 1)], "monthly"),
+        ([date(2026, 1, 1), date(2026, 4, 1), date(2026, 7, 1)], "quarterly"),
+        ([date(2025, 1, 1), date(2025, 7, 1), date(2026, 1, 1)], "semiannual"),
+        ([date(2024, 4, 1), date(2025, 4, 1), date(2026, 4, 1)], "annual"),
+    ],
+)
+def test_analyze_frequency_classifies_supported_cadences(
+    posted_dates: list[date],
+    expected_cadence: str,
+) -> None:
+    analysis = analyze_frequency(posted_dates)
+
+    assert analysis is not None
+    assert analysis.cadence == expected_cadence
+    assert analysis.interval_consistency == 1.0
+
+
+def test_analyze_frequency_returns_none_for_irregular_activity() -> None:
+    analysis = analyze_frequency(
+        [date(2026, 1, 1), date(2026, 1, 20), date(2026, 3, 19), date(2026, 6, 1)]
+    )
+
+    assert analysis is None


### PR DESCRIPTION
# Day 8 Complete — `day-08/subscription-detection-engine`

## Summary
Day 8 is complete and pushed to `origin`.

---

## What Was Built

- **`frequency.py`** — Recurring-frequency classifier
- **`confidence.py`** — Confidence classifier
- **`detection_engine.py`** — Subscription sync engine
- **`pipeline.py`** — Wired upload processing to run detection

---

## Upload Processing Behavior

Uploads now:

1. Group recurring merchants
2. Infer cadence, confidence, and status
3. Auto-create matching categories
4. Sync subscriptions
5. Link `payment_history`

---

## Verification

All checks passed:

| Check | Command |
|---|---|
| Lockfile guard | `lockfile-guard.sh` |
| Tests | `backend/.venv/bin/pytest backend/tests` |
| Linting | `backend/.venv/bin/ruff check backend/src backend/tests` |
| Type checking | `backend/.venv/bin/mypy backend/src` |

---

## Test Coverage Added

- `test_detection_engine.py`
- `test_frequency.py`
- `test_confidence.py`
- `test_uploads.py`

---

## GitHub

- Issues **#37**, **#38**, **#39** — commented and closed
- **Milestone 8** — closed

---

## Status

> ✅ No blockers remain.  
> Next scheduled run advances to **Day 9** on `day-09/upload-ui-processing-status`.