### PR TITLE
Day 10/dashboard api snapshot

### DIFF
--- a/backend/src/api/router.py
+++ b/backend/src/api/router.py
@@ -1,11 +1,20 @@
 from fastapi import APIRouter
 
-from src.api.routes import auth, categories, health, payment_methods, subscriptions, uploads
+from src.api.routes import (
+    auth,
+    categories,
+    dashboard,
+    health,
+    payment_methods,
+    subscriptions,
+    uploads,
+)
 
 api_router = APIRouter()
 api_router.include_router(health.router, tags=["health"])
 api_router.include_router(auth.router)
 api_router.include_router(categories.router)
+api_router.include_router(dashboard.router)
 api_router.include_router(payment_methods.router)
 api_router.include_router(subscriptions.router)
 api_router.include_router(uploads.router)

--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -1,10 +1,11 @@
 """Route modules for versioned APIs."""
 
-from src.api.routes import auth, categories, health, payment_methods, subscriptions
+from src.api.routes import auth, categories, dashboard, health, payment_methods, subscriptions
 
 __all__ = [
     "auth",
     "categories",
+    "dashboard",
     "health",
     "payment_methods",
     "subscriptions",

--- a/backend/src/api/routes/dashboard.py
+++ b/backend/src/api/routes/dashboard.py
@@ -1,0 +1,47 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.database import get_db
+from src.dependencies import get_current_user
+from src.models.user import User
+from src.schemas.dashboard import (
+    DashboardLayoutResponse,
+    DashboardLayoutUpdate,
+    DashboardSummaryResponse,
+)
+from src.services.dashboard import (
+    get_dashboard_layout,
+    get_dashboard_summary,
+    update_dashboard_layout,
+)
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+DbSession = Annotated[AsyncSession, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+@router.get("/summary", response_model=DashboardSummaryResponse, status_code=status.HTTP_200_OK)
+async def get_dashboard_summary_route(
+    session: DbSession,
+    current_user: CurrentUser,
+) -> DashboardSummaryResponse:
+    return await get_dashboard_summary(session, user=current_user)
+
+
+@router.get("/layout", response_model=DashboardLayoutResponse, status_code=status.HTTP_200_OK)
+async def get_dashboard_layout_route(
+    session: DbSession,
+    current_user: CurrentUser,
+) -> DashboardLayoutResponse:
+    return await get_dashboard_layout(session, user=current_user)
+
+
+@router.put("/layout", response_model=DashboardLayoutResponse, status_code=status.HTTP_200_OK)
+async def update_dashboard_layout_route(
+    payload: DashboardLayoutUpdate,
+    session: DbSession,
+    current_user: CurrentUser,
+) -> DashboardLayoutResponse:
+    return await update_dashboard_layout(session, user=current_user, payload=payload)

--- a/backend/src/schemas/dashboard.py
+++ b/backend/src/schemas/dashboard.py
@@ -1,0 +1,99 @@
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+DASHBOARD_WIDGET_IDS = (
+    "monthly-spend",
+    "category-breakdown",
+    "upcoming-renewals",
+    "recently-ended",
+)
+
+DashboardWidgetId = Literal[
+    "monthly-spend",
+    "category-breakdown",
+    "upcoming-renewals",
+    "recently-ended",
+]
+DashboardColumn = Literal["primary", "secondary"]
+
+
+class DashboardSummaryStats(BaseModel):
+    total_monthly_spend: Decimal
+    active_subscriptions: int
+    upcoming_renewals: int
+    cancelled_subscriptions: int
+
+
+class DashboardMonthlySpendPoint(BaseModel):
+    month: str
+    label: str
+    total: Decimal
+
+
+class DashboardCategoryBreakdownItem(BaseModel):
+    category_id: int | None
+    category_name: str
+    subscriptions: int
+    total_monthly_spend: Decimal
+
+
+class DashboardUpcomingRenewalItem(BaseModel):
+    subscription_id: int
+    name: str
+    vendor: str
+    amount: Decimal
+    currency: str
+    next_charge_date: date
+    days_until_charge: int
+
+
+class DashboardRecentlyEndedItem(BaseModel):
+    subscription_id: int
+    name: str
+    vendor: str
+    amount: Decimal
+    currency: str
+    end_date: date
+
+
+class DashboardSummaryResponse(BaseModel):
+    summary: DashboardSummaryStats
+    monthly_spend: list[DashboardMonthlySpendPoint]
+    category_breakdown: list[DashboardCategoryBreakdownItem]
+    upcoming_renewals: list[DashboardUpcomingRenewalItem]
+    recently_ended: list[DashboardRecentlyEndedItem]
+
+
+class DashboardLayoutWidget(BaseModel):
+    id: DashboardWidgetId
+    column: DashboardColumn
+
+
+class DashboardLayoutUpdate(BaseModel):
+    widgets: list[DashboardLayoutWidget]
+
+    @field_validator("widgets")
+    @classmethod
+    def validate_widget_count(
+        cls, value: list[DashboardLayoutWidget]
+    ) -> list[DashboardLayoutWidget]:
+        if len(value) != len(DASHBOARD_WIDGET_IDS):
+            raise ValueError("Dashboard layout must include each widget exactly once.")
+        return value
+
+    @model_validator(mode="after")
+    def validate_widget_uniqueness(self) -> "DashboardLayoutUpdate":
+        widget_ids = [widget.id for widget in self.widgets]
+        if len(set(widget_ids)) != len(widget_ids) or set(widget_ids) != set(DASHBOARD_WIDGET_IDS):
+            raise ValueError("Dashboard layout must include each widget exactly once.")
+        return self
+
+
+class DashboardLayoutResponse(DashboardLayoutUpdate):
+    version: int
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/src/services/dashboard.py
+++ b/backend/src/services/dashboard.py
@@ -1,0 +1,313 @@
+from datetime import UTC, date, datetime, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.logging import get_logger
+from src.models.category import Category
+from src.models.dashboard_layout import DashboardLayout
+from src.models.payment_history import PaymentHistory
+from src.models.subscription import Subscription
+from src.models.user import User
+from src.schemas.dashboard import (
+    DashboardCategoryBreakdownItem,
+    DashboardLayoutResponse,
+    DashboardLayoutUpdate,
+    DashboardLayoutWidget,
+    DashboardMonthlySpendPoint,
+    DashboardRecentlyEndedItem,
+    DashboardSummaryResponse,
+    DashboardSummaryStats,
+    DashboardUpcomingRenewalItem,
+)
+
+logger = get_logger(__name__)
+
+UPCOMING_WINDOW_DAYS = 30
+RECENTLY_ENDED_WINDOW_DAYS = 90
+MONTHLY_SPEND_MONTHS = 6
+
+DEFAULT_DASHBOARD_LAYOUT = DashboardLayoutUpdate(
+    widgets=[
+        DashboardLayoutWidget(id="monthly-spend", column="primary"),
+        DashboardLayoutWidget(id="category-breakdown", column="primary"),
+        DashboardLayoutWidget(id="upcoming-renewals", column="secondary"),
+        DashboardLayoutWidget(id="recently-ended", column="secondary"),
+    ]
+)
+
+
+def _quantize_money(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _monthly_equivalent(subscription: Subscription) -> Decimal:
+    cadence = subscription.cadence.lower()
+    amount = Decimal(subscription.amount)
+
+    if cadence == "weekly":
+        return _quantize_money((amount * Decimal(52)) / Decimal(12))
+    if cadence == "quarterly":
+        return _quantize_money(amount / Decimal(3))
+    if cadence == "yearly":
+        return _quantize_money(amount / Decimal(12))
+    return _quantize_money(amount)
+
+
+def _month_start(value: date) -> date:
+    return value.replace(day=1)
+
+
+def _shift_months(value: date, offset: int) -> date:
+    month_index = (value.year * 12 + value.month - 1) + offset
+    year = month_index // 12
+    month = month_index % 12 + 1
+    return date(year, month, 1)
+
+
+async def get_dashboard_summary(
+    session: AsyncSession,
+    *,
+    user: User,
+) -> DashboardSummaryResponse:
+    today = date.today()
+    upcoming_cutoff = today + timedelta(days=UPCOMING_WINDOW_DAYS)
+    recent_cutoff = today - timedelta(days=RECENTLY_ENDED_WINDOW_DAYS)
+
+    subscriptions = list(
+        (
+            await session.scalars(
+                select(Subscription)
+                .where(Subscription.user_id == user.id)
+                .order_by(Subscription.id.asc())
+            )
+        ).all()
+    )
+    category_ids = sorted(
+        {
+            subscription.category_id
+            for subscription in subscriptions
+            if subscription.category_id is not None
+        }
+    )
+    categories = (
+        list((await session.scalars(select(Category).where(Category.id.in_(category_ids)))).all())
+        if category_ids
+        else []
+    )
+    category_map = {category.id: category.name for category in categories}
+
+    active_subscriptions = [
+        subscription for subscription in subscriptions if subscription.status == "active"
+    ]
+    cancelled_subscriptions = [
+        subscription for subscription in subscriptions if subscription.status == "cancelled"
+    ]
+    upcoming_renewals = sorted(
+        [
+            subscription
+            for subscription in active_subscriptions
+            if subscription.next_charge_date is not None
+            and today <= subscription.next_charge_date <= upcoming_cutoff
+        ],
+        key=lambda subscription: (subscription.next_charge_date, subscription.id),
+    )
+    recently_ended = sorted(
+        [
+            subscription
+            for subscription in cancelled_subscriptions
+            if subscription.end_date is not None and recent_cutoff <= subscription.end_date <= today
+        ],
+        key=lambda subscription: (subscription.end_date, subscription.id),
+        reverse=True,
+    )
+
+    total_monthly_spend = _quantize_money(
+        sum(
+            (_monthly_equivalent(subscription) for subscription in active_subscriptions),
+            Decimal("0.00"),
+        )
+    )
+
+    category_totals: dict[tuple[int | None, str], dict[str, Decimal | int]] = {}
+    for subscription in active_subscriptions:
+        category_name = (
+            category_map.get(subscription.category_id)
+            if subscription.category_id is not None
+            else "Uncategorized"
+        ) or "Uncategorized"
+        category_key = (
+            subscription.category_id,
+            category_name,
+        )
+        entry = category_totals.setdefault(
+            category_key,
+            {"subscriptions": 0, "total_monthly_spend": Decimal("0.00")},
+        )
+        entry["subscriptions"] = int(entry["subscriptions"]) + 1
+        entry["total_monthly_spend"] = Decimal(entry["total_monthly_spend"]) + _monthly_equivalent(
+            subscription
+        )
+
+    month_totals: dict[str, Decimal] = {}
+    month_points: list[DashboardMonthlySpendPoint] = []
+    current_month = _month_start(today)
+    start_month = _shift_months(current_month, -(MONTHLY_SPEND_MONTHS - 1))
+    end_month = _shift_months(current_month, 1)
+    cursor = start_month
+    while cursor < end_month:
+        key = cursor.strftime("%Y-%m")
+        month_totals[key] = Decimal("0.00")
+        month_points.append(
+            DashboardMonthlySpendPoint(
+                month=key,
+                label=cursor.strftime("%b"),
+                total=Decimal("0.00"),
+            )
+        )
+        cursor = _shift_months(cursor, 1)
+
+    payment_history_rows = list(
+        (
+            await session.scalars(
+                select(PaymentHistory)
+                .join(Subscription, Subscription.id == PaymentHistory.subscription_id)
+                .where(
+                    Subscription.user_id == user.id,
+                    PaymentHistory.paid_at
+                    >= datetime.combine(
+                        start_month,
+                        datetime.min.time(),
+                        tzinfo=UTC,
+                    ),
+                    PaymentHistory.paid_at
+                    < datetime.combine(
+                        end_month,
+                        datetime.min.time(),
+                        tzinfo=UTC,
+                    ),
+                )
+                .order_by(PaymentHistory.paid_at.asc())
+            )
+        ).all()
+    )
+
+    for payment in payment_history_rows:
+        paid_at = payment.paid_at.astimezone(UTC) if payment.paid_at.tzinfo else payment.paid_at
+        key = paid_at.strftime("%Y-%m")
+        if key in month_totals:
+            month_totals[key] += Decimal(payment.amount)
+
+    monthly_spend = [
+        DashboardMonthlySpendPoint(
+            month=point.month,
+            label=point.label,
+            total=_quantize_money(month_totals[point.month]),
+        )
+        for point in month_points
+    ]
+
+    response = DashboardSummaryResponse(
+        summary=DashboardSummaryStats(
+            total_monthly_spend=total_monthly_spend,
+            active_subscriptions=len(active_subscriptions),
+            upcoming_renewals=len(upcoming_renewals),
+            cancelled_subscriptions=len(cancelled_subscriptions),
+        ),
+        monthly_spend=monthly_spend,
+        category_breakdown=[
+            DashboardCategoryBreakdownItem(
+                category_id=category_id,
+                category_name=category_name,
+                subscriptions=int(values["subscriptions"]),
+                total_monthly_spend=_quantize_money(Decimal(values["total_monthly_spend"])),
+            )
+            for (category_id, category_name), values in sorted(
+                category_totals.items(),
+                key=lambda item: (
+                    Decimal(item[1]["total_monthly_spend"]),
+                    item[0][1].lower(),
+                ),
+                reverse=True,
+            )
+        ],
+        upcoming_renewals=[
+            DashboardUpcomingRenewalItem(
+                subscription_id=subscription.id,
+                name=subscription.name,
+                vendor=subscription.vendor,
+                amount=_quantize_money(Decimal(subscription.amount)),
+                currency=subscription.currency,
+                next_charge_date=subscription.next_charge_date,
+                days_until_charge=(subscription.next_charge_date - today).days,
+            )
+            for subscription in upcoming_renewals[:6]
+            if subscription.next_charge_date is not None
+        ],
+        recently_ended=[
+            DashboardRecentlyEndedItem(
+                subscription_id=subscription.id,
+                name=subscription.name,
+                vendor=subscription.vendor,
+                amount=_quantize_money(Decimal(subscription.amount)),
+                currency=subscription.currency,
+                end_date=subscription.end_date,
+            )
+            for subscription in recently_ended[:6]
+            if subscription.end_date is not None
+        ],
+    )
+    logger.info(
+        "dashboard.summary.loaded",
+        user_id=user.id,
+        active_subscriptions=response.summary.active_subscriptions,
+        upcoming_renewals=response.summary.upcoming_renewals,
+    )
+    return response
+
+
+async def get_dashboard_layout(
+    session: AsyncSession,
+    *,
+    user: User,
+) -> DashboardLayoutResponse:
+    layout = await session.scalar(select(DashboardLayout).where(DashboardLayout.user_id == user.id))
+    if layout is None:
+        return DashboardLayoutResponse(
+            widgets=DEFAULT_DASHBOARD_LAYOUT.widgets,
+            version=1,
+            updated_at=None,
+        )
+
+    return DashboardLayoutResponse(
+        widgets=DashboardLayoutUpdate.model_validate(layout.layout).widgets,
+        version=layout.version,
+        updated_at=layout.updated_at,
+    )
+
+
+async def update_dashboard_layout(
+    session: AsyncSession,
+    *,
+    user: User,
+    payload: DashboardLayoutUpdate,
+) -> DashboardLayoutResponse:
+    layout = await session.scalar(select(DashboardLayout).where(DashboardLayout.user_id == user.id))
+    payload_data = payload.model_dump()
+
+    if layout is None:
+        layout = DashboardLayout(user_id=user.id, layout=payload_data, version=1)
+        session.add(layout)
+    else:
+        layout.layout = payload_data
+        layout.version += 1
+
+    await session.commit()
+    await session.refresh(layout)
+    logger.info("dashboard.layout.updated", user_id=user.id, version=layout.version)
+    return DashboardLayoutResponse(
+        widgets=payload.widgets,
+        version=layout.version,
+        updated_at=layout.updated_at,
+    )

--- a/backend/tests/api/test_dashboard.py
+++ b/backend/tests/api/test_dashboard.py
@@ -1,0 +1,259 @@
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+from src.core import database as database_module
+from src.models.payment_history import PaymentHistory
+from src.models.subscription import Subscription
+
+
+def _auth_headers(client, email: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "full_name": "Dashboard Owner",
+            "password": "super-secret",
+        },
+    )
+    assert response.status_code == 201
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_category(client, headers: dict[str, str], name: str) -> int:
+    response = client.post(
+        "/api/v1/categories",
+        headers=headers,
+        json={"name": name, "description": f"{name} services"},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _create_payment_method(client, headers: dict[str, str]) -> int:
+    response = client.post(
+        "/api/v1/payment-methods",
+        headers=headers,
+        json={"label": "Primary card", "provider": "Visa", "last4": "4242", "is_default": True},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _create_subscription(
+    client,
+    headers: dict[str, str],
+    *,
+    name: str,
+    amount: str,
+    cadence: str,
+    status: str,
+    start_date: str,
+    category_id: int | None = None,
+    next_charge_date: str | None = None,
+    end_date: str | None = None,
+    payment_method_id: int | None = None,
+) -> int:
+    response = client.post(
+        "/api/v1/subscriptions",
+        headers=headers,
+        json={
+            "name": name,
+            "vendor": name,
+            "amount": amount,
+            "currency": "USD",
+            "cadence": cadence,
+            "status": status,
+            "start_date": start_date,
+            "category_id": category_id,
+            "next_charge_date": next_charge_date,
+            "end_date": end_date,
+            "payment_method_id": payment_method_id,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _seed_payment_history(subscription_id: int, paid_at: datetime, amount: Decimal) -> None:
+    async def _write() -> None:
+        async with database_module.SessionLocal() as session:
+            subscription = await session.get(Subscription, subscription_id)
+            assert subscription is not None
+            session.add(
+                PaymentHistory(
+                    subscription_id=subscription.id,
+                    payment_method_id=subscription.payment_method_id,
+                    paid_at=paid_at,
+                    amount=amount,
+                    currency="USD",
+                    payment_status="settled",
+                    reference=f"{subscription_id}-{paid_at.date().isoformat()}",
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_write())
+
+
+def test_dashboard_summary_and_layout_persistence(client) -> None:
+    today = date.today()
+    current_month_start = today.replace(day=1)
+    previous_month = (current_month_start - timedelta(days=1)).replace(day=1)
+
+    owner_headers = _auth_headers(client, "owner@example.com")
+    other_headers = _auth_headers(client, "other@example.com")
+    entertainment_id = _create_category(client, owner_headers, "Entertainment")
+    productivity_id = _create_category(client, owner_headers, "Productivity")
+    payment_method_id = _create_payment_method(client, owner_headers)
+
+    netflix_id = _create_subscription(
+        client,
+        owner_headers,
+        name="Netflix",
+        amount="15.00",
+        cadence="monthly",
+        status="active",
+        start_date=str(today - timedelta(days=120)),
+        category_id=entertainment_id,
+        next_charge_date=str(today + timedelta(days=4)),
+        payment_method_id=payment_method_id,
+    )
+    dropbox_id = _create_subscription(
+        client,
+        owner_headers,
+        name="Dropbox",
+        amount="120.00",
+        cadence="yearly",
+        status="active",
+        start_date=str(today - timedelta(days=300)),
+        category_id=productivity_id,
+        next_charge_date=str(today + timedelta(days=12)),
+        payment_method_id=payment_method_id,
+    )
+    _create_subscription(
+        client,
+        owner_headers,
+        name="Gym",
+        amount="45.00",
+        cadence="monthly",
+        status="cancelled",
+        start_date=str(today - timedelta(days=200)),
+        end_date=str(today - timedelta(days=3)),
+        payment_method_id=payment_method_id,
+    )
+    _create_subscription(
+        client,
+        other_headers,
+        name="Other Service",
+        amount="99.00",
+        cadence="monthly",
+        status="active",
+        start_date=str(today - timedelta(days=10)),
+    )
+
+    _seed_payment_history(
+        netflix_id,
+        datetime.combine(
+            current_month_start + timedelta(days=2),
+            datetime.min.time(),
+            tzinfo=UTC,
+        ),
+        Decimal("15.00"),
+    )
+    _seed_payment_history(
+        dropbox_id,
+        datetime.combine(
+            current_month_start + timedelta(days=4),
+            datetime.min.time(),
+            tzinfo=UTC,
+        ),
+        Decimal("120.00"),
+    )
+    _seed_payment_history(
+        netflix_id,
+        datetime.combine(
+            previous_month + timedelta(days=8),
+            datetime.min.time(),
+            tzinfo=UTC,
+        ),
+        Decimal("15.00"),
+    )
+
+    summary_response = client.get("/api/v1/dashboard/summary", headers=owner_headers)
+
+    assert summary_response.status_code == 200
+    payload = summary_response.json()
+    assert payload["summary"] == {
+        "total_monthly_spend": "25.00",
+        "active_subscriptions": 2,
+        "upcoming_renewals": 2,
+        "cancelled_subscriptions": 1,
+    }
+    assert payload["category_breakdown"][0]["category_name"] == "Entertainment"
+    assert payload["category_breakdown"][0]["total_monthly_spend"] == "15.00"
+    assert payload["category_breakdown"][1]["category_name"] == "Productivity"
+    assert payload["upcoming_renewals"][0]["name"] == "Netflix"
+    assert payload["upcoming_renewals"][0]["days_until_charge"] == 4
+    assert payload["upcoming_renewals"][1]["name"] == "Dropbox"
+    assert payload["recently_ended"][0]["name"] == "Gym"
+
+    month_map = {item["month"]: item["total"] for item in payload["monthly_spend"]}
+    assert month_map[current_month_start.strftime("%Y-%m")] == "135.00"
+    assert month_map[previous_month.strftime("%Y-%m")] == "15.00"
+
+    layout_response = client.get("/api/v1/dashboard/layout", headers=owner_headers)
+    assert layout_response.status_code == 200
+    assert layout_response.json()["widgets"] == [
+        {"id": "monthly-spend", "column": "primary"},
+        {"id": "category-breakdown", "column": "primary"},
+        {"id": "upcoming-renewals", "column": "secondary"},
+        {"id": "recently-ended", "column": "secondary"},
+    ]
+
+    update_response = client.put(
+        "/api/v1/dashboard/layout",
+        headers=owner_headers,
+        json={
+            "widgets": [
+                {"id": "upcoming-renewals", "column": "primary"},
+                {"id": "monthly-spend", "column": "primary"},
+                {"id": "category-breakdown", "column": "secondary"},
+                {"id": "recently-ended", "column": "secondary"},
+            ]
+        },
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["version"] == 1
+    assert update_response.json()["widgets"][0]["id"] == "upcoming-renewals"
+
+    persisted_layout_response = client.get("/api/v1/dashboard/layout", headers=owner_headers)
+    assert persisted_layout_response.status_code == 200
+    assert persisted_layout_response.json()["widgets"][0] == {
+        "id": "upcoming-renewals",
+        "column": "primary",
+    }
+
+    other_layout_response = client.get("/api/v1/dashboard/layout", headers=other_headers)
+    assert other_layout_response.status_code == 200
+    assert other_layout_response.json()["widgets"][0]["id"] == "monthly-spend"
+
+
+def test_dashboard_layout_requires_each_widget_exactly_once(client) -> None:
+    headers = _auth_headers(client, "layout-owner@example.com")
+
+    response = client.put(
+        "/api/v1/dashboard/layout",
+        headers=headers,
+        json={
+            "widgets": [
+                {"id": "monthly-spend", "column": "primary"},
+                {"id": "monthly-spend", "column": "secondary"},
+                {"id": "upcoming-renewals", "column": "secondary"},
+                {"id": "recently-ended", "column": "primary"},
+            ]
+        },
+    )
+
+    assert response.status_code == 422

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -1,179 +1,353 @@
-import { ArrowRight, BellRing, CalendarClock, Layers3, WalletCards } from "lucide-react";
+"use client";
 
+import Link from "next/link";
+import { startTransition, useMemo } from "react";
+import { ArrowDown, ArrowRight, ArrowUp, Columns2, LayoutTemplate, LoaderCircle } from "lucide-react";
+
+import { SnapshotBar } from "@/components/dashboard/snapshot-bar";
 import { Button } from "@/components/ui/button";
-import { CurrencyDisplay } from "@/components/ui/currency-display";
+import { CurrencyDisplay, formatCurrency } from "@/components/ui/currency-display";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { useDashboardLayout, useDashboardSummary, useUpdateDashboardLayout } from "@/hooks/use-dashboard";
+import { cn } from "@/lib/utils";
+import type {
+  DashboardCategoryBreakdownItem,
+  DashboardLayoutWidget,
+  DashboardRecentlyEndedItem,
+  DashboardSummary,
+  DashboardWidgetId,
+} from "@/types";
 
-const metricRows = [
+const widgetMeta: Record<
+  DashboardWidgetId,
   {
-    detail: "11 active plans, 3 annual conversions worth reviewing this week.",
-    label: "Monthly recurring",
-    value: 118.4,
-  },
-  {
-    detail: "The highest renewal cluster lands between April 9 and April 14.",
-    label: "Projected next 14 days",
-    value: 46.75,
-  },
-  {
-    detail: "Shared spend is stable across household, work, and trial categories.",
-    label: "Average plan cost",
-    value: 10.76,
-  },
-];
+    detail: (summary: DashboardSummary) => string;
+    eyebrow: string;
+    title: string;
+  }
+> = {
+  "category-breakdown": {
+    detail: (summary) => {
+      const leader = summary.category_breakdown[0];
+      if (!leader) {
+        return "Category mix will populate after more subscription activity lands.";
+      }
 
-const renewalQueue = [
-  {
-    amount: 14.99,
-    date: "Apr 9",
-    detail: "Streaming bundle • Visa •••• 4109",
-    title: "Prime Video + Music",
+      return `${leader.category_name} is currently pacing the mix at ${formatCurrency({ value: Number.parseFloat(leader.total_monthly_spend) })}.`;
+    },
+    eyebrow: "Prepared",
+    title: "Category breakdown",
   },
-  {
-    amount: 9.99,
-    date: "Apr 11",
-    detail: "Cloud notes • Mastercard •••• 8221",
-    title: "Notion Plus",
-  },
-  {
-    amount: 21,
-    date: "Apr 14",
-    detail: "Meal planner • Visa •••• 4109",
-    title: "Family recipes",
-  },
-];
+  "monthly-spend": {
+    detail: (summary) => {
+      const currentMonth = summary.monthly_spend.at(-1);
+      if (!currentMonth) {
+        return "Monthly spend history becomes available once payment history starts landing.";
+      }
 
-const workspaceMoves = [
-  "Shared navigation now covers dashboard, subscriptions, payments, calendar, and settings.",
-  "The top bar exposes search affordance, notifications, theme control, and user session actions.",
-  "Empty states and reusable headers are in place so the next milestones can plug into the shell quickly.",
-];
+      return `${currentMonth.label} has ${formatCurrency({ value: Number.parseFloat(currentMonth.total) })} recorded so far.`;
+    },
+    eyebrow: "Prepared",
+    title: "Monthly spend",
+  },
+  "recently-ended": {
+    detail: (summary) => {
+      const latest = summary.recently_ended[0];
+      if (!latest) {
+        return "Recently ended subscriptions will appear once cancellations start recording end dates.";
+      }
 
-export default function DashboardPage() {
-  return (
-    <div className="space-y-10">
-      <PageHeader
-        action={
-          <Button className="rounded-full px-5" variant="outline">
-            Review upcoming charges
-            <ArrowRight className="ml-2 size-4" />
-          </Button>
+      return `${latest.name} ended most recently, closing out ${formatCurrency({ value: Number.parseFloat(latest.amount) })}.`;
+    },
+    eyebrow: "Prepared",
+    title: "Recently ended",
+  },
+  "upcoming-renewals": {
+    detail: (summary) => {
+      const next = summary.upcoming_renewals[0];
+      if (!next) {
+        return "Upcoming renewals will surface once active plans carry their next charge dates.";
+      }
+
+      return `${next.name} is next in line, due in ${next.days_until_charge} days.`;
+    },
+    eyebrow: "Prepared",
+    title: "Upcoming renewals",
+  },
+};
+
+function moveItemWithinColumn(
+  widgets: DashboardLayoutWidget[],
+  widgetId: DashboardWidgetId,
+  direction: "down" | "up",
+) {
+  const nextWidgets = [...widgets];
+  const currentIndex = nextWidgets.findIndex((widget) => widget.id === widgetId);
+
+  if (currentIndex === -1) {
+    return widgets;
+  }
+
+  const current = nextWidgets[currentIndex];
+  const columnIndexes = nextWidgets
+    .map((widget, index) => ({ index, widget }))
+    .filter(({ widget }) => widget.column === current.column)
+    .map(({ index }) => index);
+  const columnPosition = columnIndexes.indexOf(currentIndex);
+  const targetIndex =
+    direction === "up" ? columnIndexes[columnPosition - 1] : columnIndexes[columnPosition + 1];
+
+  if (targetIndex === undefined) {
+    return widgets;
+  }
+
+  [nextWidgets[currentIndex], nextWidgets[targetIndex]] = [nextWidgets[targetIndex], nextWidgets[currentIndex]];
+  return nextWidgets;
+}
+
+function toggleWidgetColumn(widgets: DashboardLayoutWidget[], widgetId: DashboardWidgetId) {
+  return widgets.map<DashboardLayoutWidget>((widget) =>
+    widget.id === widgetId
+      ? {
+          ...widget,
+          column: widget.column === "primary" ? "secondary" : "primary",
         }
-        description="A stable operator shell now wraps the authenticated experience, so new milestone work can focus on product behavior instead of rebuilding layout chrome."
-        eyebrow="Day 4 workspace"
-        title="Subscription command center"
-      />
+      : widget,
+  );
+}
 
-      <section className="grid gap-8 xl:grid-cols-[1.15fr_0.85fr]">
-        <div className="rounded-[2rem] border border-black/10 bg-white/72 p-6 shadow-line backdrop-blur sm:p-8">
-          <div className="flex items-center justify-between border-b border-black/10 pb-5">
-            <div>
-              <p className="text-xs uppercase tracking-[0.32em] text-black/45">Snapshot</p>
-              <h3 className="mt-2 text-2xl font-semibold text-ink">Recurring spend at a glance</h3>
-            </div>
-            <WalletCards className="size-5 text-ember" />
-          </div>
+function WidgetPlaceholder({
+  item,
+  onMoveDown,
+  onMoveUp,
+  onToggleColumn,
+  summary,
+}: {
+  item: DashboardLayoutWidget;
+  onMoveDown: () => void;
+  onMoveUp: () => void;
+  onToggleColumn: () => void;
+  summary: DashboardSummary;
+}) {
+  const meta = widgetMeta[item.id];
 
-          <div className="divide-y divide-black/10">
-            {metricRows.map((row) => (
-              <div className="grid gap-4 py-5 sm:grid-cols-[minmax(0,1fr)_auto]" key={row.label}>
-                <div className="space-y-2">
-                  <p className="text-sm uppercase tracking-[0.28em] text-black/45">{row.label}</p>
-                  <p className="text-sm leading-6 text-black/65">{row.detail}</p>
-                </div>
-                <CurrencyDisplay
-                  className="text-3xl font-semibold tracking-tight text-ink sm:text-4xl"
-                  value={row.value}
-                />
-              </div>
-            ))}
-          </div>
+  return (
+    <article className="group rounded-[1.8rem] border border-black/10 bg-white/82 p-5 shadow-line backdrop-blur transition duration-200 hover:-translate-y-0.5 hover:border-black/16">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-black/45">{meta.eyebrow}</p>
+          <h3 className="text-2xl font-semibold tracking-tight text-ink">{meta.title}</h3>
         </div>
 
-        <div className="space-y-6 rounded-[2rem] border border-black/10 bg-[#101922] p-6 text-white shadow-[0_24px_80px_rgba(17,20,24,0.22)] sm:p-8">
-          <div className="flex items-center justify-between border-b border-white/10 pb-5">
-            <div>
-              <p className="text-xs uppercase tracking-[0.32em] text-white/45">Attention</p>
-              <h3 className="mt-2 text-2xl font-semibold">Renewal watch</h3>
-            </div>
-            <BellRing className="size-5 text-amber-300" />
-          </div>
+        <div className="flex items-center gap-2">
+          <button
+            aria-label={`Move ${meta.title} up`}
+            className="inline-flex size-9 items-center justify-center rounded-full border border-black/10 bg-stone/70 text-black/60 transition hover:border-black/18 hover:text-ink"
+            onClick={onMoveUp}
+            type="button"
+          >
+            <ArrowUp className="size-4" />
+          </button>
+          <button
+            aria-label={`Move ${meta.title} down`}
+            className="inline-flex size-9 items-center justify-center rounded-full border border-black/10 bg-stone/70 text-black/60 transition hover:border-black/18 hover:text-ink"
+            onClick={onMoveDown}
+            type="button"
+          >
+            <ArrowDown className="size-4" />
+          </button>
+          <button
+            aria-label={`Move ${meta.title} to the other column`}
+            className="inline-flex size-9 items-center justify-center rounded-full border border-black/10 bg-stone/70 text-black/60 transition hover:border-black/18 hover:text-ink"
+            onClick={onToggleColumn}
+            type="button"
+          >
+            <Columns2 className="size-4" />
+          </button>
+        </div>
+      </div>
 
-          <div className="space-y-4">
-            {renewalQueue.map((item) => (
-              <div
-                className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4 backdrop-blur"
-                key={item.title}
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <p className="text-lg font-semibold">{item.title}</p>
-                    <p className="mt-1 text-sm text-white/62">{item.detail}</p>
-                  </div>
-                  <p className="rounded-full border border-white/12 px-3 py-1 text-xs uppercase tracking-[0.24em] text-white/72">
-                    {item.date}
+      <p className="mt-6 text-sm leading-6 text-black/62">{meta.detail(summary)}</p>
+      <div className="mt-6 flex items-center justify-between border-t border-black/10 pt-4 text-sm text-black/52">
+        <span>{item.column === "primary" ? "Primary column" : "Secondary column"}</span>
+        <span>Day 11 widget slot</span>
+      </div>
+    </article>
+  );
+}
+
+function SidebarInsight({
+  breakdown,
+  recentlyEnded,
+  upcoming,
+}: {
+  breakdown: DashboardCategoryBreakdownItem | undefined;
+  recentlyEnded: DashboardRecentlyEndedItem | undefined;
+  upcoming: DashboardSummary["upcoming_renewals"];
+}) {
+  return (
+    <section className="space-y-6 rounded-[2rem] border border-white/10 bg-[#101922] p-6 text-white shadow-[0_24px_80px_rgba(17,20,24,0.22)] sm:p-8">
+      <div className="space-y-2 border-b border-white/10 pb-5">
+        <p className="text-xs uppercase tracking-[0.32em] text-white/45">Renewal focus</p>
+        <h3 className="text-2xl font-semibold tracking-tight">What needs attention next</h3>
+        <p className="text-sm leading-6 text-white/62">
+          Day 10 keeps the dashboard operational with live KPIs now, then leaves the richer widgets ready for Day 11.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {upcoming.length === 0 ? (
+          <p className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4 text-sm leading-6 text-white/62">
+            No upcoming renewals are queued yet. As active subscriptions gain charge dates, this rail will start sorting urgency automatically.
+          </p>
+        ) : (
+          upcoming.slice(0, 3).map((item) => (
+            <div className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4" key={item.subscription_id}>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-semibold">{item.name}</p>
+                  <p className="mt-1 text-sm text-white/62">
+                    {item.vendor} · due in {item.days_until_charge} days
                   </p>
                 </div>
                 <CurrencyDisplay
-                  className="mt-4 text-2xl font-semibold text-amber-200"
-                  value={item.amount}
+                  className="text-lg font-semibold text-amber-200"
+                  value={Number.parseFloat(item.amount)}
                 />
               </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr]">
-        <div className="rounded-[2rem] border border-black/10 bg-white/72 p-6 shadow-line backdrop-blur sm:p-8">
-          <div className="flex items-center justify-between border-b border-black/10 pb-5">
-            <div>
-              <p className="text-xs uppercase tracking-[0.32em] text-black/45">Flow</p>
-              <h3 className="mt-2 text-2xl font-semibold text-ink">This week&apos;s pacing</h3>
             </div>
-            <CalendarClock className="size-5 text-ember" />
+          ))
+        )}
+      </div>
+
+      <div className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4">
+        <p className="text-xs uppercase tracking-[0.28em] text-white/42">Category lead</p>
+        <p className="mt-3 text-lg font-semibold">
+          {breakdown?.category_name ?? "Waiting for category mix"}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-white/62">
+          {breakdown
+            ? `${breakdown.subscriptions} subscriptions currently map here at ${formatCurrency({ value: Number.parseFloat(breakdown.total_monthly_spend) })} in monthly-equivalent spend.`
+            : "Once active subscriptions are categorized, this lane will call out the heaviest spend cluster."}
+        </p>
+      </div>
+
+      <div className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4">
+        <p className="text-xs uppercase tracking-[0.28em] text-white/42">Recently ended</p>
+        <p className="mt-3 text-lg font-semibold">
+          {recentlyEnded?.name ?? "No recent cancellations"}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-white/62">
+          {recentlyEnded
+            ? `${recentlyEnded.vendor} most recently closed at ${formatCurrency({ value: Number.parseFloat(recentlyEnded.amount) })}.`
+            : "As plans are cancelled with end dates, this lane will preserve the recent context for review."}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default function DashboardPage() {
+  const summaryQuery = useDashboardSummary();
+  const layoutQuery = useDashboardLayout();
+  const updateLayout = useUpdateDashboardLayout();
+
+  const summary = summaryQuery.data;
+  const widgets = layoutQuery.data?.widgets;
+  const groupedWidgets = useMemo(
+    () => ({
+      primary: (widgets ?? []).filter((widget) => widget.column === "primary"),
+      secondary: (widgets ?? []).filter((widget) => widget.column === "secondary"),
+    }),
+    [widgets],
+  );
+
+  const applyLayout = (nextWidgets: DashboardLayoutWidget[]) => {
+    startTransition(() => {
+      void updateLayout.mutateAsync({ widgets: nextWidgets });
+    });
+  };
+
+  return (
+    <div className="space-y-8 animate-page-enter">
+      <PageHeader
+        action={
+          <Button asChild className="rounded-full px-5" variant="outline">
+            <Link href="/subscriptions">
+              Open subscriptions
+              <ArrowRight className="ml-2 size-4" />
+            </Link>
+          </Button>
+        }
+        description="Track recurring spend, keep renewals in view, and stage the widget system with a persistent dashboard layout before the richer analytics surface lands."
+        eyebrow="Day 10 live surface"
+        title="Smart dashboard snapshot"
+      />
+
+      <SnapshotBar isLoading={summaryQuery.isLoading} summary={summary?.summary} />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.85fr)]">
+        <section className="rounded-[2rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur sm:p-6">
+          <div className="flex flex-col gap-4 border-b border-black/10 pb-5 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.32em] text-black/45">Widget staging</p>
+              <h2 className="text-2xl font-semibold tracking-tight text-ink">Layout now, widgets next</h2>
+              <p className="max-w-2xl text-sm leading-6 text-black/62">
+                The layout is already persistent, so Day 11 can drop real widgets into stable slots without rebuilding the page frame.
+              </p>
+            </div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-stone/70 px-4 py-2 text-sm text-black/58">
+              <LayoutTemplate className="size-4" />
+              {layoutQuery.data ? `Version ${layoutQuery.data.version}` : "Loading layout"}
+            </div>
           </div>
 
-          <div className="divide-y divide-black/10">
-            {renewalQueue.map((item) => (
-              <div className="grid gap-4 py-5 sm:grid-cols-[auto_minmax(0,1fr)_auto]" key={item.title}>
-                <p className="text-xs uppercase tracking-[0.28em] text-black/45">{item.date}</p>
-                <div>
-                  <p className="font-medium text-ink">{item.title}</p>
-                  <p className="mt-1 text-sm text-black/60">{item.detail}</p>
-                </div>
-                <CurrencyDisplay className="text-right font-semibold text-ink" value={item.amount} />
+          {summaryQuery.isLoading || layoutQuery.isLoading ? (
+            <div className="flex min-h-[22rem] items-center justify-center">
+              <div className="flex items-center gap-3 text-sm text-black/58">
+                <LoaderCircle className="size-4 animate-spin" />
+                Loading dashboard workspace...
               </div>
-            ))}
-          </div>
-        </div>
+            </div>
+          ) : !summary || !widgets || widgets.length === 0 ? (
+            <EmptyState
+              action={
+                <Button asChild className="rounded-full px-5" variant="outline">
+                  <Link href="/uploads">Bring in statement data</Link>
+                </Button>
+              }
+              description="Dashboard analytics will populate as subscriptions, payment history, and renewal dates accumulate in the workspace."
+              eyebrow="No dashboard data"
+              icon={<LayoutTemplate className="size-5" />}
+              title="Nothing to stage yet."
+            />
+          ) : (
+            <div className="mt-6 grid gap-4 xl:grid-cols-[1.08fr_0.92fr]">
+              {(["primary", "secondary"] as const).map((column) => (
+                <div className={cn("space-y-4", column === "secondary" ? "xl:pt-10" : "")} key={column}>
+                  {groupedWidgets[column].map((item) => (
+                    <WidgetPlaceholder
+                      item={item}
+                      key={item.id}
+                      onMoveDown={() => applyLayout(moveItemWithinColumn(widgets, item.id, "down"))}
+                      onMoveUp={() => applyLayout(moveItemWithinColumn(widgets, item.id, "up"))}
+                      onToggleColumn={() => applyLayout(toggleWidgetColumn(widgets, item.id))}
+                      summary={summary}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
 
-        <EmptyState
-          action={
-            <Button className="rounded-full px-5" variant="outline">
-              Open subscriptions surface
-            </Button>
-          }
-          description="The shell is live, but downstream milestone features have not populated this lane yet. Shared headers, empty states, dialogs, and formatting utilities are now ready for those flows."
-          eyebrow="Shell readiness"
-          icon={<Layers3 className="size-5" />}
-          title="The next product surfaces can plug in without layout rework."
+        <SidebarInsight
+          breakdown={summary?.category_breakdown[0]}
+          recentlyEnded={summary?.recently_ended[0]}
+          upcoming={summary?.upcoming_renewals ?? []}
         />
-      </section>
-
-      <section className="rounded-[2rem] border border-black/10 bg-white/72 p-6 shadow-line backdrop-blur sm:p-8">
-        <div className="grid gap-5 lg:grid-cols-3">
-          {workspaceMoves.map((move) => (
-            <p
-              className="border-t border-black/10 pt-4 text-sm leading-6 text-black/65 first:border-t-0 first:pt-0 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0 lg:first:border-l-0 lg:first:pl-0"
-              key={move}
-            >
-              {move}
-            </p>
-          ))}
-        </div>
-      </section>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/dashboard/snapshot-bar.tsx
+++ b/frontend/src/components/dashboard/snapshot-bar.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { AlertCircle, CalendarClock, CreditCard, Sparkles } from "lucide-react";
+
+import { CurrencyDisplay } from "@/components/ui/currency-display";
+import { cn } from "@/lib/utils";
+import type { DashboardSummaryStats } from "@/types";
+
+type SnapshotBarProps = {
+  isLoading?: boolean;
+  summary?: DashboardSummaryStats;
+};
+
+const metricMeta = [
+  {
+    accentClassName: "bg-[#101922] text-white",
+    detail: (summary: DashboardSummaryStats) =>
+      `${summary.active_subscriptions} live plans are contributing to this total.`,
+    icon: CreditCard,
+    key: "total_monthly_spend",
+    label: "Total spend",
+  },
+  {
+    accentClassName: "bg-white/82 text-ink",
+    detail: (summary: DashboardSummaryStats) =>
+      `${summary.active_subscriptions} subscriptions are currently active.`,
+    icon: Sparkles,
+    key: "active_subscriptions",
+    label: "Active subs",
+  },
+  {
+    accentClassName: "bg-white/82 text-ink",
+    detail: (summary: DashboardSummaryStats) =>
+      `${summary.upcoming_renewals} charges are due within the next 30 days.`,
+    icon: CalendarClock,
+    key: "upcoming_renewals",
+    label: "Upcoming",
+  },
+  {
+    accentClassName: "bg-white/82 text-ink",
+    detail: (summary: DashboardSummaryStats) =>
+      `${summary.cancelled_subscriptions} subscriptions are sitting in the cancelled lane.`,
+    icon: AlertCircle,
+    key: "cancelled_subscriptions",
+    label: "Cancelled",
+  },
+] as const;
+
+function renderMetricValue(metricKey: (typeof metricMeta)[number]["key"], summary: DashboardSummaryStats) {
+  if (metricKey === "total_monthly_spend") {
+    return (
+      <CurrencyDisplay
+        className="text-3xl font-semibold tracking-tight sm:text-4xl"
+        value={Number.parseFloat(summary.total_monthly_spend)}
+      />
+    );
+  }
+
+  return <span className="text-3xl font-semibold tracking-tight sm:text-4xl">{summary[metricKey]}</span>;
+}
+
+export function SnapshotBar({ isLoading = false, summary }: SnapshotBarProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
+      <div className="grid md:grid-cols-2 xl:grid-cols-4">
+        {metricMeta.map(({ accentClassName, detail, icon: Icon, key, label }, index) => (
+          <div
+            className={cn(
+              "relative min-h-44 border-black/10 px-5 py-5 sm:px-6",
+              accentClassName,
+              index > 0 ? "border-t md:border-l md:border-t-0 xl:border-l" : "",
+            )}
+            key={key}
+          >
+            <div className="flex items-center justify-between">
+              <p
+                className={cn(
+                  "text-xs uppercase tracking-[0.3em]",
+                  index === 0 ? "text-white/50" : "text-black/45",
+                )}
+              >
+                {label}
+              </p>
+              <span
+                className={cn(
+                  "inline-flex size-10 items-center justify-center rounded-full border",
+                  index === 0
+                    ? "border-white/12 bg-white/10 text-white/78"
+                    : "border-black/10 bg-stone/70 text-ink",
+                )}
+              >
+                <Icon className="size-4" />
+              </span>
+            </div>
+
+            <div className="mt-7">
+              {isLoading || !summary ? (
+                <div className="space-y-3 animate-pulse">
+                  <div className={cn("h-10 w-28 rounded-full", index === 0 ? "bg-white/14" : "bg-black/8")} />
+                  <div className={cn("h-4 w-full rounded-full", index === 0 ? "bg-white/10" : "bg-black/6")} />
+                  <div className={cn("h-4 w-4/5 rounded-full", index === 0 ? "bg-white/10" : "bg-black/6")} />
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {renderMetricValue(key, summary)}
+                  <p className={cn("text-sm leading-6", index === 0 ? "text-white/68" : "text-black/62")}>
+                    {detail(summary)}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/use-dashboard.ts
+++ b/frontend/src/hooks/use-dashboard.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useAuth } from "@/hooks/use-auth";
+import { apiClient } from "@/lib/api-client";
+import type { DashboardLayoutPayload, DashboardLayoutWidget } from "@/types";
+
+const dashboardKeys = {
+  layout: ["dashboard", "layout"] as const,
+  summary: ["dashboard", "summary"] as const,
+};
+
+type DashboardLayoutCache = {
+  updated_at: string | null;
+  version: number;
+  widgets: DashboardLayoutWidget[];
+};
+
+function useRequiredToken() {
+  const { accessToken } = useAuth();
+
+  if (!accessToken) {
+    throw new Error("You must be signed in to view the dashboard.");
+  }
+
+  return accessToken;
+}
+
+export function useDashboardSummary() {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken),
+    queryFn: () => apiClient.getDashboardSummary(accessToken!),
+    queryKey: dashboardKeys.summary,
+  });
+}
+
+export function useDashboardLayout() {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken),
+    queryFn: () => apiClient.getDashboardLayout(accessToken!),
+    queryKey: dashboardKeys.layout,
+  });
+}
+
+export function useUpdateDashboardLayout() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: DashboardLayoutPayload) => apiClient.updateDashboardLayout(token, payload),
+    onMutate: async (payload) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.layout });
+      const previousLayout = queryClient.getQueryData<DashboardLayoutCache>(dashboardKeys.layout);
+
+      queryClient.setQueryData<DashboardLayoutCache>(dashboardKeys.layout, (current) => ({
+        updated_at: current?.updated_at ?? null,
+        version: current?.version ?? 1,
+        widgets: payload.widgets,
+      }));
+
+      return { previousLayout };
+    },
+    onError: (_error, _payload, context) => {
+      if (context?.previousLayout !== undefined) {
+        queryClient.setQueryData(dashboardKeys.layout, context.previousLayout);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: dashboardKeys.layout });
+    },
+  });
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2,6 +2,9 @@ import { API_BASE_URL } from "@/lib/constants";
 import type {
   AuthResponse,
   CategoryListResponse,
+  DashboardLayout,
+  DashboardLayoutPayload,
+  DashboardSummary,
   HealthResponse,
   LoginInput,
   PaymentMethodListResponse,
@@ -156,6 +159,22 @@ export const apiClient = {
   },
   getPaymentMethods(token: string) {
     return request<PaymentMethodListResponse>("/payment-methods", undefined, { token });
+  },
+  getDashboardSummary(token: string) {
+    return request<DashboardSummary>("/dashboard/summary", undefined, { token });
+  },
+  getDashboardLayout(token: string) {
+    return request<DashboardLayout>("/dashboard/layout", undefined, { token });
+  },
+  updateDashboardLayout(token: string, payload: DashboardLayoutPayload) {
+    return request<DashboardLayout>(
+      "/dashboard/layout",
+      {
+        body: JSON.stringify(payload),
+        method: "PUT",
+      },
+      { token },
+    );
   },
   getUploads(token: string) {
     return request<UploadListResponse>("/uploads", undefined, { token });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -60,6 +60,74 @@ export type PaymentMethodListResponse = {
   total: number;
 };
 
+export type DashboardSummaryStats = {
+  total_monthly_spend: string;
+  active_subscriptions: number;
+  upcoming_renewals: number;
+  cancelled_subscriptions: number;
+};
+
+export type DashboardMonthlySpendPoint = {
+  month: string;
+  label: string;
+  total: string;
+};
+
+export type DashboardCategoryBreakdownItem = {
+  category_id: number | null;
+  category_name: string;
+  subscriptions: number;
+  total_monthly_spend: string;
+};
+
+export type DashboardUpcomingRenewalItem = {
+  subscription_id: number;
+  name: string;
+  vendor: string;
+  amount: string;
+  currency: string;
+  next_charge_date: string;
+  days_until_charge: number;
+};
+
+export type DashboardRecentlyEndedItem = {
+  subscription_id: number;
+  name: string;
+  vendor: string;
+  amount: string;
+  currency: string;
+  end_date: string;
+};
+
+export type DashboardSummary = {
+  summary: DashboardSummaryStats;
+  monthly_spend: DashboardMonthlySpendPoint[];
+  category_breakdown: DashboardCategoryBreakdownItem[];
+  upcoming_renewals: DashboardUpcomingRenewalItem[];
+  recently_ended: DashboardRecentlyEndedItem[];
+};
+
+export type DashboardWidgetId =
+  | "monthly-spend"
+  | "category-breakdown"
+  | "upcoming-renewals"
+  | "recently-ended";
+export type DashboardLayoutColumn = "primary" | "secondary";
+
+export type DashboardLayoutWidget = {
+  id: DashboardWidgetId;
+  column: DashboardLayoutColumn;
+};
+
+export type DashboardLayoutPayload = {
+  widgets: DashboardLayoutWidget[];
+};
+
+export type DashboardLayout = DashboardLayoutPayload & {
+  version: number;
+  updated_at: string | null;
+};
+
 export type UploadSourceType = "upload_csv" | "upload_pdf";
 export type UploadStatus = "queued" | "processing" | "completed" | "failed";
 

--- a/frontend/tests/unit/components/snapshot-bar.test.tsx
+++ b/frontend/tests/unit/components/snapshot-bar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SnapshotBar } from "@/components/dashboard/snapshot-bar";
+
+describe("SnapshotBar", () => {
+  it("renders all four dashboard summary metrics", () => {
+    render(
+      <SnapshotBar
+        summary={{
+          active_subscriptions: 12,
+          cancelled_subscriptions: 3,
+          total_monthly_spend: "245.99",
+          upcoming_renewals: 7,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Total spend")).toBeInTheDocument();
+    expect(screen.getByText("$245.99")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText(/7 charges are due within the next 30 days/i)).toBeInTheDocument();
+  });
+
+  it("shows loading placeholders before the summary is available", () => {
+    render(<SnapshotBar isLoading />);
+
+    expect(screen.getByText("Total spend")).toBeInTheDocument();
+    expect(screen.queryByText("$245.99")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Day 10 — Complete

**Branch:** `day-10/dashboard-api-snapshot`
**Commit:** `b26dd18`
**Status:** Pushed to origin

## Summary

- Added the backend dashboard summary/layout API.
- Replaced the static dashboard with a live snapshot-first UI plus persistent widget staging.
- Added new backend and frontend tests.
- Closed GitHub issues #44, #45, and umbrella #43.
- Milestone 10 is closed.

## Checks Passed

- `lockfile-guard.sh`
- `backend/.venv/bin/pytest backend/tests`
- `backend/.venv/bin/ruff check backend/src backend/tests`
- `backend/.venv/bin/mypy backend/src`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run typecheck`

## Next

- **Remaining work (today):** None
- **Next scheduled run:** Day 11 on `day-11/dashboard-widgets`