### PR TITLE
Day 11/dashboard widgets

### DIFF
--- a/backend/src/schemas/dashboard.py
+++ b/backend/src/schemas/dashboard.py
@@ -5,6 +5,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 DASHBOARD_WIDGET_IDS = (
+    "active-subscriptions",
     "monthly-spend",
     "category-breakdown",
     "upcoming-renewals",
@@ -12,6 +13,7 @@ DASHBOARD_WIDGET_IDS = (
 )
 
 DashboardWidgetId = Literal[
+    "active-subscriptions",
     "monthly-spend",
     "category-breakdown",
     "upcoming-renewals",
@@ -31,6 +33,17 @@ class DashboardMonthlySpendPoint(BaseModel):
     month: str
     label: str
     total: Decimal
+
+
+class DashboardActiveSubscriptionItem(BaseModel):
+    subscription_id: int
+    name: str
+    vendor: str
+    amount: Decimal
+    currency: str
+    cadence: str
+    category_name: str
+    next_charge_date: date | None = None
 
 
 class DashboardCategoryBreakdownItem(BaseModel):
@@ -61,6 +74,7 @@ class DashboardRecentlyEndedItem(BaseModel):
 
 class DashboardSummaryResponse(BaseModel):
     summary: DashboardSummaryStats
+    active_subscriptions: list[DashboardActiveSubscriptionItem]
     monthly_spend: list[DashboardMonthlySpendPoint]
     category_breakdown: list[DashboardCategoryBreakdownItem]
     upcoming_renewals: list[DashboardUpcomingRenewalItem]

--- a/backend/src/services/dashboard.py
+++ b/backend/src/services/dashboard.py
@@ -11,6 +11,7 @@ from src.models.payment_history import PaymentHistory
 from src.models.subscription import Subscription
 from src.models.user import User
 from src.schemas.dashboard import (
+    DashboardActiveSubscriptionItem,
     DashboardCategoryBreakdownItem,
     DashboardLayoutResponse,
     DashboardLayoutUpdate,
@@ -30,10 +31,11 @@ MONTHLY_SPEND_MONTHS = 6
 
 DEFAULT_DASHBOARD_LAYOUT = DashboardLayoutUpdate(
     widgets=[
+        DashboardLayoutWidget(id="active-subscriptions", column="primary"),
         DashboardLayoutWidget(id="monthly-spend", column="primary"),
-        DashboardLayoutWidget(id="category-breakdown", column="primary"),
+        DashboardLayoutWidget(id="recently-ended", column="primary"),
+        DashboardLayoutWidget(id="category-breakdown", column="secondary"),
         DashboardLayoutWidget(id="upcoming-renewals", column="secondary"),
-        DashboardLayoutWidget(id="recently-ended", column="secondary"),
     ]
 )
 
@@ -215,6 +217,32 @@ async def get_dashboard_summary(
             upcoming_renewals=len(upcoming_renewals),
             cancelled_subscriptions=len(cancelled_subscriptions),
         ),
+        active_subscriptions=[
+            DashboardActiveSubscriptionItem(
+                subscription_id=subscription.id,
+                name=subscription.name,
+                vendor=subscription.vendor,
+                amount=_quantize_money(Decimal(subscription.amount)),
+                currency=subscription.currency,
+                cadence=subscription.cadence,
+                category_name=(
+                    category_map.get(subscription.category_id)
+                    if subscription.category_id is not None
+                    else "Uncategorized"
+                )
+                or "Uncategorized",
+                next_charge_date=subscription.next_charge_date,
+            )
+            for subscription in sorted(
+                active_subscriptions,
+                key=lambda subscription: (
+                    subscription.next_charge_date is None,
+                    subscription.next_charge_date or date.max,
+                    subscription.name.lower(),
+                    subscription.id,
+                ),
+            )[:6]
+        ],
         monthly_spend=monthly_spend,
         category_breakdown=[
             DashboardCategoryBreakdownItem(

--- a/backend/tests/api/test_dashboard.py
+++ b/backend/tests/api/test_dashboard.py
@@ -191,6 +191,9 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
         "upcoming_renewals": 2,
         "cancelled_subscriptions": 1,
     }
+    assert payload["active_subscriptions"][0]["name"] == "Netflix"
+    assert payload["active_subscriptions"][0]["category_name"] == "Entertainment"
+    assert payload["active_subscriptions"][1]["name"] == "Dropbox"
     assert payload["category_breakdown"][0]["category_name"] == "Entertainment"
     assert payload["category_breakdown"][0]["total_monthly_spend"] == "15.00"
     assert payload["category_breakdown"][1]["category_name"] == "Productivity"
@@ -206,10 +209,11 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
     layout_response = client.get("/api/v1/dashboard/layout", headers=owner_headers)
     assert layout_response.status_code == 200
     assert layout_response.json()["widgets"] == [
+        {"id": "active-subscriptions", "column": "primary"},
         {"id": "monthly-spend", "column": "primary"},
-        {"id": "category-breakdown", "column": "primary"},
+        {"id": "recently-ended", "column": "primary"},
+        {"id": "category-breakdown", "column": "secondary"},
         {"id": "upcoming-renewals", "column": "secondary"},
-        {"id": "recently-ended", "column": "secondary"},
     ]
 
     update_response = client.put(
@@ -217,6 +221,7 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
         headers=owner_headers,
         json={
             "widgets": [
+                {"id": "active-subscriptions", "column": "primary"},
                 {"id": "upcoming-renewals", "column": "primary"},
                 {"id": "monthly-spend", "column": "primary"},
                 {"id": "category-breakdown", "column": "secondary"},
@@ -226,18 +231,18 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
     )
     assert update_response.status_code == 200
     assert update_response.json()["version"] == 1
-    assert update_response.json()["widgets"][0]["id"] == "upcoming-renewals"
+    assert update_response.json()["widgets"][1]["id"] == "upcoming-renewals"
 
     persisted_layout_response = client.get("/api/v1/dashboard/layout", headers=owner_headers)
     assert persisted_layout_response.status_code == 200
-    assert persisted_layout_response.json()["widgets"][0] == {
+    assert persisted_layout_response.json()["widgets"][1] == {
         "id": "upcoming-renewals",
         "column": "primary",
     }
 
     other_layout_response = client.get("/api/v1/dashboard/layout", headers=other_headers)
     assert other_layout_response.status_code == 200
-    assert other_layout_response.json()["widgets"][0]["id"] == "monthly-spend"
+    assert other_layout_response.json()["widgets"][0]["id"] == "active-subscriptions"
 
 
 def test_dashboard_layout_requires_each_widget_exactly_once(client) -> None:
@@ -248,6 +253,7 @@ def test_dashboard_layout_requires_each_widget_exactly_once(client) -> None:
         headers=headers,
         json={
             "widgets": [
+                {"id": "active-subscriptions", "column": "primary"},
                 {"id": "monthly-spend", "column": "primary"},
                 {"id": "monthly-spend", "column": "secondary"},
                 {"id": "upcoming-renewals", "column": "secondary"},

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,9 @@
         "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-grid-layout": "^2.2.3",
         "react-hook-form": "^7.57.0",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^3.3.1",
         "zod": "^4.0.5"
       },
@@ -2075,6 +2077,42 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2446,6 +2484,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -2652,6 +2696,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2715,6 +2822,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4255,6 +4368,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4353,6 +4587,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -4689,6 +4929,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -5162,6 +5412,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5177,6 +5433,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5714,6 +5976,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5764,6 +6036,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6264,7 +6545,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6474,7 +6754,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6882,7 +7161,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7472,7 +7750,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -7484,7 +7761,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -7539,6 +7815,38 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.72.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
@@ -7559,9 +7867,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -7571,6 +7901,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.1.3.tgz",
+      "integrity": "sha512-liJBNayhX7qA4tBJiBD321FDhJxgGTJ07uzH5zSORXoE8h7PyEZ8mLqmosST7ppf6C4zUsbd2gzDMmBCfFp9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/read-cache": {
@@ -7596,6 +7940,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7608,6 +7982,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7663,6 +8052,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -8598,6 +8999,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9034,12 +9441,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,9 @@
     "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-grid-layout": "^2.2.3",
     "react-hook-form": "^7.57.0",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.5"
   },

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -1,252 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { startTransition, useMemo } from "react";
-import { ArrowDown, ArrowRight, ArrowUp, Columns2, LayoutTemplate, LoaderCircle } from "lucide-react";
+import { startTransition } from "react";
+import { ArrowRight, Activity, LayoutTemplate } from "lucide-react";
 
 import { SnapshotBar } from "@/components/dashboard/snapshot-bar";
+import { DashboardWidgetBoard } from "@/components/dashboard/widget-board";
 import { Button } from "@/components/ui/button";
-import { CurrencyDisplay, formatCurrency } from "@/components/ui/currency-display";
-import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 import { useDashboardLayout, useDashboardSummary, useUpdateDashboardLayout } from "@/hooks/use-dashboard";
-import { cn } from "@/lib/utils";
-import type {
-  DashboardCategoryBreakdownItem,
-  DashboardLayoutWidget,
-  DashboardRecentlyEndedItem,
-  DashboardSummary,
-  DashboardWidgetId,
-} from "@/types";
-
-const widgetMeta: Record<
-  DashboardWidgetId,
-  {
-    detail: (summary: DashboardSummary) => string;
-    eyebrow: string;
-    title: string;
-  }
-> = {
-  "category-breakdown": {
-    detail: (summary) => {
-      const leader = summary.category_breakdown[0];
-      if (!leader) {
-        return "Category mix will populate after more subscription activity lands.";
-      }
-
-      return `${leader.category_name} is currently pacing the mix at ${formatCurrency({ value: Number.parseFloat(leader.total_monthly_spend) })}.`;
-    },
-    eyebrow: "Prepared",
-    title: "Category breakdown",
-  },
-  "monthly-spend": {
-    detail: (summary) => {
-      const currentMonth = summary.monthly_spend.at(-1);
-      if (!currentMonth) {
-        return "Monthly spend history becomes available once payment history starts landing.";
-      }
-
-      return `${currentMonth.label} has ${formatCurrency({ value: Number.parseFloat(currentMonth.total) })} recorded so far.`;
-    },
-    eyebrow: "Prepared",
-    title: "Monthly spend",
-  },
-  "recently-ended": {
-    detail: (summary) => {
-      const latest = summary.recently_ended[0];
-      if (!latest) {
-        return "Recently ended subscriptions will appear once cancellations start recording end dates.";
-      }
-
-      return `${latest.name} ended most recently, closing out ${formatCurrency({ value: Number.parseFloat(latest.amount) })}.`;
-    },
-    eyebrow: "Prepared",
-    title: "Recently ended",
-  },
-  "upcoming-renewals": {
-    detail: (summary) => {
-      const next = summary.upcoming_renewals[0];
-      if (!next) {
-        return "Upcoming renewals will surface once active plans carry their next charge dates.";
-      }
-
-      return `${next.name} is next in line, due in ${next.days_until_charge} days.`;
-    },
-    eyebrow: "Prepared",
-    title: "Upcoming renewals",
-  },
-};
-
-function moveItemWithinColumn(
-  widgets: DashboardLayoutWidget[],
-  widgetId: DashboardWidgetId,
-  direction: "down" | "up",
-) {
-  const nextWidgets = [...widgets];
-  const currentIndex = nextWidgets.findIndex((widget) => widget.id === widgetId);
-
-  if (currentIndex === -1) {
-    return widgets;
-  }
-
-  const current = nextWidgets[currentIndex];
-  const columnIndexes = nextWidgets
-    .map((widget, index) => ({ index, widget }))
-    .filter(({ widget }) => widget.column === current.column)
-    .map(({ index }) => index);
-  const columnPosition = columnIndexes.indexOf(currentIndex);
-  const targetIndex =
-    direction === "up" ? columnIndexes[columnPosition - 1] : columnIndexes[columnPosition + 1];
-
-  if (targetIndex === undefined) {
-    return widgets;
-  }
-
-  [nextWidgets[currentIndex], nextWidgets[targetIndex]] = [nextWidgets[targetIndex], nextWidgets[currentIndex]];
-  return nextWidgets;
-}
-
-function toggleWidgetColumn(widgets: DashboardLayoutWidget[], widgetId: DashboardWidgetId) {
-  return widgets.map<DashboardLayoutWidget>((widget) =>
-    widget.id === widgetId
-      ? {
-          ...widget,
-          column: widget.column === "primary" ? "secondary" : "primary",
-        }
-      : widget,
-  );
-}
-
-function WidgetPlaceholder({
-  item,
-  onMoveDown,
-  onMoveUp,
-  onToggleColumn,
-  summary,
-}: {
-  item: DashboardLayoutWidget;
-  onMoveDown: () => void;
-  onMoveUp: () => void;
-  onToggleColumn: () => void;
-  summary: DashboardSummary;
-}) {
-  const meta = widgetMeta[item.id];
-
-  return (
-    <article className="group rounded-[1.8rem] border border-black/10 bg-white/82 p-5 shadow-line backdrop-blur transition duration-200 hover:-translate-y-0.5 hover:border-black/16">
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-2">
-          <p className="text-xs uppercase tracking-[0.3em] text-black/45">{meta.eyebrow}</p>
-          <h3 className="text-2xl font-semibold tracking-tight text-ink">{meta.title}</h3>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <button
-            aria-label={`Move ${meta.title} up`}
-            className="inline-flex size-9 items-center justify-center rounded-full border border-black/10 bg-stone/70 text-black/60 transition hover:border-black/18 hover:text-ink"
-            onClick={onMoveUp}
-            type="button"
-          >
-            <ArrowUp className="size-4" />
-          </button>
-          <button
-            aria-label={`Move ${meta.title} down`}
-            className="inline-flex size-9 items-center justify-center rounded-full border border-black/10 bg-stone/70 text-black/60 transition hover:border-black/18 hover:text-ink"
-            onClick={onMoveDown}
-            type="button"
-          >
-            <ArrowDown className="size-4" />
-          </button>
-          <button
-            aria-label={`Move ${meta.title} to the other column`}
-            className="inline-flex size-9 items-center justify-center rounded-full border border-black/10 bg-stone/70 text-black/60 transition hover:border-black/18 hover:text-ink"
-            onClick={onToggleColumn}
-            type="button"
-          >
-            <Columns2 className="size-4" />
-          </button>
-        </div>
-      </div>
-
-      <p className="mt-6 text-sm leading-6 text-black/62">{meta.detail(summary)}</p>
-      <div className="mt-6 flex items-center justify-between border-t border-black/10 pt-4 text-sm text-black/52">
-        <span>{item.column === "primary" ? "Primary column" : "Secondary column"}</span>
-        <span>Day 11 widget slot</span>
-      </div>
-    </article>
-  );
-}
-
-function SidebarInsight({
-  breakdown,
-  recentlyEnded,
-  upcoming,
-}: {
-  breakdown: DashboardCategoryBreakdownItem | undefined;
-  recentlyEnded: DashboardRecentlyEndedItem | undefined;
-  upcoming: DashboardSummary["upcoming_renewals"];
-}) {
-  return (
-    <section className="space-y-6 rounded-[2rem] border border-white/10 bg-[#101922] p-6 text-white shadow-[0_24px_80px_rgba(17,20,24,0.22)] sm:p-8">
-      <div className="space-y-2 border-b border-white/10 pb-5">
-        <p className="text-xs uppercase tracking-[0.32em] text-white/45">Renewal focus</p>
-        <h3 className="text-2xl font-semibold tracking-tight">What needs attention next</h3>
-        <p className="text-sm leading-6 text-white/62">
-          Day 10 keeps the dashboard operational with live KPIs now, then leaves the richer widgets ready for Day 11.
-        </p>
-      </div>
-
-      <div className="space-y-4">
-        {upcoming.length === 0 ? (
-          <p className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4 text-sm leading-6 text-white/62">
-            No upcoming renewals are queued yet. As active subscriptions gain charge dates, this rail will start sorting urgency automatically.
-          </p>
-        ) : (
-          upcoming.slice(0, 3).map((item) => (
-            <div className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4" key={item.subscription_id}>
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="font-semibold">{item.name}</p>
-                  <p className="mt-1 text-sm text-white/62">
-                    {item.vendor} · due in {item.days_until_charge} days
-                  </p>
-                </div>
-                <CurrencyDisplay
-                  className="text-lg font-semibold text-amber-200"
-                  value={Number.parseFloat(item.amount)}
-                />
-              </div>
-            </div>
-          ))
-        )}
-      </div>
-
-      <div className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4">
-        <p className="text-xs uppercase tracking-[0.28em] text-white/42">Category lead</p>
-        <p className="mt-3 text-lg font-semibold">
-          {breakdown?.category_name ?? "Waiting for category mix"}
-        </p>
-        <p className="mt-2 text-sm leading-6 text-white/62">
-          {breakdown
-            ? `${breakdown.subscriptions} subscriptions currently map here at ${formatCurrency({ value: Number.parseFloat(breakdown.total_monthly_spend) })} in monthly-equivalent spend.`
-            : "Once active subscriptions are categorized, this lane will call out the heaviest spend cluster."}
-        </p>
-      </div>
-
-      <div className="rounded-[1.4rem] border border-white/10 bg-white/6 p-4">
-        <p className="text-xs uppercase tracking-[0.28em] text-white/42">Recently ended</p>
-        <p className="mt-3 text-lg font-semibold">
-          {recentlyEnded?.name ?? "No recent cancellations"}
-        </p>
-        <p className="mt-2 text-sm leading-6 text-white/62">
-          {recentlyEnded
-            ? `${recentlyEnded.vendor} most recently closed at ${formatCurrency({ value: Number.parseFloat(recentlyEnded.amount) })}.`
-            : "As plans are cancelled with end dates, this lane will preserve the recent context for review."}
-        </p>
-      </div>
-    </section>
-  );
-}
+import type { DashboardLayoutWidget } from "@/types";
 
 export default function DashboardPage() {
   const summaryQuery = useDashboardSummary();
@@ -255,13 +18,6 @@ export default function DashboardPage() {
 
   const summary = summaryQuery.data;
   const widgets = layoutQuery.data?.widgets;
-  const groupedWidgets = useMemo(
-    () => ({
-      primary: (widgets ?? []).filter((widget) => widget.column === "primary"),
-      secondary: (widgets ?? []).filter((widget) => widget.column === "secondary"),
-    }),
-    [widgets],
-  );
 
   const applyLayout = (nextWidgets: DashboardLayoutWidget[]) => {
     startTransition(() => {
@@ -280,73 +36,77 @@ export default function DashboardPage() {
             </Link>
           </Button>
         }
-        description="Track recurring spend, keep renewals in view, and stage the widget system with a persistent dashboard layout before the richer analytics surface lands."
-        eyebrow="Day 10 live surface"
-        title="Smart dashboard snapshot"
+        description="Operate from a live dashboard where five persistent widgets keep spend, renewals, category mix, and subscription churn in one working surface."
+        eyebrow="Day 11 widget system"
+        title="Smart dashboard workspace"
       />
 
       <SnapshotBar isLoading={summaryQuery.isLoading} summary={summary?.summary} />
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.85fr)]">
-        <section className="rounded-[2rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur sm:p-6">
-          <div className="flex flex-col gap-4 border-b border-black/10 pb-5 lg:flex-row lg:items-end lg:justify-between">
-            <div className="space-y-2">
-              <p className="text-xs uppercase tracking-[0.32em] text-black/45">Widget staging</p>
-              <h2 className="text-2xl font-semibold tracking-tight text-ink">Layout now, widgets next</h2>
-              <p className="max-w-2xl text-sm leading-6 text-black/62">
-                The layout is already persistent, so Day 11 can drop real widgets into stable slots without rebuilding the page frame.
-              </p>
-            </div>
-            <div className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-stone/70 px-4 py-2 text-sm text-black/58">
-              <LayoutTemplate className="size-4" />
-              {layoutQuery.data ? `Version ${layoutQuery.data.version}` : "Loading layout"}
-            </div>
-          </div>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.24fr)_320px]">
+        <DashboardWidgetBoard
+          isLoading={summaryQuery.isLoading || layoutQuery.isLoading}
+          isSaving={updateLayout.isPending}
+          onChange={applyLayout}
+          summary={summary}
+          version={layoutQuery.data?.version}
+          widgets={widgets}
+        />
 
-          {summaryQuery.isLoading || layoutQuery.isLoading ? (
-            <div className="flex min-h-[22rem] items-center justify-center">
-              <div className="flex items-center gap-3 text-sm text-black/58">
-                <LoaderCircle className="size-4 animate-spin" />
-                Loading dashboard workspace...
+        <aside className="space-y-5">
+          <section className="rounded-[2rem] border border-white/10 bg-[#101922] p-6 text-white shadow-[0_24px_80px_rgba(17,20,24,0.22)] sm:p-7">
+            <p className="text-xs uppercase tracking-[0.32em] text-white/45">Control lane</p>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight">Keep the board operational</h2>
+            <p className="mt-3 text-sm leading-6 text-white/65">
+              Use the snapshot bar for totals, then let the widget board answer the next question: what is active, what is growing, what is due, and what just ended.
+            </p>
+
+            <div className="mt-5 space-y-3">
+              <div className="rounded-[1.35rem] border border-white/10 bg-white/6 p-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-white/42">Layout persistence</p>
+                <p className="mt-2 text-sm leading-6 text-white/68">
+                  Moves save back to your dashboard layout so the same instrument panel returns on the next visit.
+                </p>
+              </div>
+              <div className="rounded-[1.35rem] border border-white/10 bg-white/6 p-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-white/42">Data freshness</p>
+                <p className="mt-2 text-sm leading-6 text-white/68">
+                  Upload history feeds the spend curve, while subscription records keep category, renewal, and churn widgets grounded.
+                </p>
               </div>
             </div>
-          ) : !summary || !widgets || widgets.length === 0 ? (
-            <EmptyState
-              action={
-                <Button asChild className="rounded-full px-5" variant="outline">
-                  <Link href="/uploads">Bring in statement data</Link>
-                </Button>
-              }
-              description="Dashboard analytics will populate as subscriptions, payment history, and renewal dates accumulate in the workspace."
-              eyebrow="No dashboard data"
-              icon={<LayoutTemplate className="size-5" />}
-              title="Nothing to stage yet."
-            />
-          ) : (
-            <div className="mt-6 grid gap-4 xl:grid-cols-[1.08fr_0.92fr]">
-              {(["primary", "secondary"] as const).map((column) => (
-                <div className={cn("space-y-4", column === "secondary" ? "xl:pt-10" : "")} key={column}>
-                  {groupedWidgets[column].map((item) => (
-                    <WidgetPlaceholder
-                      item={item}
-                      key={item.id}
-                      onMoveDown={() => applyLayout(moveItemWithinColumn(widgets, item.id, "down"))}
-                      onMoveUp={() => applyLayout(moveItemWithinColumn(widgets, item.id, "up"))}
-                      onToggleColumn={() => applyLayout(toggleWidgetColumn(widgets, item.id))}
-                      summary={summary}
-                    />
-                  ))}
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
+          </section>
 
-        <SidebarInsight
-          breakdown={summary?.category_breakdown[0]}
-          recentlyEnded={summary?.recently_ended[0]}
-          upcoming={summary?.upcoming_renewals ?? []}
-        />
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+            <div className="inline-flex size-12 items-center justify-center rounded-[1.1rem] border border-black/10 bg-stone text-ink">
+              <Activity className="size-5" />
+            </div>
+            <h3 className="mt-4 text-2xl font-semibold tracking-tight text-ink">Keep the signal moving</h3>
+            <p className="mt-3 text-sm leading-6 text-black/62">
+              If one lane is empty, the fastest way to improve this board is usually adding or refreshing source data rather than rearranging the layout again.
+            </p>
+
+            <div className="mt-5 space-y-3">
+              <Button asChild className="w-full rounded-full" variant="outline">
+                <Link href="/uploads">
+                  Open uploads
+                  <ArrowRight className="ml-2 size-4" />
+                </Link>
+              </Button>
+              <Button asChild className="w-full rounded-full" variant="ghost">
+                <Link href="/subscriptions">
+                  Review subscriptions
+                  <ArrowRight className="ml-2 size-4" />
+                </Link>
+              </Button>
+            </div>
+
+            <div className="mt-5 inline-flex items-center gap-2 rounded-full border border-black/10 bg-stone/70 px-4 py-2 text-sm text-black/58">
+              <LayoutTemplate className="size-4" />
+              {layoutQuery.data ? `Layout v${layoutQuery.data.version}` : "Widget board"}
+            </div>
+          </section>
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -66,3 +66,25 @@ body {
   animation: page-enter 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
   animation-delay: 0.08s;
 }
+
+.dashboard-grid-layout {
+  min-height: 20rem;
+}
+
+.dashboard-grid-layout > .react-grid-item {
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.dashboard-grid-layout > .react-grid-item.react-draggable-dragging {
+  z-index: 20;
+}
+
+.dashboard-grid-layout > .react-grid-item.react-grid-placeholder {
+  border-radius: 1.8rem;
+  background: rgba(220, 93, 48, 0.14);
+  border: 1px dashed rgba(220, 93, 48, 0.28);
+}
+
+.dashboard-grid-layout--compact > .react-grid-item {
+  width: 100% !important;
+}

--- a/frontend/src/components/dashboard/widget-board.tsx
+++ b/frontend/src/components/dashboard/widget-board.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import GridLayout, { WidthProvider, type Layout, type LayoutItem } from "react-grid-layout/legacy";
+import { LayoutTemplate, LoaderCircle } from "lucide-react";
+
+import { DashboardWidgetCard, DashboardBoardFootnote, dashboardWidgetMeta } from "@/components/dashboard/widget-library";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { cn } from "@/lib/utils";
+import type { DashboardLayoutWidget, DashboardSummary, DashboardWidgetId } from "@/types";
+
+const DashboardGridLayout = WidthProvider(GridLayout);
+const COMPACT_QUERY = "(max-width: 1023px)";
+
+type DashboardWidgetBoardProps = {
+  isLoading?: boolean;
+  isSaving?: boolean;
+  onChange: (widgets: DashboardLayoutWidget[]) => void;
+  summary?: DashboardSummary;
+  version?: number;
+  widgets?: DashboardLayoutWidget[];
+};
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const handleChange = () => {
+      setMatches(mediaQuery.matches);
+    };
+
+    handleChange();
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, [query]);
+
+  return matches;
+}
+
+function serializeWidgets(widgets: DashboardLayoutWidget[]) {
+  return widgets.map((widget) => `${widget.id}:${widget.column}`).join("|");
+}
+
+function buildGridLayout(widgets: DashboardLayoutWidget[], isCompact: boolean) {
+  const columnY = {
+    primary: 0,
+    secondary: 0,
+  };
+
+  return widgets.map<LayoutItem>((widget, index) => {
+    if (isCompact) {
+      return {
+        h: Math.max(3, dashboardWidgetMeta[widget.id].desktopHeight - 1),
+        i: widget.id,
+        isResizable: false,
+        minH: 3,
+        minW: 1,
+        w: 1,
+        x: 0,
+        y: index * 3,
+      };
+    }
+
+    const column = widget.column;
+    const y = columnY[column];
+    columnY[column] += dashboardWidgetMeta[widget.id].desktopHeight;
+
+    return {
+      h: dashboardWidgetMeta[widget.id].desktopHeight,
+      i: widget.id,
+      isResizable: false,
+      minH: 3,
+      minW: 6,
+      w: 6,
+      x: column === "primary" ? 0 : 6,
+      y,
+    };
+  }) as Layout;
+}
+
+function normalizeWidgets(layout: Layout): DashboardLayoutWidget[] {
+  return [...layout]
+    .sort((left, right) => {
+      const leftColumn = left.x >= 6 ? 1 : 0;
+      const rightColumn = right.x >= 6 ? 1 : 0;
+
+      if (leftColumn !== rightColumn) {
+        return leftColumn - rightColumn;
+      }
+
+      if (left.y !== right.y) {
+        return left.y - right.y;
+      }
+
+      return left.x - right.x;
+    })
+    .map((item) => ({
+      column: item.x >= 6 ? "secondary" : "primary",
+      id: item.i as DashboardWidgetId,
+    }));
+}
+
+function toggleWidgetColumn(widgets: DashboardLayoutWidget[], widgetId: DashboardWidgetId) {
+  return widgets.map<DashboardLayoutWidget>((widget) =>
+    widget.id === widgetId
+      ? {
+          ...widget,
+          column: widget.column === "primary" ? "secondary" : "primary",
+        }
+      : widget,
+  );
+}
+
+export function DashboardWidgetBoard({
+  isLoading = false,
+  isSaving = false,
+  onChange,
+  summary,
+  version,
+  widgets,
+}: DashboardWidgetBoardProps) {
+  const isCompact = useMediaQuery(COMPACT_QUERY);
+  const layout = useMemo(
+    () => buildGridLayout(widgets ?? [], isCompact),
+    [isCompact, widgets],
+  );
+  const serializedWidgets = serializeWidgets(widgets ?? []);
+
+  const handleLayoutStop = (nextLayout: Layout) => {
+    if (isCompact || !widgets?.length) {
+      return;
+    }
+
+    const normalized = normalizeWidgets(nextLayout);
+    if (serializeWidgets(normalized) === serializedWidgets) {
+      return;
+    }
+
+    onChange(normalized);
+  };
+
+  return (
+    <section className="rounded-[2rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur sm:p-6">
+      <div className="flex flex-col gap-4 border-b border-black/10 pb-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.32em] text-black/45">Widget workspace</p>
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Drag the dashboard into focus</h2>
+          <p className="max-w-2xl text-sm leading-6 text-black/62">
+            The board holds five live widgets, each tuned for a specific operating question instead of a generic dashboard card.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-stone/70 px-4 py-2 text-sm text-black/58">
+            <LayoutTemplate className="size-4" />
+            {isSaving ? "Saving layout..." : version ? `Version ${version}` : "Live layout"}
+          </div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/72 px-4 py-2 text-sm text-black/58">
+            Drag by the grip. Use the lane toggle for keyboard-friendly moves.
+          </div>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex min-h-[28rem] items-center justify-center">
+          <div className="flex items-center gap-3 text-sm text-black/58">
+            <LoaderCircle className="size-4 animate-spin" />
+            Loading dashboard workspace...
+          </div>
+        </div>
+      ) : !summary || !widgets || widgets.length === 0 ? (
+        <div className="mt-6">
+          <EmptyState
+            action={
+              <Button asChild className="rounded-full px-5" variant="outline">
+                <Link href="/uploads">Bring in statement data</Link>
+              </Button>
+            }
+            description="Dashboard widgets need subscriptions, payment history, and renewal dates before they can become useful."
+            eyebrow="No dashboard data"
+            icon={<LayoutTemplate className="size-5" />}
+            title="Nothing to arrange yet."
+          />
+        </div>
+      ) : (
+        <div className="mt-6 space-y-6">
+          <DashboardGridLayout
+            className={cn("dashboard-grid-layout", isCompact ? "dashboard-grid-layout--compact" : "")}
+            cols={isCompact ? 1 : 12}
+            compactType="vertical"
+            containerPadding={[0, 0]}
+            draggableHandle=".dashboard-grid-handle"
+            isDraggable={!isCompact && !isSaving}
+            isResizable={false}
+            layout={layout}
+            margin={[16, 16]}
+            onDragStop={handleLayoutStop}
+            rowHeight={92}
+            useCSSTransforms
+          >
+            {widgets.map((widget) => (
+              <div key={widget.id}>
+                <DashboardWidgetCard
+                  onToggleColumn={
+                    isCompact ? undefined : () => onChange(toggleWidgetColumn(widgets, widget.id))
+                  }
+                  summary={summary}
+                  widgetId={widget.id}
+                />
+              </div>
+            ))}
+          </DashboardGridLayout>
+
+          <DashboardBoardFootnote summary={summary} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/widget-container.tsx
+++ b/frontend/src/components/dashboard/widget-container.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { GripVertical, MoveHorizontal } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type WidgetContainerProps = {
+  children: ReactNode;
+  className?: string;
+  description: string;
+  eyebrow: string;
+  onToggleColumn?: () => void;
+  title: string;
+};
+
+export function WidgetContainer({
+  children,
+  className,
+  description,
+  eyebrow,
+  onToggleColumn,
+  title,
+}: WidgetContainerProps) {
+  return (
+    <article
+      className={cn(
+        "flex h-full flex-col overflow-hidden rounded-[1.8rem] border border-black/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(246,241,232,0.76))] p-5 shadow-line backdrop-blur transition duration-200 hover:-translate-y-0.5 hover:border-black/18",
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between gap-4 border-b border-black/10 pb-4">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-black/45">{eyebrow}</p>
+          <div className="space-y-1">
+            <h3 className="text-2xl font-semibold tracking-tight text-ink">{title}</h3>
+            <p className="max-w-xl text-sm leading-6 text-black/62">{description}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {onToggleColumn ? (
+            <button
+              aria-label={`Move ${title} to the other column`}
+              className="inline-flex size-10 items-center justify-center rounded-full border border-black/10 bg-white/72 text-black/60 transition hover:border-black/18 hover:text-ink"
+              onClick={onToggleColumn}
+              type="button"
+            >
+              <MoveHorizontal className="size-4" />
+            </button>
+          ) : null}
+          <button
+            aria-label={`Drag ${title} widget`}
+            className="dashboard-grid-handle inline-flex size-10 cursor-grab items-center justify-center rounded-full border border-black/10 bg-[#101922] text-white/76 transition hover:bg-[#111a24] active:cursor-grabbing"
+            type="button"
+          >
+            <GripVertical className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 pt-5">{children}</div>
+    </article>
+  );
+}

--- a/frontend/src/components/dashboard/widget-library.tsx
+++ b/frontend/src/components/dashboard/widget-library.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import {
+  Activity,
+  ArrowUpRight,
+  CalendarClock,
+  Donut,
+  FolderClock,
+  Layers3,
+} from "lucide-react";
+import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis } from "recharts";
+
+import { Button } from "@/components/ui/button";
+import { CurrencyDisplay, formatCurrency } from "@/components/ui/currency-display";
+import { cn } from "@/lib/utils";
+import type { DashboardSummary, DashboardWidgetId } from "@/types";
+
+import { WidgetContainer } from "./widget-container";
+
+type WidgetMeta = {
+  description: string;
+  desktopHeight: number;
+  emptyText: string;
+  eyebrow: string;
+  title: string;
+};
+
+const CATEGORY_COLORS = ["#111418", "#dc5d30", "#d9895d", "#95a6ba", "#cdb28f"];
+
+export const dashboardWidgetMeta: Record<DashboardWidgetId, WidgetMeta> = {
+  "active-subscriptions": {
+    description: "Live roster of the subscriptions currently shaping monthly spend.",
+    desktopHeight: 4,
+    emptyText: "Add subscriptions or import statement data to populate the active roster.",
+    eyebrow: "Live roster",
+    title: "Active subscriptions",
+  },
+  "category-breakdown": {
+    description: "Where recurring spend is clustering right now across categories.",
+    desktopHeight: 4,
+    emptyText: "Categorize active subscriptions to unlock the category breakdown.",
+    eyebrow: "Spend mix",
+    title: "Category breakdown",
+  },
+  "monthly-spend": {
+    description: "Six months of payment history, shaped into a single spend curve.",
+    desktopHeight: 4,
+    emptyText: "Upload statement history to start plotting monthly spend.",
+    eyebrow: "Trend line",
+    title: "Monthly spend",
+  },
+  "recently-ended": {
+    description: "Recent cancellations with enough context to review what changed.",
+    desktopHeight: 3,
+    emptyText: "Cancelled subscriptions with end dates will show up here.",
+    eyebrow: "Closed recently",
+    title: "Recently ended",
+  },
+  "upcoming-renewals": {
+    description: "Charges due soon, ordered by urgency so the next move is obvious.",
+    desktopHeight: 4,
+    emptyText: "Upcoming renewal dates will appear once active plans have charge schedules.",
+    eyebrow: "Next up",
+    title: "Upcoming renewals",
+  },
+};
+
+type DashboardWidgetCardProps = {
+  onToggleColumn?: () => void;
+  summary: DashboardSummary;
+  widgetId: DashboardWidgetId;
+};
+
+type WidgetEmptyStateProps = {
+  ctaHref: string;
+  ctaLabel: string;
+  icon: ReactNode;
+  text: string;
+};
+
+function formatCompactCurrency(value: string, currency = "USD") {
+  return formatCurrency({
+    compact: true,
+    currency,
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 0,
+    value: Number.parseFloat(value),
+  });
+}
+
+function formatDisplayDate(value: string | null) {
+  if (!value) {
+    return "Schedule pending";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+  }).format(new Date(`${value}T00:00:00`));
+}
+
+function WidgetEmptyState({ ctaHref, ctaLabel, icon, text }: WidgetEmptyStateProps) {
+  return (
+    <div className="flex h-full min-h-48 flex-col items-start justify-between rounded-[1.4rem] border border-dashed border-black/12 bg-white/54 p-5">
+      <div className="space-y-3">
+        <div className="inline-flex size-12 items-center justify-center rounded-[1.1rem] border border-black/10 bg-stone text-ink">
+          {icon}
+        </div>
+        <p className="max-w-sm text-sm leading-6 text-black/62">{text}</p>
+      </div>
+
+      <Button asChild className="mt-5 rounded-full px-4" size="sm" variant="outline">
+        <Link href={ctaHref}>{ctaLabel}</Link>
+      </Button>
+    </div>
+  );
+}
+
+function ChartTooltip({
+  active,
+  label,
+  payload,
+}: {
+  active?: boolean;
+  label?: string;
+  payload?: Array<{ payload?: { total?: number } }>;
+}) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-[1.2rem] border border-black/10 bg-white/94 px-4 py-3 shadow-line">
+      <p className="text-xs uppercase tracking-[0.28em] text-black/42">{label}</p>
+      <p className="mt-2 text-sm font-semibold text-ink">
+        {formatCurrency({ value: payload[0]?.payload?.total ?? 0 })}
+      </p>
+    </div>
+  );
+}
+
+function ActiveSubscriptionsWidget({ summary }: { summary: DashboardSummary }) {
+  const items = summary.active_subscriptions.slice(0, 4);
+
+  if (items.length === 0) {
+    return (
+      <WidgetEmptyState
+        ctaHref="/subscriptions"
+        ctaLabel="Add a subscription"
+        icon={<Layers3 className="size-5" />}
+        text={dashboardWidgetMeta["active-subscriptions"].emptyText}
+      />
+    );
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(210px,0.82fr)_minmax(0,1.18fr)]">
+      <div className="rounded-[1.5rem] bg-[#101922] p-5 text-white shadow-[0_18px_60px_rgba(17,20,24,0.22)]">
+        <p className="text-xs uppercase tracking-[0.28em] text-white/45">Live now</p>
+        <p className="mt-4 text-5xl font-semibold tracking-tight">{summary.summary.active_subscriptions}</p>
+        <p className="mt-3 text-sm leading-6 text-white/65">
+          {formatCurrency({
+            value: Number.parseFloat(summary.summary.total_monthly_spend),
+          })}{" "}
+          in monthly-equivalent spend is currently active.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {items.map((item) => (
+          <div
+            className="flex items-center justify-between gap-4 rounded-[1.35rem] border border-black/10 bg-white/68 px-4 py-3"
+            key={item.subscription_id}
+          >
+            <div className="min-w-0">
+              <p className="truncate text-base font-semibold text-ink">{item.name}</p>
+              <p className="mt-1 truncate text-sm text-black/58">
+                {item.vendor} · {item.category_name} · {item.cadence}
+              </p>
+            </div>
+
+            <div className="text-right">
+              <CurrencyDisplay
+                className="text-base font-semibold text-ink"
+                currency={item.currency}
+                value={Number.parseFloat(item.amount)}
+              />
+              <p className="mt-1 text-xs uppercase tracking-[0.24em] text-black/42">
+                {formatDisplayDate(item.next_charge_date)}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MonthlySpendWidget({ summary }: { summary: DashboardSummary }) {
+  const chartData = summary.monthly_spend.map((point) => ({
+    label: point.label,
+    month: point.month,
+    total: Number.parseFloat(point.total),
+  }));
+  const hasData = chartData.some((point) => point.total > 0);
+
+  if (!hasData) {
+    return (
+      <WidgetEmptyState
+        ctaHref="/uploads"
+        ctaLabel="Import statements"
+        icon={<Activity className="size-5" />}
+        text={dashboardWidgetMeta["monthly-spend"].emptyText}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.28em] text-black/45">Latest recorded month</p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-ink">
+            {formatCurrency({ value: chartData.at(-1)?.total ?? 0 })}
+          </p>
+        </div>
+        <p className="max-w-xs text-sm leading-6 text-black/58">
+          The bar chart reads the last six months of payment history and surfaces actual paid totals.
+        </p>
+      </div>
+
+      <div className="h-60 rounded-[1.5rem] bg-white/58 px-3 py-4">
+        <ResponsiveContainer height="100%" width="100%">
+          <BarChart accessibilityLayer data={chartData} margin={{ bottom: 0, left: -12, right: 8, top: 6 }}>
+            <CartesianGrid stroke="rgba(17,20,24,0.08)" strokeDasharray="4 8" vertical={false} />
+            <XAxis
+              axisLine={false}
+              dataKey="label"
+              tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
+              tickLine={false}
+            />
+            <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(220, 93, 48, 0.08)" }} />
+            <Bar dataKey="total" fill="#dc5d30" radius={[12, 12, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+function CategoryBreakdownWidget({ summary }: { summary: DashboardSummary }) {
+  const chartData = summary.category_breakdown.slice(0, 5).map((item) => ({
+    label: item.category_name,
+    subscriptions: item.subscriptions,
+    total: Number.parseFloat(item.total_monthly_spend),
+  }));
+
+  if (chartData.length === 0) {
+    return (
+      <WidgetEmptyState
+        ctaHref="/subscriptions"
+        ctaLabel="Review subscriptions"
+        icon={<Donut className="size-5" />}
+        text={dashboardWidgetMeta["category-breakdown"].emptyText}
+      />
+    );
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(190px,0.82fr)_minmax(0,1.18fr)]">
+      <div className="flex h-56 items-center justify-center rounded-[1.5rem] bg-white/58 p-4">
+        <ResponsiveContainer height="100%" width="100%">
+          <PieChart>
+            <Pie
+              cx="50%"
+              cy="50%"
+              data={chartData}
+              dataKey="total"
+              innerRadius={54}
+              outerRadius={82}
+              paddingAngle={3}
+            >
+              {chartData.map((item, index) => (
+                <Cell fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]} key={item.label} />
+              ))}
+            </Pie>
+            <Tooltip content={<ChartTooltip />} />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="space-y-3">
+        {chartData.map((item, index) => (
+          <div
+            className="flex items-center justify-between gap-4 rounded-[1.35rem] border border-black/10 bg-white/68 px-4 py-3"
+            key={item.label}
+          >
+            <div className="flex min-w-0 items-center gap-3">
+              <span
+                aria-hidden="true"
+                className="size-3 rounded-full"
+                style={{ backgroundColor: CATEGORY_COLORS[index % CATEGORY_COLORS.length] }}
+              />
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold text-ink">{item.label}</p>
+                <p className="text-sm text-black/58">{item.subscriptions} subscriptions</p>
+              </div>
+            </div>
+
+            <p className="text-sm font-semibold text-ink">{formatCompactCurrency(String(item.total))}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function UpcomingRenewalsWidget({ summary }: { summary: DashboardSummary }) {
+  const items = summary.upcoming_renewals.slice(0, 4);
+
+  if (items.length === 0) {
+    return (
+      <WidgetEmptyState
+        ctaHref="/subscriptions"
+        ctaLabel="Review renewal dates"
+        icon={<CalendarClock className="size-5" />}
+        text={dashboardWidgetMeta["upcoming-renewals"].emptyText}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((item) => {
+        const isUrgent = item.days_until_charge <= 7;
+
+        return (
+          <div
+            className="rounded-[1.35rem] border border-black/10 bg-white/68 px-4 py-4"
+            key={item.subscription_id}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="truncate text-base font-semibold text-ink">{item.name}</p>
+                <p className="mt-1 text-sm text-black/58">
+                  {item.vendor} · {formatDisplayDate(item.next_charge_date)}
+                </p>
+              </div>
+              <div className="text-right">
+                <CurrencyDisplay
+                  className="text-base font-semibold text-ink"
+                  currency={item.currency}
+                  value={Number.parseFloat(item.amount)}
+                />
+                <p
+                  className={cn(
+                    "mt-1 text-xs uppercase tracking-[0.24em]",
+                    isUrgent ? "text-ember" : "text-black/42",
+                  )}
+                >
+                  {item.days_until_charge} days
+                </p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RecentlyEndedWidget({ summary }: { summary: DashboardSummary }) {
+  const items = summary.recently_ended.slice(0, 4);
+
+  if (items.length === 0) {
+    return (
+      <WidgetEmptyState
+        ctaHref="/subscriptions"
+        ctaLabel="Inspect subscriptions"
+        icon={<FolderClock className="size-5" />}
+        text={dashboardWidgetMeta["recently-ended"].emptyText}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((item) => (
+        <div
+          className="flex items-center justify-between gap-4 rounded-[1.35rem] border border-black/10 bg-white/68 px-4 py-4"
+          key={item.subscription_id}
+        >
+          <div className="min-w-0">
+            <p className="truncate text-base font-semibold text-ink">{item.name}</p>
+            <p className="mt-1 text-sm text-black/58">
+              {item.vendor} · ended {formatDisplayDate(item.end_date)}
+            </p>
+          </div>
+
+          <div className="text-right">
+            <CurrencyDisplay
+              className="text-base font-semibold text-ink"
+              currency={item.currency}
+              value={Number.parseFloat(item.amount)}
+            />
+            <p className="mt-1 text-xs uppercase tracking-[0.24em] text-black/42">Closed out</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function renderWidgetBody(widgetId: DashboardWidgetId, summary: DashboardSummary) {
+  switch (widgetId) {
+    case "active-subscriptions":
+      return <ActiveSubscriptionsWidget summary={summary} />;
+    case "monthly-spend":
+      return <MonthlySpendWidget summary={summary} />;
+    case "category-breakdown":
+      return <CategoryBreakdownWidget summary={summary} />;
+    case "upcoming-renewals":
+      return <UpcomingRenewalsWidget summary={summary} />;
+    case "recently-ended":
+      return <RecentlyEndedWidget summary={summary} />;
+    default:
+      return null;
+  }
+}
+
+export function DashboardWidgetCard({ onToggleColumn, summary, widgetId }: DashboardWidgetCardProps) {
+  const meta = dashboardWidgetMeta[widgetId];
+
+  return (
+    <WidgetContainer
+      description={meta.description}
+      eyebrow={meta.eyebrow}
+      onToggleColumn={onToggleColumn}
+      title={meta.title}
+    >
+      {renderWidgetBody(widgetId, summary)}
+    </WidgetContainer>
+  );
+}
+
+export function DashboardBoardFootnote({ summary }: { summary: DashboardSummary }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="rounded-[1.6rem] border border-black/10 bg-white/72 p-5 shadow-line backdrop-blur">
+        <p className="text-xs uppercase tracking-[0.3em] text-black/45">Why this board works</p>
+        <p className="mt-3 text-sm leading-6 text-black/62">
+          Dragging changes the persisted widget order, while the summary strip keeps the top-line numbers fixed for quick scanning.
+        </p>
+      </div>
+      <div className="rounded-[1.6rem] border border-black/10 bg-[#101922] p-5 text-white shadow-[0_20px_70px_rgba(17,20,24,0.22)]">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-white/45">Live spend signal</p>
+            <p className="mt-2 text-2xl font-semibold tracking-tight">
+              {formatCurrency({ value: Number.parseFloat(summary.summary.total_monthly_spend) })}
+            </p>
+          </div>
+          <ArrowUpRight className="size-5 text-white/55" />
+        </div>
+        <p className="mt-3 text-sm leading-6 text-white/65">
+          {summary.summary.upcoming_renewals} renewal{summary.summary.upcoming_renewals === 1 ? "" : "s"} are due soon, so the widget grid stays grounded in action instead of just reporting totals.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,6 +73,17 @@ export type DashboardMonthlySpendPoint = {
   total: string;
 };
 
+export type DashboardActiveSubscriptionItem = {
+  subscription_id: number;
+  name: string;
+  vendor: string;
+  amount: string;
+  currency: string;
+  cadence: string;
+  category_name: string;
+  next_charge_date: string | null;
+};
+
 export type DashboardCategoryBreakdownItem = {
   category_id: number | null;
   category_name: string;
@@ -101,6 +112,7 @@ export type DashboardRecentlyEndedItem = {
 
 export type DashboardSummary = {
   summary: DashboardSummaryStats;
+  active_subscriptions: DashboardActiveSubscriptionItem[];
   monthly_spend: DashboardMonthlySpendPoint[];
   category_breakdown: DashboardCategoryBreakdownItem[];
   upcoming_renewals: DashboardUpcomingRenewalItem[];
@@ -108,6 +120,7 @@ export type DashboardSummary = {
 };
 
 export type DashboardWidgetId =
+  | "active-subscriptions"
   | "monthly-spend"
   | "category-breakdown"
   | "upcoming-renewals"

--- a/frontend/tests/unit/components/dashboard-widgets.test.tsx
+++ b/frontend/tests/unit/components/dashboard-widgets.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DashboardWidgetCard } from "@/components/dashboard/widget-library";
+import type { DashboardSummary, DashboardWidgetId } from "@/types";
+
+const fullSummary: DashboardSummary = {
+  active_subscriptions: [
+    {
+      amount: "15.99",
+      cadence: "monthly",
+      category_name: "Entertainment",
+      currency: "USD",
+      name: "Netflix",
+      next_charge_date: "2026-04-15",
+      subscription_id: 1,
+      vendor: "Netflix",
+    },
+    {
+      amount: "9.99",
+      cadence: "monthly",
+      category_name: "Productivity",
+      currency: "USD",
+      name: "Dropbox",
+      next_charge_date: "2026-04-21",
+      subscription_id: 2,
+      vendor: "Dropbox",
+    },
+  ],
+  category_breakdown: [
+    {
+      category_id: 10,
+      category_name: "Entertainment",
+      subscriptions: 2,
+      total_monthly_spend: "25.98",
+    },
+    {
+      category_id: 11,
+      category_name: "Productivity",
+      subscriptions: 1,
+      total_monthly_spend: "9.99",
+    },
+  ],
+  monthly_spend: [
+    { label: "Jan", month: "2026-01", total: "0.00" },
+    { label: "Feb", month: "2026-02", total: "0.00" },
+    { label: "Mar", month: "2026-03", total: "59.98" },
+    { label: "Apr", month: "2026-04", total: "86.50" },
+  ],
+  recently_ended: [
+    {
+      amount: "12.99",
+      currency: "USD",
+      end_date: "2026-04-05",
+      name: "Headspace",
+      subscription_id: 3,
+      vendor: "Headspace",
+    },
+  ],
+  summary: {
+    active_subscriptions: 2,
+    cancelled_subscriptions: 1,
+    total_monthly_spend: "35.97",
+    upcoming_renewals: 2,
+  },
+  upcoming_renewals: [
+    {
+      amount: "15.99",
+      currency: "USD",
+      days_until_charge: 3,
+      name: "Netflix",
+      next_charge_date: "2026-04-15",
+      subscription_id: 1,
+      vendor: "Netflix",
+    },
+    {
+      amount: "9.99",
+      currency: "USD",
+      days_until_charge: 9,
+      name: "Dropbox",
+      next_charge_date: "2026-04-21",
+      subscription_id: 2,
+      vendor: "Dropbox",
+    },
+  ],
+};
+
+const emptySummary: DashboardSummary = {
+  active_subscriptions: [],
+  category_breakdown: [],
+  monthly_spend: [
+    { label: "Jan", month: "2026-01", total: "0.00" },
+    { label: "Feb", month: "2026-02", total: "0.00" },
+  ],
+  recently_ended: [],
+  summary: {
+    active_subscriptions: 0,
+    cancelled_subscriptions: 0,
+    total_monthly_spend: "0.00",
+    upcoming_renewals: 0,
+  },
+  upcoming_renewals: [],
+};
+
+describe("DashboardWidgetCard", () => {
+  it.each<
+    [DashboardWidgetId, string, DashboardSummary, string]
+  >([
+    ["active-subscriptions", "Active subscriptions", fullSummary, "Netflix"],
+    ["monthly-spend", "Monthly spend", fullSummary, "Latest recorded month"],
+    ["category-breakdown", "Category breakdown", fullSummary, "Entertainment"],
+    ["upcoming-renewals", "Upcoming renewals", fullSummary, "3 days"],
+    ["recently-ended", "Recently ended", fullSummary, "Headspace"],
+  ])("renders %s with live data", (widgetId, title, summary, detailText) => {
+    render(
+      <div style={{ width: 720 }}>
+        <DashboardWidgetCard summary={summary} widgetId={widgetId} />
+      </div>,
+    );
+
+    expect(screen.getByRole("heading", { level: 3, name: title })).toBeInTheDocument();
+    expect(screen.getByText(detailText)).toBeInTheDocument();
+  });
+
+  it.each<
+    [DashboardWidgetId, string]
+  >([
+    ["active-subscriptions", "Add subscriptions or import statement data to populate the active roster."],
+    ["monthly-spend", "Upload statement history to start plotting monthly spend."],
+    ["category-breakdown", "Categorize active subscriptions to unlock the category breakdown."],
+    ["upcoming-renewals", "Upcoming renewal dates will appear once active plans have charge schedules."],
+    ["recently-ended", "Cancelled subscriptions with end dates will show up here."],
+  ])("shows the empty state for %s", (widgetId, emptyText) => {
+    render(
+      <div style={{ width: 720 }}>
+        <DashboardWidgetCard summary={emptySummary} widgetId={widgetId} />
+      </div>,
+    );
+
+    expect(screen.getByText(emptyText)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/setup.ts
+++ b/frontend/tests/unit/setup.ts
@@ -13,3 +13,16 @@ Object.defineProperty(window, "matchMedia", {
   }),
   writable: true,
 });
+
+class ResizeObserverMock {
+  disconnect() {}
+
+  observe() {}
+
+  unobserve() {}
+}
+
+Object.defineProperty(window, "ResizeObserver", {
+  value: ResizeObserverMock,
+  writable: true,
+});


### PR DESCRIPTION
# Day 11 — Dashboard Widgets

**Branch:** `day-11/dashboard-widgets`
**Pushed to:** `origin/day-11/dashboard-widgets` at `85fb8d0`

---

The dashboard now has the full five-widget workspace with persisted layout moves, plus backend summary support for active subscription rows.

**Main UI work:**

- `dashboard page`
- `widget board`
- `widget library`

**Backend contract update:**

- `dashboard service`

---

## Verification

All checks passed:

- `lockfile-guard`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `backend/.venv/bin/pytest backend/tests`
- `backend/.venv/bin/ruff check backend/src backend/tests`
- `backend/.venv/bin/mypy backend/src`

---

## GitHub Sync

- Issues **#47**, **#48**, and umbrella **#46** are closed.
- **Milestone 11** is closed with `open_issues = 0`.