### PR TITLE
Day 09/upload UI processing status

### DIFF
--- a/frontend/src/app/(app)/uploads/page.tsx
+++ b/frontend/src/app/(app)/uploads/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import Link from "next/link";
+import { startTransition, useEffect, useMemo, useState } from "react";
+import { ArrowRight, FolderSearch, LoaderCircle } from "lucide-react";
+
+import { UploadDropzone } from "@/components/uploads/upload-dropzone";
+import { UploadHistoryList } from "@/components/uploads/upload-history-list";
+import { UploadProcessingPanel } from "@/components/uploads/upload-processing-panel";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  mergeSelectedUpload,
+  useCreateUpload,
+  useDeleteUpload,
+  useUploadHistory,
+  useUploadStatus,
+} from "@/hooks/use-uploads";
+
+function getVisualStep(
+  status: "completed" | "failed" | "processing" | "queued",
+  processingPhase: number,
+) {
+  if (status === "completed") {
+    return "Done" as const;
+  }
+
+  if (status === "failed") {
+    return "Failed" as const;
+  }
+
+  if (status === "queued") {
+    return "Queued" as const;
+  }
+
+  return processingPhase > 0 ? ("Detecting" as const) : ("Parsing" as const);
+}
+
+export default function UploadsPage() {
+  const uploadsQuery = useUploadHistory();
+  const createUpload = useCreateUpload();
+  const deleteUpload = useDeleteUpload();
+
+  const [selectedUploadId, setSelectedUploadId] = useState<number | null>(null);
+  const [processingPhase, setProcessingPhase] = useState(0);
+
+  const uploads = useMemo(() => uploadsQuery.data?.items ?? [], [uploadsQuery.data?.items]);
+  const selectedUploadStatusQuery = useUploadStatus(selectedUploadId);
+  const selectedUpload = mergeSelectedUpload(
+    selectedUploadId,
+    uploads,
+    selectedUploadStatusQuery.data,
+  );
+  const selectedUploadKey = selectedUpload?.id ?? null;
+  const selectedUploadStatus = selectedUpload?.status ?? null;
+
+  useEffect(() => {
+    if (uploads.length === 0) {
+      setSelectedUploadId(null);
+      return;
+    }
+
+    const stillExists = selectedUploadId !== null && uploads.some((upload) => upload.id === selectedUploadId);
+    if (!stillExists) {
+      startTransition(() => {
+        setSelectedUploadId(uploads[0]?.id ?? null);
+      });
+    }
+  }, [selectedUploadId, uploads]);
+
+  useEffect(() => {
+    setProcessingPhase(0);
+
+    if (selectedUploadStatus !== "processing") {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setProcessingPhase(1);
+    }, 1_400);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [selectedUploadKey, selectedUploadStatus]);
+
+  const visualStep = getVisualStep(selectedUpload?.status ?? "queued", processingPhase);
+  const activeUploads = useMemo(
+    () => uploads.filter((upload) => upload.status === "queued" || upload.status === "processing").length,
+    [uploads],
+  );
+  const completedUploads = useMemo(
+    () => uploads.filter((upload) => upload.status === "completed").length,
+    [uploads],
+  );
+
+  return (
+    <div className="space-y-8 animate-page-enter">
+      <PageHeader
+        action={
+          completedUploads > 0 ? (
+            <Button asChild className="rounded-full px-5" variant="outline">
+              <Link href="/subscriptions">
+                Review detected subscriptions
+                <ArrowRight className="ml-2 size-4" />
+              </Link>
+            </Button>
+          ) : undefined
+        }
+        description="Pull statement files into the pipeline, keep the queue visible, and watch ingestion finish without leaving the authenticated workspace."
+        eyebrow="Day 9 live surface"
+        title="Uploads and processing status"
+      />
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="rounded-[1.7rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur">
+          <p className="text-xs uppercase tracking-[0.3em] text-black/45">Total files</p>
+          <p className="mt-4 text-4xl font-semibold tracking-tight text-ink">{uploads.length}</p>
+          <p className="mt-2 text-sm leading-6 text-black/60">
+            Every statement stays in history with deletion controls and provider detection visible.
+          </p>
+        </div>
+        <div className="rounded-[1.7rem] border border-black/10 bg-[#101922] p-5 text-white shadow-[0_24px_80px_rgba(16,25,34,0.16)]">
+          <p className="text-xs uppercase tracking-[0.3em] text-white/45">Active queue</p>
+          <p className="mt-4 text-4xl font-semibold tracking-tight">{activeUploads}</p>
+          <p className="mt-2 text-sm leading-6 text-white/62">
+            Polling stays live while anything is queued or processing so the status rail keeps moving.
+          </p>
+        </div>
+        <div className="rounded-[1.7rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur">
+          <p className="text-xs uppercase tracking-[0.3em] text-black/45">Completed ingests</p>
+          <p className="mt-4 text-4xl font-semibold tracking-tight text-ink">{completedUploads}</p>
+          <p className="mt-2 text-sm leading-6 text-black/60">
+            Finished uploads are ready for downstream subscription review and cleanup.
+          </p>
+        </div>
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(340px,0.95fr)]">
+        <div className="space-y-6">
+          <UploadDropzone
+            onUpload={async (file, onProgress) => {
+              const created = await createUpload.mutateAsync({ file, onProgress });
+              startTransition(() => {
+                setSelectedUploadId(created.id);
+              });
+            }}
+          />
+          <UploadProcessingPanel upload={selectedUpload} visualStep={visualStep} />
+        </div>
+
+        {uploadsQuery.isLoading ? (
+          <div className="flex min-h-[24rem] items-center justify-center rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
+            <div className="flex items-center gap-3 text-sm text-black/58">
+              <LoaderCircle className="size-4 animate-spin" />
+              Loading upload history...
+            </div>
+          </div>
+        ) : uploads.length === 0 ? (
+          <EmptyState
+            action={
+              <Button className="rounded-full px-5" variant="outline">
+                Queue your first file
+              </Button>
+            }
+            description="The history rail will populate after the first CSV or PDF upload and stay searchable from this workspace."
+            eyebrow="No uploads yet"
+            icon={<FolderSearch className="size-5" />}
+            title="Nothing in the queue yet."
+          />
+        ) : (
+          <UploadHistoryList
+            deletingUploadId={deleteUpload.isPending ? deleteUpload.variables ?? null : null}
+            onDelete={(uploadId) => {
+              void deleteUpload.mutateAsync(uploadId).then(() => {
+                if (selectedUploadId === uploadId) {
+                  startTransition(() => {
+                    setSelectedUploadId(null);
+                  });
+                }
+              });
+            }}
+            onSelect={(uploadId) => {
+              startTransition(() => {
+                setSelectedUploadId(uploadId);
+              });
+            }}
+            selectedUploadId={selectedUpload?.id ?? null}
+            uploads={uploads}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/app-shell/app-shell.tsx
+++ b/frontend/src/components/app-shell/app-shell.tsx
@@ -9,6 +9,7 @@ import {
   CalendarDays,
   ChevronDown,
   CreditCard,
+  FileUp,
   LayoutDashboard,
   LogOut,
   PanelLeftClose,
@@ -49,6 +50,12 @@ const navItems: NavItem[] = [
     label: "Subscriptions",
   },
   {
+    caption: "Statement ingest",
+    href: "/uploads",
+    icon: FileUp,
+    label: "Uploads",
+  },
+  {
     caption: "Cards and billing",
     href: "/payments",
     icon: CreditCard,
@@ -83,6 +90,11 @@ const routeMeta: Record<string, { description: string; searchPlaceholder: string
     description: "Billing rails, cards, and fallback payment methods live here.",
     searchPlaceholder: "Search cards, billing fallback, payment health",
     title: "Payments",
+  },
+  "/uploads": {
+    description: "Upload statement files, watch queue status, and manage ingestion history.",
+    searchPlaceholder: "Search uploads, providers, queue status, file history",
+    title: "Uploads",
   },
   "/settings": {
     description: "Theme, team-level defaults, and session controls stay in this operator surface.",
@@ -226,10 +238,10 @@ export function AppShell({ children }: AppShellProps) {
                 isSidebarExpanded ? "block" : "hidden xl:block",
               )}
             >
-              <p className="text-xs uppercase tracking-[0.3em] text-white/40">Day 5 status</p>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/40">Milestone status</p>
               <p className="mt-3 text-sm leading-6 text-white/75">
-                Subscription management is live with manual entry, detail routes, and lifecycle
-                edits layered onto the shared shell.
+                Subscription management, parsing, and detection are live. Upload operations now
+                extend that workflow with statement intake and queue visibility.
               </p>
             </div>
           </div>

--- a/frontend/src/components/uploads/service-logo.tsx
+++ b/frontend/src/components/uploads/service-logo.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+const providerDomains: Record<string, string> = {
+  amex: "americanexpress.com",
+  bank_of_america: "bankofamerica.com",
+  capital_one: "capitalone.com",
+  chase: "chase.com",
+  citi: "citi.com",
+  wells_fargo: "wellsfargo.com",
+};
+
+function formatProvider(provider: string) {
+  if (provider === "pending") {
+    return "Pending source";
+  }
+
+  return provider
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function fallbackTone(provider: string) {
+  const tones = [
+    "from-[#111827] to-[#334155]",
+    "from-[#7c2d12] to-[#ea580c]",
+    "from-[#14532d] to-[#22c55e]",
+    "from-[#1d4ed8] to-[#60a5fa]",
+    "from-[#4c1d95] to-[#a78bfa]",
+  ];
+
+  const hash = Array.from(provider).reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  return tones[hash % tones.length];
+}
+
+type ServiceLogoProps = {
+  provider: string;
+  size?: "lg" | "md" | "sm";
+};
+
+export function ServiceLogo({ provider, size = "md" }: ServiceLogoProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const normalizedProvider = provider.toLowerCase();
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [normalizedProvider]);
+
+  const label = useMemo(() => formatProvider(normalizedProvider), [normalizedProvider]);
+  const domain = providerDomains[normalizedProvider];
+  const initials = label
+    .split(/\s+/)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("")
+    .slice(0, 2);
+
+  const sizeClasses = {
+    lg: "size-14 rounded-[1.35rem] text-base",
+    md: "size-12 rounded-2xl text-sm",
+    sm: "size-10 rounded-xl text-xs",
+  }[size];
+
+  if (domain && !imageFailed) {
+    return (
+      <div
+        aria-label={`${label} logo`}
+        className={cn(
+          "overflow-hidden border border-black/10 bg-white shadow-[0_18px_32px_rgba(15,23,42,0.08)]",
+          sizeClasses,
+        )}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element -- Clearbit is a remote logo source and this fallback path only needs a lightweight image tag. */}
+        <img
+          alt={`${label} logo`}
+          className="size-full object-cover"
+          onError={() => setImageFailed(true)}
+          src={`https://logo.clearbit.com/${domain}`}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      aria-label={`${label} fallback`}
+      className={cn(
+        "inline-flex items-center justify-center border border-black/10 bg-gradient-to-br font-semibold uppercase tracking-[0.18em] text-white shadow-[0_18px_32px_rgba(15,23,42,0.08)]",
+        fallbackTone(normalizedProvider),
+        sizeClasses,
+      )}
+    >
+      {initials || "MS"}
+    </div>
+  );
+}

--- a/frontend/src/components/uploads/upload-dropzone.tsx
+++ b/frontend/src/components/uploads/upload-dropzone.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import { FileUp, LoaderCircle, TriangleAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
+const supportedMimeTypes = new Set(["text/csv", "application/csv", "application/pdf", "application/vnd.ms-excel"]);
+
+function validateFile(file: File) {
+  const lowerName = file.name.toLowerCase();
+  const matchesExtension = lowerName.endsWith(".csv") || lowerName.endsWith(".pdf");
+  const matchesMimeType = !file.type || supportedMimeTypes.has(file.type);
+
+  if (!matchesExtension || !matchesMimeType) {
+    return "Only CSV and PDF uploads are supported.";
+  }
+
+  if (file.size === 0) {
+    return "Uploaded file is empty.";
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE) {
+    return "Uploaded file exceeds the 10 MB limit.";
+  }
+
+  return null;
+}
+
+function formatSize(size: number) {
+  if (size >= 1024 * 1024) {
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  return `${Math.max(1, Math.round(size / 1024))} KB`;
+}
+
+type UploadDropzoneProps = {
+  disabled?: boolean;
+  onUpload: (file: File, onProgress: (progress: number) => void) => Promise<void>;
+};
+
+export function UploadDropzone({ disabled = false, onUpload }: UploadDropzoneProps) {
+  const inputId = useId();
+  const [dragActive, setDragActive] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const [selectedFileSize, setSelectedFileSize] = useState<number | null>(null);
+  const [uploadProgress, setUploadProgress] = useState(0);
+
+  const helperText = useMemo(() => {
+    if (errorMessage) {
+      return errorMessage;
+    }
+
+    if (selectedFileName && selectedFileSize !== null) {
+      return `${selectedFileName} ready to process • ${formatSize(selectedFileSize)}`;
+    }
+
+    return "Drop a statement export here or browse for a CSV/PDF file up to 10 MB.";
+  }, [errorMessage, selectedFileName, selectedFileSize]);
+
+  async function handleFile(file: File | null) {
+    if (!file || disabled || isUploading) {
+      return;
+    }
+
+    const validationError = validateFile(file);
+    if (validationError) {
+      setErrorMessage(validationError);
+      setUploadProgress(0);
+      setSelectedFileName(file.name);
+      setSelectedFileSize(file.size);
+      return;
+    }
+
+    setErrorMessage(null);
+    setSelectedFileName(file.name);
+    setSelectedFileSize(file.size);
+    setUploadProgress(0);
+    setIsUploading(true);
+
+    try {
+      await onUpload(file, (progress) => {
+        setUploadProgress(Math.max(8, progress));
+      });
+      setUploadProgress(100);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Upload failed.");
+      setUploadProgress(0);
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-black/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.86),rgba(245,239,231,0.92))] shadow-line backdrop-blur">
+      <div className="border-b border-black/10 px-5 py-5 sm:px-6">
+        <p className="text-xs uppercase tracking-[0.32em] text-black/45">Ingest</p>
+        <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-2xl space-y-2">
+            <h3 className="text-3xl font-semibold tracking-tight text-ink">Upload a bank export</h3>
+            <p className="text-sm leading-6 text-black/62">
+              Drag in a PDF or CSV statement, validate it before it leaves the browser, and hand
+              the file straight into the parsing queue.
+            </p>
+          </div>
+
+          <Button asChild className="rounded-full px-5" variant="outline">
+            <label className={cn(disabled ? "cursor-not-allowed" : "cursor-pointer")} htmlFor={inputId}>
+              Choose file
+            </label>
+          </Button>
+        </div>
+      </div>
+
+      <div className="p-5 sm:p-6">
+        <input
+          accept=".csv,.pdf,text/csv,application/pdf,application/vnd.ms-excel"
+          aria-label="Upload statement"
+          className="sr-only"
+          disabled={disabled || isUploading}
+          id={inputId}
+          onChange={(event) => {
+            void handleFile(event.target.files?.[0] ?? null);
+            event.currentTarget.value = "";
+          }}
+          type="file"
+        />
+
+        <div
+          className={cn(
+            "relative overflow-hidden rounded-[1.9rem] border border-dashed px-5 py-7 transition sm:px-7 sm:py-10",
+            dragActive
+              ? "border-ember bg-[#fff5ed] shadow-[inset_0_0_0_1px_rgba(220,93,48,0.15)]"
+              : "border-black/12 bg-white/78",
+            disabled ? "opacity-60" : "",
+          )}
+          onDragEnter={(event) => {
+            event.preventDefault();
+            if (!disabled) {
+              setDragActive(true);
+            }
+          }}
+          onDragLeave={(event) => {
+            event.preventDefault();
+            if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+              return;
+            }
+            setDragActive(false);
+          }}
+          onDragOver={(event) => {
+            event.preventDefault();
+          }}
+          onDrop={(event) => {
+            event.preventDefault();
+            setDragActive(false);
+            void handleFile(event.dataTransfer.files[0] ?? null);
+          }}
+        >
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-xl">
+              <div className="inline-flex size-14 items-center justify-center rounded-[1.35rem] border border-black/10 bg-stone text-ink">
+                {isUploading ? (
+                  <LoaderCircle className="size-6 animate-spin" />
+                ) : (
+                  <FileUp className="size-6" />
+                )}
+              </div>
+              <p className="mt-4 text-xl font-semibold text-ink">Drop a statement or browse locally</p>
+              <p className="mt-2 text-sm leading-6 text-black/62">
+                CSV exports move fastest. PDFs work too and stay visible in the queue while parsing
+                and detection finish in the background.
+              </p>
+            </div>
+
+            <div className="min-w-0 max-w-sm space-y-3 rounded-[1.5rem] border border-black/10 bg-[#101922] p-5 text-white shadow-[0_24px_70px_rgba(16,25,34,0.18)]">
+              <p className="text-xs uppercase tracking-[0.3em] text-white/45">Validation</p>
+              <p
+                className={cn(
+                  "text-sm leading-6",
+                  errorMessage ? "text-[#ffd0c7]" : "text-white/76",
+                )}
+                role={errorMessage ? "alert" : undefined}
+              >
+                {helperText}
+              </p>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.22em] text-white/48">
+                  <span>{isUploading ? "Upload progress" : "Ready state"}</span>
+                  <span>{isUploading ? `${uploadProgress}%` : errorMessage ? "Check file" : "Waiting"}</span>
+                </div>
+                <div className="h-2 rounded-full bg-white/10">
+                  <div
+                    aria-hidden="true"
+                    className={cn(
+                      "h-full rounded-full transition-[width] duration-300",
+                      errorMessage ? "bg-[#ff7f66]" : "bg-[#f4caad]",
+                    )}
+                    style={{ width: `${uploadProgress}%` }}
+                  />
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-[1.15rem] border border-white/10 bg-white/5 p-3 text-xs leading-5 text-white/58">
+                <TriangleAlert className="mt-0.5 size-4 shrink-0 text-[#f4caad]" />
+                <p>Accepted formats: CSV and PDF. Larger files or mismatched extensions are rejected before upload.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/uploads/upload-history-list.tsx
+++ b/frontend/src/components/uploads/upload-history-list.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Clock3, FileSpreadsheet, FileText, Trash2 } from "lucide-react";
+
+import { ServiceLogo } from "@/components/uploads/service-logo";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Upload, UploadStatus } from "@/types";
+
+const statusStyles: Record<UploadStatus, string> = {
+  completed: "border-emerald-500/25 bg-emerald-500/10 text-emerald-700",
+  failed: "border-rose-500/25 bg-rose-500/10 text-rose-700",
+  processing: "border-amber-500/25 bg-amber-500/10 text-amber-700",
+  queued: "border-sky-500/25 bg-sky-500/10 text-sky-700",
+};
+
+function formatStatus(status: UploadStatus) {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function formatProvider(provider: string) {
+  if (provider === "pending") {
+    return "Awaiting source";
+  }
+
+  return provider
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+type UploadHistoryListProps = {
+  deletingUploadId?: number | null;
+  onDelete: (uploadId: number) => void;
+  onSelect: (uploadId: number) => void;
+  selectedUploadId: number | null;
+  uploads: Upload[];
+};
+
+export function UploadHistoryList({
+  deletingUploadId = null,
+  onDelete,
+  onSelect,
+  selectedUploadId,
+  uploads,
+}: UploadHistoryListProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
+      <div className="border-b border-black/10 px-5 py-5 sm:px-6">
+        <p className="text-xs uppercase tracking-[0.32em] text-black/45">History</p>
+        <div className="mt-3 flex items-end justify-between gap-4">
+          <div>
+            <h3 className="text-2xl font-semibold text-ink">Recent uploads</h3>
+            <p className="mt-2 text-sm leading-6 text-black/62">
+              Re-open any file to inspect status, provider detection, transaction counts, and queue
+              changes without leaving this workspace.
+            </p>
+          </div>
+          <p className="text-sm font-medium text-black/48">{uploads.length} files</p>
+        </div>
+      </div>
+
+      <div className="divide-y divide-black/8">
+        {uploads.map((upload) => {
+          const isSelected = selectedUploadId === upload.id;
+
+          return (
+            <button
+              className={cn(
+                "group grid w-full gap-4 px-5 py-4 text-left transition sm:px-6",
+                isSelected ? "bg-[#f7f0e7]" : "hover:bg-black/[0.025]",
+              )}
+              key={upload.id}
+              onClick={() => onSelect(upload.id)}
+              type="button"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex min-w-0 items-center gap-4">
+                  <ServiceLogo provider={upload.provider} size="sm" />
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-ink">{upload.file_name}</p>
+                    <p className="mt-1 text-sm text-black/55">{formatProvider(upload.provider)}</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em]",
+                      statusStyles[upload.status],
+                    )}
+                  >
+                    {formatStatus(upload.status)}
+                  </span>
+                  <Button
+                    aria-label={`Delete ${upload.file_name}`}
+                    className="rounded-full"
+                    disabled={deletingUploadId === upload.id}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDelete(upload.id);
+                    }}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.24em] text-black/42">
+                <span className="inline-flex items-center gap-2">
+                  {upload.source_type === "upload_pdf" ? (
+                    <FileText className="size-3.5" />
+                  ) : (
+                    <FileSpreadsheet className="size-3.5" />
+                  )}
+                  {upload.source_type === "upload_pdf" ? "PDF" : "CSV"}
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <Clock3 className="size-3.5" />
+                  {formatTimestamp(upload.created_at)}
+                </span>
+                <span>{upload.transaction_count} transactions</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/uploads/upload-processing-panel.tsx
+++ b/frontend/src/components/uploads/upload-processing-panel.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { CheckCircle2, CircleDashed, LoaderCircle, TriangleAlert } from "lucide-react";
+
+import { ServiceLogo } from "@/components/uploads/service-logo";
+import { cn } from "@/lib/utils";
+import type { Upload } from "@/types";
+
+const stepLabels = ["Queued", "Parsing", "Detecting", "Done"] as const;
+type VisualStep = (typeof stepLabels)[number] | "Failed";
+
+function formatProvider(provider: string) {
+  if (provider === "pending") {
+    return "Awaiting source";
+  }
+
+  return provider
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) {
+    return "Waiting for completion";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+type UploadProcessingPanelProps = {
+  upload: Upload | null;
+  visualStep: VisualStep;
+};
+
+export function UploadProcessingPanel({ upload, visualStep }: UploadProcessingPanelProps) {
+  if (!upload) {
+    return (
+      <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+        <p className="text-xs uppercase tracking-[0.32em] text-black/45">Processing</p>
+        <div className="mt-4 max-w-xl space-y-3">
+          <h3 className="text-2xl font-semibold text-ink">No upload selected</h3>
+          <p className="text-sm leading-6 text-black/62">
+            Start with a CSV or PDF export to light up the queue, then select any history row to
+            inspect the live status rail here.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const activeIndex = visualStep === "Failed" ? 2 : stepLabels.indexOf(visualStep);
+
+  return (
+    <section className="rounded-[2rem] border border-black/10 bg-[#101922] p-6 text-white shadow-[0_24px_80px_rgba(16,25,34,0.22)] sm:p-7">
+      <div className="flex flex-col gap-5 border-b border-white/10 pb-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex items-start gap-4">
+          <ServiceLogo provider={upload.provider} size="lg" />
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.32em] text-white/45">Selected file</p>
+            <h3 className="text-2xl font-semibold">{upload.file_name}</h3>
+            <p className="text-sm text-white/62">{formatProvider(upload.provider)}</p>
+          </div>
+        </div>
+
+        <div className="grid gap-3 rounded-[1.5rem] border border-white/10 bg-white/6 p-4 text-sm text-white/72 sm:grid-cols-2">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.24em] text-white/42">Transactions</p>
+            <p className="mt-2 text-lg font-semibold text-white">{upload.transaction_count}</p>
+          </div>
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.24em] text-white/42">Last update</p>
+            <p className="mt-2 text-sm leading-6 text-white/72">{formatTimestamp(upload.updated_at)}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(260px,0.75fr)]">
+        <div className="space-y-4">
+          <p className="text-xs uppercase tracking-[0.32em] text-white/45">Pipeline</p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {stepLabels.map((label, index) => {
+              const isDone = visualStep !== "Failed" && index < activeIndex;
+              const isCurrent = visualStep !== "Failed" && index === activeIndex;
+              const isPending = visualStep !== "Failed" && index > activeIndex;
+
+              return (
+                <div
+                  className={cn(
+                    "rounded-[1.5rem] border px-4 py-4 transition",
+                    isDone
+                      ? "border-emerald-400/30 bg-emerald-400/10"
+                      : isCurrent
+                        ? "border-amber-300/25 bg-white/8"
+                        : "border-white/10 bg-white/4",
+                  )}
+                  key={label}
+                >
+                  <div className="flex items-center gap-3">
+                    {isDone ? (
+                      <CheckCircle2 className="size-5 text-emerald-300" />
+                    ) : isCurrent ? (
+                      <LoaderCircle className="size-5 animate-spin text-amber-200" />
+                    ) : (
+                      <CircleDashed className="size-5 text-white/28" />
+                    )}
+                    <p className="text-sm font-semibold">{label}</p>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-white/62">
+                    {label === "Queued" && "File accepted and waiting to start."}
+                    {label === "Parsing" && "Statement rows are being extracted and normalized."}
+                    {label === "Detecting" && "Recurring services are being matched from the upload."}
+                    {label === "Done" && "Upload is ready for downstream review."}
+                  </p>
+                  {isPending ? (
+                    <p className="mt-3 text-[11px] uppercase tracking-[0.24em] text-white/34">Pending</p>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="space-y-4 rounded-[1.7rem] border border-white/10 bg-white/6 p-5">
+          <p className="text-xs uppercase tracking-[0.32em] text-white/45">Queue notes</p>
+          <div className="space-y-3 text-sm leading-6 text-white/72">
+            <p>
+              Current backend status: <span className="font-semibold capitalize text-white">{upload.status}</span>
+            </p>
+            <p>
+              Last sync: <span className="text-white">{formatTimestamp(upload.last_synced_at)}</span>
+            </p>
+            {upload.error_message ? (
+              <div className="flex gap-3 rounded-[1.25rem] border border-rose-300/20 bg-rose-400/10 p-4 text-rose-100">
+                <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                <p>{upload.error_message}</p>
+              </div>
+            ) : (
+              <p>
+                The step rail above is driven by the live status poll and keeps advancing while the
+                selected file remains queued or processing.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/use-uploads.ts
+++ b/frontend/src/hooks/use-uploads.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useAuth } from "@/hooks/use-auth";
+import { apiClient } from "@/lib/api-client";
+import type { Upload } from "@/types";
+
+const uploadKeys = {
+  history: ["uploads", "history"] as const,
+  status: (uploadId: number) => ["uploads", "status", uploadId] as const,
+};
+
+function useRequiredToken() {
+  const { accessToken } = useAuth();
+
+  if (!accessToken) {
+    throw new Error("You must be signed in to manage uploads.");
+  }
+
+  return accessToken;
+}
+
+export function useUploadHistory() {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken),
+    queryFn: () => apiClient.getUploads(accessToken!),
+    queryKey: uploadKeys.history,
+    refetchInterval: (query) => {
+      const items = query.state.data?.items ?? [];
+      return items.some((item) => item.status === "queued" || item.status === "processing")
+        ? 2_000
+        : false;
+    },
+  });
+}
+
+export function useUploadStatus(uploadId: number | null) {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken) && uploadId !== null,
+    queryFn: () => apiClient.getUploadStatus(accessToken!, uploadId!),
+    queryKey: uploadId === null ? ["uploads", "status", "idle"] : uploadKeys.status(uploadId),
+    refetchInterval: (query) => {
+      const upload = query.state.data;
+      return upload?.status === "queued" || upload?.status === "processing" ? 1_250 : false;
+    },
+  });
+}
+
+export function useCreateUpload() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ file, onProgress }: { file: File; onProgress?: (progress: number) => void }) =>
+      apiClient.uploadFile(token, file, onProgress),
+    onSuccess: (upload) => {
+      queryClient.setQueryData(uploadKeys.status(upload.id), upload);
+      void queryClient.invalidateQueries({ queryKey: uploadKeys.history });
+    },
+  });
+}
+
+export function useDeleteUpload() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (uploadId: number) => apiClient.deleteUpload(token, uploadId),
+    onSuccess: (_, uploadId) => {
+      void queryClient.invalidateQueries({ queryKey: uploadKeys.history });
+      queryClient.removeQueries({ queryKey: uploadKeys.status(uploadId) });
+    },
+  });
+}
+
+export function mergeSelectedUpload(
+  selectedUploadId: number | null,
+  historyItems: Upload[],
+  selectedUploadStatus: Upload | undefined,
+) {
+  if (selectedUploadStatus && selectedUploadId === selectedUploadStatus.id) {
+    return selectedUploadStatus;
+  }
+
+  return historyItems.find((item) => item.id === selectedUploadId) ?? historyItems[0] ?? null;
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -10,6 +10,8 @@ import type {
   SubscriptionFilters,
   SubscriptionListResponse,
   SubscriptionUpsertInput,
+  Upload,
+  UploadListResponse,
   User,
 } from "@/types";
 
@@ -40,10 +42,12 @@ async function request<T>(
   init?: RequestInit,
   options?: RequestOptions,
 ): Promise<T> {
+  const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData;
+
   const response = await fetch(buildUrl(path, options?.query), {
     ...init,
     headers: {
-      "Content-Type": "application/json",
+      ...(isFormData ? {} : { "Content-Type": "application/json" }),
       ...(options?.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...init?.headers,
     },
@@ -63,6 +67,63 @@ async function request<T>(
   }
 
   return response.json() as Promise<T>;
+}
+
+function getErrorMessage(status: number, response: unknown) {
+  if (response && typeof response === "object" && "detail" in response) {
+    const detail = response.detail;
+    if (typeof detail === "string" && detail.trim()) {
+      return detail;
+    }
+  }
+
+  return `Request failed with ${status}`;
+}
+
+function uploadFile(
+  token: string,
+  file: File,
+  onProgress?: (progress: number) => void,
+): Promise<Upload> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    const formData = new FormData();
+    formData.append("file", file);
+
+    xhr.open("POST", buildUrl("/uploads"));
+    xhr.responseType = "json";
+    xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+
+    xhr.upload.addEventListener("progress", (event) => {
+      if (!event.lengthComputable || !onProgress) {
+        return;
+      }
+
+      onProgress(Math.round((event.loaded / event.total) * 100));
+    });
+
+    xhr.addEventListener("load", () => {
+      const response =
+        xhr.response && typeof xhr.response === "object"
+          ? xhr.response
+          : xhr.responseText
+            ? (JSON.parse(xhr.responseText) as unknown)
+            : null;
+
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(new Error(getErrorMessage(xhr.status, response)));
+        return;
+      }
+
+      resolve(response as Upload);
+    });
+
+    xhr.addEventListener("error", () => {
+      reject(new Error("Network request failed."));
+    });
+
+    xhr.send(formData);
+  });
 }
 
 export const apiClient = {
@@ -96,6 +157,13 @@ export const apiClient = {
   getPaymentMethods(token: string) {
     return request<PaymentMethodListResponse>("/payment-methods", undefined, { token });
   },
+  getUploads(token: string) {
+    return request<UploadListResponse>("/uploads", undefined, { token });
+  },
+  getUploadStatus(token: string, uploadId: number) {
+    return request<Upload>(`/uploads/${uploadId}/status`, undefined, { token });
+  },
+  uploadFile,
   getSubscriptions(token: string, filters?: SubscriptionFilters) {
     return request<SubscriptionListResponse>("/subscriptions", undefined, {
       query: filters,
@@ -119,6 +187,11 @@ export const apiClient = {
   },
   deleteSubscription(token: string, subscriptionId: number) {
     return request<void>(`/subscriptions/${subscriptionId}`, {
+      method: "DELETE",
+    }, { token });
+  },
+  deleteUpload(token: string, uploadId: number) {
+    return request<void>(`/uploads/${uploadId}`, {
       method: "DELETE",
     }, { token });
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,6 +60,29 @@ export type PaymentMethodListResponse = {
   total: number;
 };
 
+export type UploadSourceType = "upload_csv" | "upload_pdf";
+export type UploadStatus = "queued" | "processing" | "completed" | "failed";
+
+export type Upload = {
+  id: number;
+  file_name: string;
+  source_type: UploadSourceType;
+  provider: string;
+  status: UploadStatus;
+  content_type: string | null;
+  file_size: number | null;
+  error_message: string | null;
+  transaction_count: number;
+  created_at: string;
+  updated_at: string;
+  last_synced_at: string | null;
+};
+
+export type UploadListResponse = {
+  items: Upload[];
+  total: number;
+};
+
 export type SubscriptionStatus = "active" | "paused" | "cancelled";
 export type SubscriptionCadence = "weekly" | "monthly" | "quarterly" | "yearly";
 

--- a/frontend/tests/unit/components/dropzone.test.tsx
+++ b/frontend/tests/unit/components/dropzone.test.tsx
@@ -1,0 +1,72 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { UploadDropzone } from "@/components/uploads/upload-dropzone";
+
+describe("UploadDropzone", () => {
+  it("accepts supported CSV files and forwards upload progress", async () => {
+    const user = userEvent.setup();
+    let resolveUpload: (() => void) | undefined;
+    const onUpload = vi.fn((_file: File, onProgress: (progress: number) => void) => {
+      onProgress(64);
+      return new Promise<void>((resolve) => {
+        resolveUpload = resolve;
+      });
+    });
+
+    render(<UploadDropzone onUpload={onUpload} />);
+
+    const input = screen.getByLabelText("Upload statement");
+    const file = new File(["Posting Date,Details,Amount"], "statement.csv", {
+      type: "text/csv",
+    });
+
+    await user.upload(input, file);
+
+    await waitFor(() => {
+      expect(onUpload).toHaveBeenCalledTimes(1);
+    });
+    expect(onUpload).toHaveBeenCalledWith(file, expect.any(Function));
+    expect(screen.getByText(/statement\.csv ready to process/i)).toBeInTheDocument();
+    expect(screen.getByText("64%")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveUpload?.();
+    });
+  });
+
+  it("rejects unsupported file types before upload", async () => {
+    const user = userEvent.setup({ applyAccept: false });
+    const onUpload = vi.fn();
+
+    render(<UploadDropzone onUpload={onUpload} />);
+
+    const input = screen.getByLabelText("Upload statement");
+    const file = new File(["hello"], "statement.txt", {
+      type: "text/plain",
+    });
+
+    await user.upload(input, file);
+
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent("Only CSV and PDF uploads are supported.");
+  });
+
+  it("rejects files larger than ten megabytes", async () => {
+    const user = userEvent.setup();
+    const onUpload = vi.fn();
+
+    render(<UploadDropzone onUpload={onUpload} />);
+
+    const input = screen.getByLabelText("Upload statement");
+    const file = new File([new Uint8Array(10 * 1024 * 1024 + 1)], "large.pdf", {
+      type: "application/pdf",
+    });
+
+    await user.upload(input, file);
+
+    expect(onUpload).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent("Uploaded file exceeds the 10 MB limit.");
+  });
+});


### PR DESCRIPTION
## Day 9 Summary

Completed Day 9 on `day-09/upload-ui-processing-status` and pushed **10 commits** ending at `a22dda5`.

### Frontend Changes

The frontend now has:

- A live uploads workspace at `frontend/src/app/(app)/uploads/page.tsx`
- Upload hooks/API support in `frontend/src/hooks/use-uploads.ts` and `frontend/src/lib/api-client.ts`
- Day 9 coverage in `frontend/tests/unit/components/dropzone.test.tsx`

### Verification

Passed with:

- `zsh /Users/work/.codex/automations/daily-milestone-worker-2/lockfile-guard.sh "$PWD"`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run typecheck`

### GitHub Housekeeping

- Issues **#41**, **#42**, and **#40** are commented and closed
- Milestone 9 is closed with `open_issues = 0`
- Automation memory is updated

### Next Steps

Remaining Day 9 work is **none**; the next scheduled run should advance to **Day 10** on `day-10/dashboard-api-snapshot`.