### PR TITLE
Day 12/search filter settings

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.database import get_db
@@ -14,7 +14,12 @@ from src.schemas.auth import (
     TokenResponse,
     UserResponse,
 )
-from src.services.auth import login_user, refresh_user_tokens, register_user
+from src.services.auth import (
+    delete_user_workspace_data,
+    login_user,
+    refresh_user_tokens,
+    register_user,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 DbSession = Annotated[AsyncSession, Depends(get_db)]
@@ -63,3 +68,12 @@ async def refresh(
 @router.get("/me", response_model=UserResponse, status_code=status.HTTP_200_OK)
 async def me(current_user: CurrentUser) -> UserResponse:
     return UserResponse.model_validate(current_user)
+
+
+@router.delete("/me/data", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_my_workspace_data(
+    session: DbSession,
+    current_user: CurrentUser,
+) -> Response:
+    await delete_user_workspace_data(session, current_user)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/api/routes/subscriptions.py
+++ b/backend/src/api/routes/subscriptions.py
@@ -1,6 +1,7 @@
+from decimal import Decimal
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.database import get_db
@@ -23,6 +24,8 @@ from src.services.subscription import (
 router = APIRouter(prefix="/subscriptions", tags=["subscriptions"])
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
+MinAmountQuery = Annotated[Decimal | None, Query(default=None)]
+MaxAmountQuery = Annotated[Decimal | None, Query(default=None)]
 
 
 @router.get("", response_model=SubscriptionListResponse, status_code=status.HTTP_200_OK)
@@ -32,16 +35,28 @@ async def get_subscriptions(
     status_filter: str | None = Query(default=None, alias="status"),
     category_id: int | None = Query(default=None),
     payment_method_id: int | None = Query(default=None),
+    cadence: str | None = Query(default=None),
+    min_amount: MinAmountQuery = None,
+    max_amount: MaxAmountQuery = None,
     search: str | None = Query(default=None),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=25, ge=1, le=100),
 ) -> SubscriptionListResponse:
+    if min_amount is not None and max_amount is not None and min_amount > max_amount:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="min_amount must be less than or equal to max_amount.",
+        )
+
     items, total = await list_subscriptions(
         session,
         user=current_user,
         status_filter=status_filter,
         category_id=category_id,
         payment_method_id=payment_method_id,
+        cadence=cadence,
+        min_amount=min_amount,
+        max_amount=max_amount,
         search=search,
         offset=offset,
         limit=limit,

--- a/backend/src/api/routes/subscriptions.py
+++ b/backend/src/api/routes/subscriptions.py
@@ -24,8 +24,8 @@ from src.services.subscription import (
 router = APIRouter(prefix="/subscriptions", tags=["subscriptions"])
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
-MinAmountQuery = Annotated[Decimal | None, Query(default=None)]
-MaxAmountQuery = Annotated[Decimal | None, Query(default=None)]
+MinAmountQuery = Annotated[Decimal | None, Query()]
+MaxAmountQuery = Annotated[Decimal | None, Query()]
 
 
 @router.get("", response_model=SubscriptionListResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/services/auth.py
+++ b/backend/src/services/auth.py
@@ -1,12 +1,18 @@
 from datetime import timedelta
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import get_settings
 from src.core.logging import get_logger
 from src.core.security import create_token, decode_token, hash_password, verify_password
+from src.models.dashboard_layout import DashboardLayout
+from src.models.data_source import DataSource
+from src.models.payment_history import PaymentHistory
+from src.models.payment_method import PaymentMethod
+from src.models.raw_transaction import RawTransaction
+from src.models.subscription import Subscription
 from src.models.user import User
 from src.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
 
@@ -100,3 +106,33 @@ async def refresh_user_tokens(session: AsyncSession, refresh_token: str) -> Toke
 
     logger.info("auth.refreshed", user_id=user.id, email=user.email)
     return _build_token_response(user)
+
+
+async def delete_user_workspace_data(session: AsyncSession, user: User) -> None:
+    subscription_ids = list(
+        (
+            await session.scalars(
+                select(Subscription.id).where(Subscription.user_id == user.id),
+            )
+        ).all()
+    )
+
+    if subscription_ids:
+        await session.execute(
+            delete(PaymentHistory).where(PaymentHistory.subscription_id.in_(subscription_ids)),
+        )
+
+    await session.execute(delete(DashboardLayout).where(DashboardLayout.user_id == user.id))
+    await session.execute(delete(RawTransaction).where(RawTransaction.user_id == user.id))
+    await session.execute(delete(DataSource).where(DataSource.user_id == user.id))
+    await session.execute(delete(Subscription).where(Subscription.user_id == user.id))
+    await session.execute(delete(PaymentMethod).where(PaymentMethod.user_id == user.id))
+    await session.commit()
+
+    logger.info(
+        "auth.workspace_data_deleted",
+        user_id=user.id,
+        dashboard_layouts_removed=True,
+        payment_methods_removed=True,
+        subscriptions_removed=len(subscription_ids),
+    )

--- a/backend/src/services/subscription.py
+++ b/backend/src/services/subscription.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from fastapi import HTTPException, status
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -45,6 +47,9 @@ async def list_subscriptions(
     status_filter: str | None,
     category_id: int | None,
     payment_method_id: int | None,
+    cadence: str | None,
+    min_amount: Decimal | None,
+    max_amount: Decimal | None,
     search: str | None,
     offset: int,
     limit: int,
@@ -57,6 +62,12 @@ async def list_subscriptions(
         conditions.append(Subscription.category_id == category_id)
     if payment_method_id is not None:
         conditions.append(Subscription.payment_method_id == payment_method_id)
+    if cadence:
+        conditions.append(Subscription.cadence == cadence.strip().lower())
+    if min_amount is not None:
+        conditions.append(Subscription.amount >= min_amount)
+    if max_amount is not None:
+        conditions.append(Subscription.amount <= max_amount)
     if search:
         pattern = f"%{search.strip().lower()}%"
         conditions.append(
@@ -75,7 +86,16 @@ async def list_subscriptions(
     )
     items = list((await session.scalars(statement)).all())
     total = await session.scalar(select(func.count()).select_from(Subscription).where(*conditions))
-    logger.info("subscriptions.listed", user_id=user.id, total=total, offset=offset, limit=limit)
+    logger.info(
+        "subscriptions.listed",
+        user_id=user.id,
+        total=total,
+        offset=offset,
+        limit=limit,
+        cadence=cadence,
+        min_amount=str(min_amount) if min_amount is not None else None,
+        max_amount=str(max_amount) if max_amount is not None else None,
+    )
     return items, int(total or 0)
 
 

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -88,6 +88,10 @@ def test_login_is_rate_limited_after_repeated_attempts(client) -> None:
 def test_delete_my_workspace_data_resets_user_owned_records(client) -> None:
     headers = _auth_headers(client, "cleanup@example.com")
 
+    default_layout_response = client.get("/api/v1/dashboard/layout", headers=headers)
+    assert default_layout_response.status_code == 200
+    default_widgets = default_layout_response.json()["widgets"]
+
     payment_method_response = client.post(
         "/api/v1/payment-methods",
         headers=headers,
@@ -113,17 +117,15 @@ def test_delete_my_workspace_data_resets_user_owned_records(client) -> None:
     )
     assert subscription_response.status_code == 201
 
+    updated_widgets = [
+        *[widget for widget in default_widgets if widget["id"] == "upcoming-renewals"],
+        *[widget for widget in default_widgets if widget["id"] != "upcoming-renewals"],
+    ]
+
     layout_response = client.put(
         "/api/v1/dashboard/layout",
         headers=headers,
-        json={
-            "widgets": [
-                {"id": "upcoming-renewals", "column": "primary"},
-                {"id": "monthly-spend", "column": "primary"},
-                {"id": "category-breakdown", "column": "secondary"},
-                {"id": "recently-ended", "column": "secondary"},
-            ]
-        },
+        json={"widgets": updated_widgets},
     )
     assert layout_response.status_code == 200
     assert layout_response.json()["widgets"][0]["id"] == "upcoming-renewals"
@@ -141,4 +143,4 @@ def test_delete_my_workspace_data_resets_user_owned_records(client) -> None:
 
     reset_layout_response = client.get("/api/v1/dashboard/layout", headers=headers)
     assert reset_layout_response.status_code == 200
-    assert reset_layout_response.json()["widgets"][0]["id"] == "monthly-spend"
+    assert reset_layout_response.json()["widgets"] == default_widgets

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -1,3 +1,17 @@
+def _auth_headers(client, email: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "full_name": "Owner One",
+            "password": "super-secret",
+        },
+    )
+    assert response.status_code == 201
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
 def test_register_login_refresh_and_me(client) -> None:
     register_response = client.post(
         "/api/v1/auth/register",
@@ -69,3 +83,62 @@ def test_login_is_rate_limited_after_repeated_attempts(client) -> None:
 
     assert limited_response.status_code == 429
     assert limited_response.json()["detail"] == "Too many requests. Try again in a minute."
+
+
+def test_delete_my_workspace_data_resets_user_owned_records(client) -> None:
+    headers = _auth_headers(client, "cleanup@example.com")
+
+    payment_method_response = client.post(
+        "/api/v1/payment-methods",
+        headers=headers,
+        json={"label": "Primary Card", "provider": "Visa", "last4": "4242", "is_default": True},
+    )
+    assert payment_method_response.status_code == 201
+    payment_method_id = payment_method_response.json()["id"]
+
+    subscription_response = client.post(
+        "/api/v1/subscriptions",
+        headers=headers,
+        json={
+            "name": "Netflix",
+            "vendor": "Netflix",
+            "amount": "15.49",
+            "currency": "USD",
+            "cadence": "monthly",
+            "status": "active",
+            "start_date": "2026-04-01",
+            "payment_method_id": payment_method_id,
+            "auto_renew": True,
+        },
+    )
+    assert subscription_response.status_code == 201
+
+    layout_response = client.put(
+        "/api/v1/dashboard/layout",
+        headers=headers,
+        json={
+            "widgets": [
+                {"id": "upcoming-renewals", "column": "primary"},
+                {"id": "monthly-spend", "column": "primary"},
+                {"id": "category-breakdown", "column": "secondary"},
+                {"id": "recently-ended", "column": "secondary"},
+            ]
+        },
+    )
+    assert layout_response.status_code == 200
+    assert layout_response.json()["widgets"][0]["id"] == "upcoming-renewals"
+
+    delete_response = client.delete("/api/v1/auth/me/data", headers=headers)
+    assert delete_response.status_code == 204
+
+    subscriptions_response = client.get("/api/v1/subscriptions", headers=headers)
+    assert subscriptions_response.status_code == 200
+    assert subscriptions_response.json()["total"] == 0
+
+    payment_methods_response = client.get("/api/v1/payment-methods", headers=headers)
+    assert payment_methods_response.status_code == 200
+    assert payment_methods_response.json()["total"] == 0
+
+    reset_layout_response = client.get("/api/v1/dashboard/layout", headers=headers)
+    assert reset_layout_response.status_code == 200
+    assert reset_layout_response.json()["widgets"][0]["id"] == "monthly-spend"

--- a/backend/tests/api/test_subscriptions.py
+++ b/backend/tests/api/test_subscriptions.py
@@ -86,15 +86,52 @@ def test_subscriptions_support_crud_and_filters(client) -> None:
     )
     assert second_response.status_code == 201
 
+    third_payment_method_id = _create_payment_method(client, owner_headers, "Travel Card")
+    third_response = client.post(
+        "/api/v1/subscriptions",
+        headers=owner_headers,
+        json={
+            "name": "Dropbox",
+            "vendor": "Dropbox",
+            "amount": "120.00",
+            "currency": "USD",
+            "cadence": "yearly",
+            "status": "active",
+            "start_date": "2026-01-15",
+            "payment_method_id": third_payment_method_id,
+            "auto_renew": True,
+        },
+    )
+    assert third_response.status_code == 201
+
     list_response = client.get(
         "/api/v1/subscriptions",
         headers=owner_headers,
-        params={"status": "active", "search": "net", "limit": 10, "offset": 0},
+        params={
+            "status": "active",
+            "search": "net",
+            "payment_method_id": payment_method_id,
+            "cadence": "monthly",
+            "min_amount": "12.00",
+            "max_amount": "20.00",
+            "limit": 10,
+            "offset": 0,
+        },
     )
     assert list_response.status_code == 200
     listed = list_response.json()
     assert listed["total"] == 1
     assert listed["items"][0]["name"] == "Netflix"
+
+    yearly_response = client.get(
+        "/api/v1/subscriptions",
+        headers=owner_headers,
+        params={"cadence": "yearly", "min_amount": "100.00", "max_amount": "140.00"},
+    )
+    assert yearly_response.status_code == 200
+    yearly_listed = yearly_response.json()
+    assert yearly_listed["total"] == 1
+    assert yearly_listed["items"][0]["name"] == "Dropbox"
 
     get_response = client.get(f"/api/v1/subscriptions/{created['id']}", headers=owner_headers)
     assert get_response.status_code == 200
@@ -211,3 +248,14 @@ def test_subscriptions_enforce_validation_and_ownership(client) -> None:
         },
     )
     assert invalid_url_response.status_code == 422
+
+    invalid_range_response = client.get(
+        "/api/v1/subscriptions",
+        headers=owner_headers,
+        params={"min_amount": "30.00", "max_amount": "10.00"},
+    )
+    assert invalid_range_response.status_code == 422
+    assert (
+        invalid_range_response.json()["detail"]
+        == "min_amount must be less than or equal to max_amount."
+    )

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -1,44 +1,627 @@
-import { ShieldCheck, SlidersHorizontal } from "lucide-react";
+"use client";
 
-import { EmptyState } from "@/components/ui/empty-state";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { CreditCard, FolderTree, LoaderCircle, PencilLine, ShieldAlert, Trash2, UserRound } from "lucide-react";
+
+import { useAuth } from "@/hooks/use-auth";
+import {
+  useCreateCategory,
+  useCreatePaymentMethod,
+  useDeleteCategory,
+  useDeletePaymentMethod,
+  useDeleteWorkspaceData,
+  useSubscriptionCatalog,
+  useSubscriptionList,
+  useUpdateCategory,
+  useUpdatePaymentMethod,
+} from "@/hooks/use-subscriptions";
+import type { Category, PaymentMethod } from "@/types";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { PageHeader } from "@/components/ui/page-header";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 
-export default function SettingsPage() {
+type CategoryDraft = {
+  description: string;
+  name: string;
+};
+
+type PaymentMethodDraft = {
+  is_default: boolean;
+  label: string;
+  last4: string;
+  provider: string;
+};
+
+const emptyCategoryDraft: CategoryDraft = {
+  description: "",
+  name: "",
+};
+
+const emptyPaymentMethodDraft: PaymentMethodDraft = {
+  is_default: false,
+  label: "",
+  last4: "",
+  provider: "",
+};
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Something went wrong. Try again.";
+}
+
+function getCurrencySummary(currencies: string[]) {
+  if (currencies.length === 0) {
+    return {
+      detail: "No saved subscriptions yet. New plans still default to USD until the workspace fills in.",
+      label: "USD",
+    };
+  }
+
+  const counts = new Map<string, number>();
+  for (const currency of currencies) {
+    counts.set(currency, (counts.get(currency) ?? 0) + 1);
+  }
+
+  const [label, count] = [...counts.entries()].sort((left, right) => right[1] - left[1])[0];
+  return {
+    detail: `${count} of ${currencies.length} saved subscriptions currently bill in ${label}.`,
+    label,
+  };
+}
+
+function SectionShell({
+  children,
+  description,
+  icon,
+  title,
+}: Readonly<{
+  children: ReactNode;
+  description: string;
+  icon: ReactNode;
+  title: string;
+}>) {
   return (
-    <div className="space-y-8">
+    <section className="rounded-[2rem] border border-black/10 bg-white/78 p-6 shadow-line backdrop-blur sm:p-7">
+      <div className="flex flex-col gap-4 border-b border-black/10 pb-5 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.32em] text-black/42">Settings block</p>
+          <h2 className="mt-2 text-2xl font-semibold text-ink">{title}</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-black/62">{description}</p>
+        </div>
+        <div className="inline-flex size-12 items-center justify-center rounded-2xl border border-black/10 bg-stone text-ink">
+          {icon}
+        </div>
+      </div>
+      <div className="mt-6">{children}</div>
+    </section>
+  );
+}
+
+export default function SettingsPage() {
+  const { user } = useAuth();
+  const [categoryDraft, setCategoryDraft] = useState<CategoryDraft>(emptyCategoryDraft);
+  const [paymentMethodDraft, setPaymentMethodDraft] = useState<PaymentMethodDraft>(emptyPaymentMethodDraft);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+  const [editingCategoryDraft, setEditingCategoryDraft] = useState<CategoryDraft>(emptyCategoryDraft);
+  const [editingPaymentMethod, setEditingPaymentMethod] = useState<PaymentMethod | null>(null);
+  const [editingPaymentMethodDraft, setEditingPaymentMethodDraft] =
+    useState<PaymentMethodDraft>(emptyPaymentMethodDraft);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const { categoriesQuery, paymentMethodsQuery } = useSubscriptionCatalog();
+  const subscriptionsQuery = useSubscriptionList({ limit: 100 });
+  const createCategory = useCreateCategory();
+  const createPaymentMethod = useCreatePaymentMethod();
+  const deleteWorkspaceData = useDeleteWorkspaceData();
+  const editingCategoryMutation = useUpdateCategory();
+  const deletingCategoryMutation = useDeleteCategory();
+  const editingPaymentMethodMutation = useUpdatePaymentMethod();
+  const deletingPaymentMethodMutation = useDeletePaymentMethod();
+
+  const categories = categoriesQuery.data?.items ?? [];
+  const paymentMethods = paymentMethodsQuery.data?.items ?? [];
+  const currencySummary = useMemo(
+    () => getCurrencySummary((subscriptionsQuery.data?.items ?? []).map((subscription) => subscription.currency)),
+    [subscriptionsQuery.data?.items],
+  );
+
+  const isCatalogLoading = categoriesQuery.isLoading || paymentMethodsQuery.isLoading;
+
+  const openCategoryEditor = (category: Category) => {
+    setEditingCategory(category);
+    setEditingCategoryDraft({
+      description: category.description ?? "",
+      name: category.name,
+    });
+  };
+
+  const openPaymentMethodEditor = (paymentMethod: PaymentMethod) => {
+    setEditingPaymentMethod(paymentMethod);
+    setEditingPaymentMethodDraft({
+      is_default: paymentMethod.is_default,
+      label: paymentMethod.label,
+      last4: paymentMethod.last4 ?? "",
+      provider: paymentMethod.provider,
+    });
+  };
+
+  return (
+    <div className="space-y-8 animate-page-enter">
       <PageHeader
         action={<ThemeToggle />}
-        description="Session controls, theme preferences, and later workspace defaults all belong here. The authenticated shell can now host them consistently."
+        description="Keep shared billing metadata tidy, manage payment rails, and control the workspace profile without leaving the authenticated shell."
         eyebrow="Settings"
-        title="Workspace controls"
+        title="Settings and workspace profile"
       />
 
-      <section className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr]">
-        <div className="rounded-[2rem] border border-black/10 bg-white/72 p-6 shadow-line backdrop-blur sm:p-8">
-          <div className="flex items-center justify-between border-b border-black/10 pb-5">
-            <div>
-              <p className="text-xs uppercase tracking-[0.32em] text-black/45">Live preference</p>
-              <h3 className="mt-2 text-2xl font-semibold text-ink">Theme mode</h3>
-            </div>
-            <SlidersHorizontal className="size-5 text-ember" />
+      <div className="grid gap-8 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+        <SectionShell
+          description="Rename taxonomy, add fresh buckets for new services, and prune categories without leaving the operator workspace."
+          icon={<FolderTree className="size-5" />}
+          title="Categories management"
+        >
+          <form
+            className="grid gap-3 rounded-[1.6rem] border border-black/10 bg-stone/55 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)_auto]"
+            onSubmit={async (event) => {
+              event.preventDefault();
+              await createCategory.mutateAsync({
+                description: categoryDraft.description || undefined,
+                name: categoryDraft.name,
+              });
+              setCategoryDraft(emptyCategoryDraft);
+            }}
+          >
+            <input
+              className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              onChange={(event) =>
+                setCategoryDraft((current) => ({ ...current, name: event.target.value }))
+              }
+              placeholder="Add a category name"
+              value={categoryDraft.name}
+            />
+            <input
+              className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              onChange={(event) =>
+                setCategoryDraft((current) => ({ ...current, description: event.target.value }))
+              }
+              placeholder="Optional description"
+              value={categoryDraft.description}
+            />
+            <Button className="rounded-full px-5" disabled={createCategory.isPending} type="submit">
+              {createCategory.isPending ? "Saving..." : "Add category"}
+            </Button>
+          </form>
+
+          {createCategory.error ? (
+            <p className="mt-3 text-sm text-ember">{getErrorMessage(createCategory.error)}</p>
+          ) : null}
+
+          <div className="mt-5 space-y-3">
+            {categoriesQuery.isLoading ? (
+              <div className="flex items-center gap-3 text-sm text-black/58">
+                <LoaderCircle className="size-4 animate-spin" />
+                Loading categories...
+              </div>
+            ) : categories.length === 0 ? (
+              <p className="text-sm text-black/58">No categories yet. Add the first one above.</p>
+            ) : (
+              categories.map((category) => {
+                const isEditing = editingCategory?.id === category.id;
+
+                return (
+                  <div
+                    className="rounded-[1.5rem] border border-black/10 bg-white/85 p-4"
+                    key={category.id}
+                  >
+                    {isEditing ? (
+                      <form
+                        className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)_auto_auto]"
+                        onSubmit={async (event) => {
+                          event.preventDefault();
+                          if (!editingCategory) {
+                            return;
+                          }
+                          await editingCategoryMutation.mutateAsync({
+                            categoryId: editingCategory.id,
+                            payload: {
+                              description: editingCategoryDraft.description || undefined,
+                              name: editingCategoryDraft.name,
+                            },
+                          });
+                          setEditingCategory(null);
+                        }}
+                      >
+                        <input
+                          className="h-11 rounded-2xl border border-black/10 bg-stone/35 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                          onChange={(event) =>
+                            setEditingCategoryDraft((current) => ({
+                              ...current,
+                              name: event.target.value,
+                            }))
+                          }
+                          value={editingCategoryDraft.name}
+                        />
+                        <input
+                          className="h-11 rounded-2xl border border-black/10 bg-stone/35 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                          onChange={(event) =>
+                            setEditingCategoryDraft((current) => ({
+                              ...current,
+                              description: event.target.value,
+                            }))
+                          }
+                          value={editingCategoryDraft.description}
+                        />
+                        <Button disabled={editingCategoryMutation.isPending} type="submit" variant="outline">
+                          Save
+                        </Button>
+                        <Button
+                          onClick={() => setEditingCategory(null)}
+                          type="button"
+                          variant="ghost"
+                        >
+                          Cancel
+                        </Button>
+                      </form>
+                    ) : (
+                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <h3 className="text-lg font-semibold text-ink">{category.name}</h3>
+                          <p className="mt-1 text-sm text-black/58">
+                            {category.description || "No description yet."}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            className="rounded-full"
+                            onClick={() => openCategoryEditor(category)}
+                            size="sm"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <PencilLine className="mr-2 size-4" />
+                            Edit
+                          </Button>
+                          <Button
+                            className="rounded-full"
+                            onClick={async () => deletingCategoryMutation.mutateAsync(category.id)}
+                            size="sm"
+                            type="button"
+                            variant="outline"
+                          >
+                            <Trash2 className="mr-2 size-4" />
+                            Delete
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+
+                    {isEditing && editingCategoryMutation.error ? (
+                      <p className="mt-3 text-sm text-ember">
+                        {getErrorMessage(editingCategoryMutation.error)}
+                      </p>
+                    ) : null}
+                  </div>
+                );
+              })
+            )}
           </div>
-          <p className="mt-5 max-w-lg text-base leading-7 text-black/65">
-            Theme switching is already wired into the shell, so the user can move between light
-            and dark modes without leaving the workspace.
-          </p>
-          <div className="mt-6">
-            <ThemeToggle />
+        </SectionShell>
+
+        <SectionShell
+          description="Add, rename, and retire payment methods while keeping the default card obvious for future billing flows."
+          icon={<CreditCard className="size-5" />}
+          title="Payment methods management"
+        >
+          <form
+            className="grid gap-3 rounded-[1.6rem] border border-black/10 bg-stone/55 p-4 md:grid-cols-2"
+            onSubmit={async (event) => {
+              event.preventDefault();
+              await createPaymentMethod.mutateAsync({
+                is_default: paymentMethodDraft.is_default,
+                label: paymentMethodDraft.label,
+                last4: paymentMethodDraft.last4 || undefined,
+                provider: paymentMethodDraft.provider,
+              });
+              setPaymentMethodDraft(emptyPaymentMethodDraft);
+            }}
+          >
+            <input
+              className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              onChange={(event) =>
+                setPaymentMethodDraft((current) => ({ ...current, label: event.target.value }))
+              }
+              placeholder="Label"
+              value={paymentMethodDraft.label}
+            />
+            <input
+              className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              onChange={(event) =>
+                setPaymentMethodDraft((current) => ({ ...current, provider: event.target.value }))
+              }
+              placeholder="Provider"
+              value={paymentMethodDraft.provider}
+            />
+            <input
+              className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+              inputMode="numeric"
+              maxLength={4}
+              onChange={(event) =>
+                setPaymentMethodDraft((current) => ({
+                  ...current,
+                  last4: event.target.value.replace(/\D/g, "").slice(0, 4),
+                }))
+              }
+              placeholder="Last 4 digits"
+              value={paymentMethodDraft.last4}
+            />
+            <div className="flex items-center justify-between rounded-2xl border border-black/10 bg-white px-4">
+              <label className="text-sm font-medium text-ink" htmlFor="payment-method-default">
+                Mark as default
+              </label>
+              <input
+                checked={paymentMethodDraft.is_default}
+                id="payment-method-default"
+                onChange={(event) =>
+                  setPaymentMethodDraft((current) => ({
+                    ...current,
+                    is_default: event.target.checked,
+                  }))
+                }
+                type="checkbox"
+              />
+            </div>
+            <Button
+              className="rounded-full px-5 md:col-span-2 md:justify-self-start"
+              disabled={createPaymentMethod.isPending}
+              type="submit"
+            >
+              {createPaymentMethod.isPending ? "Saving..." : "Add payment method"}
+            </Button>
+          </form>
+
+          {createPaymentMethod.error ? (
+            <p className="mt-3 text-sm text-ember">{getErrorMessage(createPaymentMethod.error)}</p>
+          ) : null}
+
+          <div className="mt-5 space-y-3">
+            {paymentMethodsQuery.isLoading ? (
+              <div className="flex items-center gap-3 text-sm text-black/58">
+                <LoaderCircle className="size-4 animate-spin" />
+                Loading payment methods...
+              </div>
+            ) : paymentMethods.length === 0 ? (
+              <p className="text-sm text-black/58">
+                No payment methods yet. Add the primary billing rail above.
+              </p>
+            ) : (
+              paymentMethods.map((paymentMethod) => {
+                const isEditing = editingPaymentMethod?.id === paymentMethod.id;
+
+                return (
+                  <div
+                    className="rounded-[1.5rem] border border-black/10 bg-white/85 p-4"
+                    key={paymentMethod.id}
+                  >
+                    {isEditing ? (
+                      <form
+                        className="grid gap-3 md:grid-cols-2"
+                        onSubmit={async (event) => {
+                          event.preventDefault();
+                          if (!editingPaymentMethod) {
+                            return;
+                          }
+                          await editingPaymentMethodMutation.mutateAsync({
+                            paymentMethodId: editingPaymentMethod.id,
+                            payload: {
+                              is_default: editingPaymentMethodDraft.is_default,
+                              label: editingPaymentMethodDraft.label,
+                              last4: editingPaymentMethodDraft.last4 || undefined,
+                              provider: editingPaymentMethodDraft.provider,
+                            },
+                          });
+                          setEditingPaymentMethod(null);
+                        }}
+                      >
+                        <input
+                          className="h-11 rounded-2xl border border-black/10 bg-stone/35 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                          onChange={(event) =>
+                            setEditingPaymentMethodDraft((current) => ({
+                              ...current,
+                              label: event.target.value,
+                            }))
+                          }
+                          value={editingPaymentMethodDraft.label}
+                        />
+                        <input
+                          className="h-11 rounded-2xl border border-black/10 bg-stone/35 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                          onChange={(event) =>
+                            setEditingPaymentMethodDraft((current) => ({
+                              ...current,
+                              provider: event.target.value,
+                            }))
+                          }
+                          value={editingPaymentMethodDraft.provider}
+                        />
+                        <input
+                          className="h-11 rounded-2xl border border-black/10 bg-stone/35 px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                          inputMode="numeric"
+                          maxLength={4}
+                          onChange={(event) =>
+                            setEditingPaymentMethodDraft((current) => ({
+                              ...current,
+                              last4: event.target.value.replace(/\D/g, "").slice(0, 4),
+                            }))
+                          }
+                          value={editingPaymentMethodDraft.last4}
+                        />
+                        <div className="flex items-center justify-between rounded-2xl border border-black/10 bg-stone/35 px-4">
+                          <label
+                            className="text-sm font-medium text-ink"
+                            htmlFor={`payment-default-${paymentMethod.id}`}
+                          >
+                            Default card
+                          </label>
+                          <input
+                            checked={editingPaymentMethodDraft.is_default}
+                            id={`payment-default-${paymentMethod.id}`}
+                            onChange={(event) =>
+                              setEditingPaymentMethodDraft((current) => ({
+                                ...current,
+                                is_default: event.target.checked,
+                              }))
+                            }
+                            type="checkbox"
+                          />
+                        </div>
+                        <div className="flex items-center gap-2 md:col-span-2">
+                          <Button disabled={editingPaymentMethodMutation.isPending} type="submit" variant="outline">
+                            Save
+                          </Button>
+                          <Button
+                            onClick={() => setEditingPaymentMethod(null)}
+                            type="button"
+                            variant="ghost"
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </form>
+                    ) : (
+                      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="text-lg font-semibold text-ink">{paymentMethod.label}</h3>
+                            {paymentMethod.is_default ? (
+                              <span className="rounded-full border border-black/10 bg-stone px-3 py-1 text-xs uppercase tracking-[0.24em] text-black/48">
+                                Default
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="mt-1 text-sm text-black/58">
+                            {paymentMethod.provider}
+                            {paymentMethod.last4 ? ` •••• ${paymentMethod.last4}` : ""}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            className="rounded-full"
+                            onClick={() => openPaymentMethodEditor(paymentMethod)}
+                            size="sm"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <PencilLine className="mr-2 size-4" />
+                            Edit
+                          </Button>
+                          <Button
+                            className="rounded-full"
+                            onClick={async () =>
+                              deletingPaymentMethodMutation.mutateAsync(paymentMethod.id)
+                            }
+                            size="sm"
+                            type="button"
+                            variant="outline"
+                          >
+                            <Trash2 className="mr-2 size-4" />
+                            Delete
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+
+                    {isEditing && editingPaymentMethodMutation.error ? (
+                      <p className="mt-3 text-sm text-ember">
+                        {getErrorMessage(editingPaymentMethodMutation.error)}
+                      </p>
+                    ) : null}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </SectionShell>
+      </div>
+
+      <SectionShell
+        description="Surface the active operator identity, keep the visual theme accessible, and provide a deliberate destructive path for wiping workspace-owned records."
+        icon={<UserRound className="size-5" />}
+        title="Profile and workspace controls"
+      >
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <div className="space-y-4 rounded-[1.6rem] border border-black/10 bg-stone/55 p-5">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-black/42">Signed in as</p>
+              <h3 className="mt-2 text-xl font-semibold text-ink">{user?.full_name ?? "Workspace operator"}</h3>
+              <p className="mt-1 text-sm text-black/58">{user?.email ?? "No email available"}</p>
+            </div>
+
+            <div className="rounded-[1.35rem] border border-black/10 bg-white/85 p-4">
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Workspace currency</p>
+              <p className="mt-2 text-2xl font-semibold text-ink">{currencySummary.label}</p>
+              <p className="mt-2 text-sm leading-6 text-black/58">{currencySummary.detail}</p>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="rounded-[1.6rem] border border-black/10 bg-white/85 p-5">
+              <p className="text-xs uppercase tracking-[0.3em] text-black/42">Theme mode</p>
+              <h3 className="mt-2 text-xl font-semibold text-ink">Display preference</h3>
+              <p className="mt-2 text-sm leading-6 text-black/58">
+                Toggle the shell between light and dark modes without leaving the workspace.
+              </p>
+              <div className="mt-4">
+                <ThemeToggle />
+              </div>
+            </div>
+
+            <div className="rounded-[1.6rem] border border-ember/20 bg-[rgba(255,241,234,0.88)] p-5">
+              <div className="flex items-start gap-3">
+                <ShieldAlert className="mt-0.5 size-5 text-ember" />
+                <div>
+                  <p className="text-xs uppercase tracking-[0.3em] text-black/42">Danger zone</p>
+                  <h3 className="mt-2 text-xl font-semibold text-ink">Delete workspace data</h3>
+                  <p className="mt-2 text-sm leading-6 text-black/58">
+                    Removes subscriptions, payment methods, uploads, raw transactions, payment history, and saved dashboard layout for this user.
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                className="mt-5 rounded-full bg-ember px-5 text-white hover:bg-ember/92"
+                disabled={deleteWorkspaceData.isPending || isCatalogLoading}
+                onClick={() => setIsDeleteDialogOpen(true)}
+                type="button"
+              >
+                <Trash2 className="mr-2 size-4" />
+                Delete workspace data
+              </Button>
+
+              {deleteWorkspaceData.error ? (
+                <p className="mt-3 text-sm text-ember">{getErrorMessage(deleteWorkspaceData.error)}</p>
+              ) : null}
+            </div>
           </div>
         </div>
+      </SectionShell>
 
-        <EmptyState
-          description="Role management, alert defaults, shared household settings, and other operational controls should accumulate here instead of leaking into product pages."
-          eyebrow="Reserved for later milestones"
-          icon={<ShieldCheck className="size-5" />}
-          title="Core settings scaffolding is ready."
-        />
-      </section>
+      <ConfirmDialog
+        confirmLabel={deleteWorkspaceData.isPending ? "Deleting..." : "Delete data"}
+        description="This clears saved subscriptions, payment rails, upload history, raw transactions, payment history, and dashboard layout for the current user."
+        onConfirm={() => {
+          void deleteWorkspaceData.mutateAsync().then(() => {
+            setIsDeleteDialogOpen(false);
+          });
+        }}
+        onOpenChange={setIsDeleteDialogOpen}
+        open={isDeleteDialogOpen}
+        title="Delete all workspace data?"
+        tone="danger"
+      />
     </div>
   );
 }

--- a/frontend/src/app/(app)/subscriptions/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/page.tsx
@@ -1,30 +1,41 @@
 "use client";
 
 import Link from "next/link";
-import { useDeferredValue, useState } from "react";
-import { ArrowRight, LayoutGrid, List, LoaderCircle, Search, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { ArrowRight, LayoutGrid, List, LoaderCircle, SlidersHorizontal, Sparkles } from "lucide-react";
 
+import { SearchBar } from "@/components/subscriptions/search-bar";
 import { SubscriptionCard } from "@/components/subscriptions/subscription-card";
 import { SubscriptionForm } from "@/components/subscriptions/subscription-form";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { useFilters } from "@/hooks/use-filters";
 import { useCreateSubscription, useSubscriptionCatalog, useSubscriptionList } from "@/hooks/use-subscriptions";
-import { subscriptionStatusOptions } from "@/lib/validators";
-import type { SubscriptionStatus } from "@/types";
+import { subscriptionCadenceOptions, subscriptionStatusOptions } from "@/lib/validators";
 
 export default function SubscriptionsPage() {
-  const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<"all" | SubscriptionStatus>("all");
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
-  const deferredSearch = useDeferredValue(search);
+  const {
+    activeFilterCount,
+    clearFilters,
+    filters,
+    hasActiveFilters,
+    queryFilters,
+    setCadence,
+    setCategoryId,
+    setMaxAmount,
+    setMinAmount,
+    setPaymentMethodId,
+    setSearch,
+    setStatus,
+  } = useFilters();
 
   const createSubscription = useCreateSubscription();
   const { categoriesQuery, paymentMethodsQuery } = useSubscriptionCatalog();
   const subscriptionsQuery = useSubscriptionList({
     limit: 100,
-    search: deferredSearch.trim() || undefined,
-    status: statusFilter === "all" ? undefined : statusFilter,
+    ...queryFilters,
   });
 
   const categories = categoriesQuery.data?.items ?? [];
@@ -64,8 +75,8 @@ export default function SubscriptionsPage() {
                   {subscriptionsQuery.data?.total ?? subscriptions.length} subscriptions in view
                 </h2>
                 <p className="text-sm leading-6 text-black/62">
-                  Filter by status, switch the density, and open a detail route for edits,
-                  cancellation, or lifecycle review.
+                  Search by vendor, pin the exact billing rail, constrain price ranges, and keep
+                  the filters live in the URL while you move through the workspace.
                 </p>
               </div>
 
@@ -95,30 +106,116 @@ export default function SubscriptionsPage() {
               </div>
             </div>
 
-            <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
-              <label className="relative flex items-center">
-                <Search className="pointer-events-none absolute left-4 size-4 text-black/38" />
-                <input
-                  className="h-12 w-full rounded-full border border-black/10 bg-white/88 pl-11 pr-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
-                  onChange={(event) => setSearch(event.target.value)}
+            <div className="mt-5 space-y-4">
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px]">
+                <SearchBar
+                  onChange={setSearch}
                   placeholder="Search plans, vendors, notes"
-                  type="search"
-                  value={search}
+                  value={filters.search}
                 />
-              </label>
 
-              <select
-                className="h-12 rounded-full border border-black/10 bg-white/88 px-4 text-sm capitalize text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
-                onChange={(event) => setStatusFilter(event.target.value as "all" | SubscriptionStatus)}
-                value={statusFilter}
-              >
-                <option value="all">All statuses</option>
-                {subscriptionStatusOptions.map((status) => (
-                  <option className="capitalize" key={status} value={status}>
-                    {status}
-                  </option>
-                ))}
-              </select>
+                <select
+                  aria-label="Filter by status"
+                  className="h-12 rounded-full border border-black/10 bg-white/88 px-4 text-sm capitalize text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                  onChange={(event) => setStatus(event.target.value as typeof filters.status)}
+                  value={filters.status}
+                >
+                  <option value="all">All statuses</option>
+                  {subscriptionStatusOptions.map((status) => (
+                    <option className="capitalize" key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="rounded-[1.7rem] border border-black/10 bg-stone/65 p-4">
+                <div className="flex flex-col gap-3 border-b border-black/10 pb-4 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-black/42">Filter panel</p>
+                    <h3 className="mt-1 text-lg font-semibold text-ink">
+                      {activeFilterCount} live constraint{activeFilterCount === 1 ? "" : "s"}
+                    </h3>
+                  </div>
+
+                  <div className="flex items-center gap-3 text-sm text-black/58">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/75 px-3 py-1.5">
+                      <SlidersHorizontal className="size-4" />
+                      URL synced
+                    </span>
+                    <Button
+                      className="rounded-full"
+                      onClick={clearFilters}
+                      type="button"
+                      variant="ghost"
+                    >
+                      Reset all
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+                  <select
+                    aria-label="Filter by category"
+                    className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                    onChange={(event) => setCategoryId(event.target.value)}
+                    value={filters.categoryId}
+                  >
+                    <option value="all">All categories</option>
+                    {categories.map((category) => (
+                      <option key={category.id} value={String(category.id)}>
+                        {category.name}
+                      </option>
+                    ))}
+                  </select>
+
+                  <select
+                    aria-label="Filter by payment method"
+                    className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                    onChange={(event) => setPaymentMethodId(event.target.value)}
+                    value={filters.paymentMethodId}
+                  >
+                    <option value="all">All payment methods</option>
+                    {paymentMethods.map((paymentMethod) => (
+                      <option key={paymentMethod.id} value={String(paymentMethod.id)}>
+                        {paymentMethod.label}
+                      </option>
+                    ))}
+                  </select>
+
+                  <select
+                    aria-label="Filter by cadence"
+                    className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm capitalize text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                    onChange={(event) => setCadence(event.target.value as typeof filters.cadence)}
+                    value={filters.cadence}
+                  >
+                    <option value="all">All cadences</option>
+                    {subscriptionCadenceOptions.map((cadence) => (
+                      <option className="capitalize" key={cadence} value={cadence}>
+                        {cadence}
+                      </option>
+                    ))}
+                  </select>
+
+                  <input
+                    aria-label="Minimum monthly amount"
+                    className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                    inputMode="decimal"
+                    onChange={(event) => setMinAmount(event.target.value)}
+                    placeholder="Min amount"
+                    value={filters.minAmount}
+                  />
+
+                  <input
+                    aria-label="Maximum monthly amount"
+                    className="h-11 rounded-2xl border border-black/10 bg-white px-4 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                    inputMode="decimal"
+                    onChange={(event) => setMaxAmount(event.target.value)}
+                    placeholder="Max amount"
+                    value={filters.maxAmount}
+                  />
+                </div>
+              </div>
             </div>
           </section>
 
@@ -132,9 +229,11 @@ export default function SubscriptionsPage() {
           ) : subscriptions.length === 0 ? (
             <EmptyState
               action={
-                <Button className="rounded-full px-5" onClick={() => setSearch("")} variant="outline">
-                  Clear filters
-                </Button>
+                hasActiveFilters ? (
+                  <Button className="rounded-full px-5" onClick={clearFilters} variant="outline">
+                    Clear filters
+                  </Button>
+                ) : undefined
               }
               description="No plans match the current search or filter. Save a new subscription on the right to populate the workspace."
               eyebrow="Empty state"

--- a/frontend/src/components/subscriptions/search-bar.tsx
+++ b/frontend/src/components/subscriptions/search-bar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+
+type SearchBarProps = {
+  onChange: (value: string) => void;
+  placeholder?: string;
+  value: string;
+};
+
+export function SearchBar({
+  onChange,
+  placeholder = "Search subscriptions",
+  value,
+}: SearchBarProps) {
+  return (
+    <label className="relative flex items-center">
+      <Search className="pointer-events-none absolute left-4 size-4 text-black/38" />
+      <input
+        className="h-12 w-full rounded-full border border-black/10 bg-white/88 pl-11 pr-12 text-sm text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        type="search"
+        value={value}
+      />
+      {value ? (
+        <button
+          aria-label="Clear search"
+          className="absolute right-2 inline-flex size-8 items-center justify-center rounded-full text-black/45 transition hover:bg-stone hover:text-ink"
+          onClick={() => onChange("")}
+          type="button"
+        >
+          <X className="size-4" />
+        </button>
+      ) : null}
+    </label>
+  );
+}

--- a/frontend/src/hooks/use-debounce.ts
+++ b/frontend/src/hooks/use-debounce.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay = 250) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [delay, value]);
+
+  return debouncedValue;
+}

--- a/frontend/src/hooks/use-filters.ts
+++ b/frontend/src/hooks/use-filters.ts
@@ -1,0 +1,182 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { startTransition, useEffect, useState } from "react";
+
+import { useDebounce } from "@/hooks/use-debounce";
+import { subscriptionCadenceOptions, subscriptionStatusOptions } from "@/lib/validators";
+import type { SubscriptionCadence, SubscriptionFilters, SubscriptionStatus } from "@/types";
+
+export type SubscriptionFilterState = {
+  cadence: "all" | SubscriptionCadence;
+  categoryId: string;
+  maxAmount: string;
+  minAmount: string;
+  paymentMethodId: string;
+  search: string;
+  status: "all" | SubscriptionStatus;
+};
+
+type UseFiltersOptions = {
+  searchDelay?: number;
+};
+
+const defaultFilterState: SubscriptionFilterState = {
+  cadence: "all",
+  categoryId: "all",
+  maxAmount: "",
+  minAmount: "",
+  paymentMethodId: "all",
+  search: "",
+  status: "all",
+};
+
+function sanitizeAmount(value: string) {
+  const normalized = value.trim();
+  if (!normalized) {
+    return "";
+  }
+
+  const match = normalized.match(/^\d+(?:\.\d{0,2})?$/);
+  return match ? match[0] : "";
+}
+
+function parseSelectValue(value: string | null) {
+  if (!value || !/^\d+$/.test(value)) {
+    return "all";
+  }
+
+  return value;
+}
+
+function parseAmount(value: string) {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function readFilterState(searchParams: { get: (key: string) => string | null }) {
+  const status = searchParams.get("status");
+  const cadence = searchParams.get("cadence");
+
+  return {
+    cadence:
+      cadence && subscriptionCadenceOptions.includes(cadence as SubscriptionCadence)
+        ? (cadence as SubscriptionFilterState["cadence"])
+        : "all",
+    categoryId: parseSelectValue(searchParams.get("category_id")),
+    maxAmount: sanitizeAmount(searchParams.get("max_amount") ?? ""),
+    minAmount: sanitizeAmount(searchParams.get("min_amount") ?? ""),
+    paymentMethodId: parseSelectValue(searchParams.get("payment_method_id")),
+    search: searchParams.get("search") ?? "",
+    status:
+      status && subscriptionStatusOptions.includes(status as SubscriptionStatus)
+        ? (status as SubscriptionFilterState["status"])
+        : "all",
+  };
+}
+
+function areStatesEqual(left: SubscriptionFilterState, right: SubscriptionFilterState) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function useFilters(options: UseFiltersOptions = {}) {
+  const { searchDelay = 300 } = options;
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [filters, setFilters] = useState<SubscriptionFilterState>(() => readFilterState(searchParams));
+  const debouncedSearch = useDebounce(filters.search, searchDelay);
+
+  useEffect(() => {
+    const nextFilters = readFilterState(searchParams);
+    setFilters((current) => (areStatesEqual(current, nextFilters) ? current : nextFilters));
+  }, [searchParams]);
+
+  useEffect(() => {
+    const nextParams = new URLSearchParams(searchParams.toString());
+
+    const updates: Record<string, string | undefined> = {
+      cadence: filters.cadence === "all" ? undefined : filters.cadence,
+      category_id: filters.categoryId === "all" ? undefined : filters.categoryId,
+      max_amount: filters.maxAmount || undefined,
+      min_amount: filters.minAmount || undefined,
+      payment_method_id: filters.paymentMethodId === "all" ? undefined : filters.paymentMethodId,
+      search: debouncedSearch.trim() || undefined,
+      status: filters.status === "all" ? undefined : filters.status,
+    };
+
+    for (const [key, value] of Object.entries(updates)) {
+      if (value) {
+        nextParams.set(key, value);
+      } else {
+        nextParams.delete(key);
+      }
+    }
+
+    const nextQuery = nextParams.toString();
+    const currentQuery = searchParams.toString();
+    if (nextQuery === currentQuery) {
+      return;
+    }
+
+    startTransition(() => {
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+    });
+  }, [
+    debouncedSearch,
+    filters.cadence,
+    filters.categoryId,
+    filters.maxAmount,
+    filters.minAmount,
+    filters.paymentMethodId,
+    filters.status,
+    pathname,
+    router,
+    searchParams,
+  ]);
+
+  const queryFilters: SubscriptionFilters = {
+    cadence: filters.cadence === "all" ? undefined : filters.cadence,
+    category_id: filters.categoryId === "all" ? undefined : Number(filters.categoryId),
+    max_amount: parseAmount(filters.maxAmount),
+    min_amount: parseAmount(filters.minAmount),
+    payment_method_id:
+      filters.paymentMethodId === "all" ? undefined : Number(filters.paymentMethodId),
+    search: debouncedSearch.trim() || undefined,
+    status: filters.status === "all" ? undefined : filters.status,
+  };
+
+  const activeFilterCount = [
+    queryFilters.search,
+    queryFilters.status,
+    queryFilters.category_id,
+    queryFilters.payment_method_id,
+    queryFilters.cadence,
+    queryFilters.min_amount,
+    queryFilters.max_amount,
+  ].filter((value) => value !== undefined).length;
+
+  return {
+    activeFilterCount,
+    clearFilters: () => setFilters(defaultFilterState),
+    filters,
+    hasActiveFilters: activeFilterCount > 0,
+    queryFilters,
+    setCadence: (value: SubscriptionFilterState["cadence"]) =>
+      setFilters((current) => ({ ...current, cadence: value })),
+    setCategoryId: (value: string) => setFilters((current) => ({ ...current, categoryId: value })),
+    setMaxAmount: (value: string) =>
+      setFilters((current) => ({ ...current, maxAmount: sanitizeAmount(value) })),
+    setMinAmount: (value: string) =>
+      setFilters((current) => ({ ...current, minAmount: sanitizeAmount(value) })),
+    setPaymentMethodId: (value: string) =>
+      setFilters((current) => ({ ...current, paymentMethodId: value })),
+    setSearch: (value: string) => setFilters((current) => ({ ...current, search: value })),
+    setStatus: (value: SubscriptionFilterState["status"]) =>
+      setFilters((current) => ({ ...current, status: value })),
+  };
+}

--- a/frontend/src/hooks/use-subscriptions.ts
+++ b/frontend/src/hooks/use-subscriptions.ts
@@ -4,7 +4,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useAuth } from "@/hooks/use-auth";
 import { apiClient } from "@/lib/api-client";
-import type { SubscriptionFilters, SubscriptionUpsertInput } from "@/types";
+import type {
+  CategoryInput,
+  PaymentMethodInput,
+  SubscriptionFilters,
+  SubscriptionUpsertInput,
+} from "@/types";
 
 const subscriptionKeys = {
   categories: ["categories"] as const,
@@ -101,6 +106,108 @@ export function useDeleteSubscription(subscriptionId: number) {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
       queryClient.removeQueries({ queryKey: subscriptionKeys.detail(subscriptionId) });
+    },
+  });
+}
+
+export function useCreateCategory() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CategoryInput) => apiClient.createCategory(token, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.categories });
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+  });
+}
+
+export function useUpdateCategory() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      categoryId,
+      payload,
+    }: {
+      categoryId: number;
+      payload: CategoryInput;
+    }) => apiClient.updateCategory(token, categoryId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.categories });
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+  });
+}
+
+export function useDeleteCategory() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (categoryId: number) => apiClient.deleteCategory(token, categoryId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.categories });
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+  });
+}
+
+export function useCreatePaymentMethod() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: PaymentMethodInput) => apiClient.createPaymentMethod(token, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.paymentMethods });
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+  });
+}
+
+export function useUpdatePaymentMethod() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      paymentMethodId,
+      payload,
+    }: {
+      paymentMethodId: number;
+      payload: PaymentMethodInput;
+    }) => apiClient.updatePaymentMethod(token, paymentMethodId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.paymentMethods });
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+  });
+}
+
+export function useDeletePaymentMethod() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (paymentMethodId: number) => apiClient.deletePaymentMethod(token, paymentMethodId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.paymentMethods });
+      void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+  });
+}
+
+export function useDeleteWorkspaceData() {
+  const token = useRequiredToken();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => apiClient.deleteWorkspaceData(token),
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
     },
   });
 }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,12 +1,16 @@
 import { API_BASE_URL } from "@/lib/constants";
 import type {
   AuthResponse,
+  Category,
+  CategoryInput,
   CategoryListResponse,
   DashboardLayout,
   DashboardLayoutPayload,
   DashboardSummary,
   HealthResponse,
   LoginInput,
+  PaymentMethod,
+  PaymentMethodInput,
   PaymentMethodListResponse,
   RegisterInput,
   Subscription,
@@ -157,8 +161,42 @@ export const apiClient = {
   getCategories(token: string) {
     return request<CategoryListResponse>("/categories", undefined, { token });
   },
+  createCategory(token: string, payload: CategoryInput) {
+    return request<Category>("/categories", {
+      body: JSON.stringify(payload),
+      method: "POST",
+    }, { token });
+  },
+  updateCategory(token: string, categoryId: number, payload: CategoryInput) {
+    return request<Category>(`/categories/${categoryId}`, {
+      body: JSON.stringify(payload),
+      method: "PATCH",
+    }, { token });
+  },
+  deleteCategory(token: string, categoryId: number) {
+    return request<void>(`/categories/${categoryId}`, {
+      method: "DELETE",
+    }, { token });
+  },
   getPaymentMethods(token: string) {
     return request<PaymentMethodListResponse>("/payment-methods", undefined, { token });
+  },
+  createPaymentMethod(token: string, payload: PaymentMethodInput) {
+    return request<PaymentMethod>("/payment-methods", {
+      body: JSON.stringify(payload),
+      method: "POST",
+    }, { token });
+  },
+  updatePaymentMethod(token: string, paymentMethodId: number, payload: PaymentMethodInput) {
+    return request<PaymentMethod>(`/payment-methods/${paymentMethodId}`, {
+      body: JSON.stringify(payload),
+      method: "PATCH",
+    }, { token });
+  },
+  deletePaymentMethod(token: string, paymentMethodId: number) {
+    return request<void>(`/payment-methods/${paymentMethodId}`, {
+      method: "DELETE",
+    }, { token });
   },
   getDashboardSummary(token: string) {
     return request<DashboardSummary>("/dashboard/summary", undefined, { token });
@@ -211,6 +249,11 @@ export const apiClient = {
   },
   deleteUpload(token: string, uploadId: number) {
     return request<void>(`/uploads/${uploadId}`, {
+      method: "DELETE",
+    }, { token });
+  },
+  deleteWorkspaceData(token: string) {
+    return request<void>("/auth/me/data", {
       method: "DELETE",
     }, { token });
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -44,6 +44,11 @@ export type CategoryListResponse = {
   total: number;
 };
 
+export type CategoryInput = {
+  description?: string;
+  name: string;
+};
+
 export type PaymentMethod = {
   id: number;
   user_id: number | null;
@@ -58,6 +63,13 @@ export type PaymentMethod = {
 export type PaymentMethodListResponse = {
   items: PaymentMethod[];
   total: number;
+};
+
+export type PaymentMethodInput = {
+  is_default: boolean;
+  label: string;
+  last4?: string;
+  provider: string;
 };
 
 export type DashboardSummaryStats = {
@@ -185,8 +197,11 @@ export type SubscriptionListResponse = {
 };
 
 export type SubscriptionFilters = {
+  cadence?: string;
   category_id?: number;
   limit?: number;
+  max_amount?: number;
+  min_amount?: number;
   offset?: number;
   payment_method_id?: number;
   search?: string;

--- a/frontend/tests/unit/components/search-bar.test.tsx
+++ b/frontend/tests/unit/components/search-bar.test.tsx
@@ -1,0 +1,29 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SearchBar } from "@/components/subscriptions/search-bar";
+import { render, screen } from "../../../test-utils/render";
+
+describe("SearchBar", () => {
+  it("forwards typed values to the change handler", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<SearchBar onChange={onChange} value="" />);
+
+    await user.type(screen.getByRole("searchbox"), "net");
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("clears the current search value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<SearchBar onChange={onChange} value="Netflix" />);
+
+    await user.click(screen.getByRole("button", { name: "Clear search" }));
+
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+});

--- a/frontend/tests/unit/hooks/use-debounce.test.ts
+++ b/frontend/tests/unit/hooks/use-debounce.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDebounce } from "@/hooks/use-debounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("holds the previous value until the delay elapses", () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 200), {
+      initialProps: { value: "net" },
+    });
+
+    rerender({ value: "netflix" });
+
+    expect(result.current).toBe("net");
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe("netflix");
+  });
+});

--- a/frontend/tests/unit/hooks/use-filters.test.ts
+++ b/frontend/tests/unit/hooks/use-filters.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useFilters } from "@/hooks/use-filters";
+
+const replace = vi.fn();
+let currentSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/subscriptions",
+  useRouter: () => ({
+    replace,
+  }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+describe("useFilters", () => {
+  beforeEach(() => {
+    replace.mockReset();
+    currentSearchParams = new URLSearchParams();
+  });
+
+  it("reads the current URL state into filter values", () => {
+    currentSearchParams = new URLSearchParams(
+      "search=netflix&status=active&category_id=3&payment_method_id=7&cadence=monthly&min_amount=8&max_amount=25",
+    );
+
+    const { result } = renderHook(() => useFilters({ searchDelay: 0 }));
+
+    expect(result.current.filters.search).toBe("netflix");
+    expect(result.current.filters.status).toBe("active");
+    expect(result.current.filters.categoryId).toBe("3");
+    expect(result.current.filters.paymentMethodId).toBe("7");
+    expect(result.current.queryFilters.min_amount).toBe(8);
+    expect(result.current.queryFilters.max_amount).toBe(25);
+  });
+
+  it("syncs filter changes back into the URL", async () => {
+    const { result } = renderHook(() => useFilters({ searchDelay: 0 }));
+
+    act(() => {
+      result.current.setSearch("hulu");
+      result.current.setStatus("paused");
+      result.current.setCategoryId("4");
+      result.current.setPaymentMethodId("8");
+      result.current.setCadence("yearly");
+      result.current.setMinAmount("12");
+      result.current.setMaxAmount("42");
+    });
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenLastCalledWith(
+        "/subscriptions?cadence=yearly&category_id=4&max_amount=42&min_amount=12&payment_method_id=8&search=hulu&status=paused",
+        { scroll: false },
+      );
+    });
+  });
+});

--- a/frontend/tests/unit/lib/api-client.test.ts
+++ b/frontend/tests/unit/lib/api-client.test.ts
@@ -93,13 +93,18 @@ describe("apiClient", () => {
     );
 
     await apiClient.getSubscriptions("access-token", {
+      cadence: "monthly",
+      category_id: 3,
       limit: 25,
+      max_amount: 18,
+      min_amount: 10,
+      payment_method_id: 7,
       search: "netflix",
       status: "active",
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8000/api/v1/subscriptions?limit=25&search=netflix&status=active",
+      "http://localhost:8000/api/v1/subscriptions?cadence=monthly&category_id=3&limit=25&max_amount=18&min_amount=10&payment_method_id=7&search=netflix&status=active",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer access-token",


### PR DESCRIPTION
```markdown
## Day 12 — Backend CI Fixes

On Day 12 we hit two backend CI problems in the automation runs.

### Failure 1: Branch Build — FastAPI Query Parameter Import

The backend test job crashed while importing the subscriptions router because FastAPI rejected this pattern in `subscriptions.py` (line 24):

```python
Annotated[Decimal | None, Query(default=None)]
```

This caused `uv run pytest` to fail before most tests even ran.

### Failure 2: PR Merge Build — Dashboard Schema Mismatch

After fixing the first issue, **backend (push)** passed, but **backend (pull_request)** still failed. This turned out to be a merge-context issue, not the auth delete endpoint. In the PR merge build, `test_auth.py` (line 88) was sending a hardcoded 4-widget dashboard layout, while the merged schema on `main` requires 5 widgets including `active-subscriptions` (`dashboard.py`, line 7). The test received a `422` on `PUT /api/v1/dashboard/layout`.

---

### What We Did

- Reproduced the failing backend CI locally against the exact branch commit.
- Confirmed the first issue was the FastAPI query parameter declaration, then changed the query aliases to use `Query()` and kept the `= None` defaults on the function parameters.
- Re-ran `ruff`, `mypy`, and full `pytest` — all passed.
- Reproduced the failing `pull_request` job against the exact GitHub PR merge ref.
- Confirmed the second issue was a test/schema mismatch in the merged dashboard layout, not `/api/v1/auth/me/data`.
- Updated the auth cleanup test to fetch the current default dashboard layout from the API, reorder that real layout, and assert that workspace deletion restores the saved default.
- Re-ran tests in both contexts:
  - **Branch backend:** passed
  - **PR merge backend:** passed
- Pushed both fixes to `day-12/search-filter-settings`.

### What We Added / Changed

- Day 12 already added new subscription filtering/search work, including backend support for filters like `cadence`, `min_amount`, and `max_amount`.
- In the fix work, we added:
  - FastAPI-compatible query declarations for the new subscription filters.
  - A more robust cleanup test that adapts to the API's actual dashboard default instead of hardcoding widget lists.
- New fix commits pushed:
  - `a72246c` — `fix(day-12): make subscription query params FastAPI compatible`
  - `695bfe9` — `test(day-12): derive dashboard cleanup layout from API defaults`

### Net Result

The Day 12 backend automation issues were diagnosed as one router import bug and one PR-only test compatibility bug. Both were fixed and pushed.
```