### PR TITLE
Day 13/integration testing e2e

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,18 +15,33 @@ on:
 jobs:
   frontend:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
+      - run: uv sync --project backend --locked --group dev
       - run: npm ci
+        working-directory: frontend
+      - run: npx playwright install --with-deps chromium firefox webkit
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: /tmp/ms-playwright
       - run: npm run lint
+        working-directory: frontend
       - run: npm run typecheck
+        working-directory: frontend
       - run: npm run test
+        working-directory: frontend
       - run: npm run build
+        working-directory: frontend
+      - run: npm run test:e2e
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: /tmp/ms-playwright

--- a/backend/scripts/start_playwright_server.sh
+++ b/backend/scripts/start_playwright_server.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/backend/scripts/start_playwright_server.sh
+++ b/backend/scripts/start_playwright_server.sh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+BACKEND_DIR=$(cd "$(dirname "$0")/.." && pwd)
+DB_PATH=/tmp/mysubscription-playwright-e2e.db
+STORAGE_PATH=/tmp/mysubscription-playwright-storage
+
+cd "$BACKEND_DIR"
+
+rm -f "$DB_PATH"
+rm -rf "$STORAGE_PATH"
+
+export UV_CACHE_DIR=/tmp/uv-cache
+export DATABASE_URL="sqlite+aiosqlite:///$DB_PATH"
+export LOCAL_STORAGE_PATH="$STORAGE_PATH"
+export BACKEND_CORS_ORIGINS='["http://127.0.0.1:3000"]'
+export ACCESS_TOKEN_EXPIRE_MINUTES=120
+
+uv run python - <<'PY'
+import asyncio
+
+import src.models  # noqa: F401
+from src.core.database import engine
+from src.models.base import Base
+
+
+async def main() -> None:
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+
+asyncio.run(main())
+PY
+
+uv run uvicorn src.main:app --host 127.0.0.1 --port 8000

--- a/backend/scripts/start_playwright_server.sh
+++ b/backend/scripts/start_playwright_server.sh
@@ -16,6 +16,7 @@ export DATABASE_URL="sqlite+aiosqlite:///$DB_PATH"
 export LOCAL_STORAGE_PATH="$STORAGE_PATH"
 export BACKEND_CORS_ORIGINS='["http://127.0.0.1:3000"]'
 export ACCESS_TOKEN_EXPIRE_MINUTES=120
+export DISABLE_RATE_LIMITING=true
 
 uv run python - <<'PY'
 import asyncio

--- a/backend/src/api/routes/subscriptions.py
+++ b/backend/src/api/routes/subscriptions.py
@@ -24,8 +24,8 @@ from src.services.subscription import (
 router = APIRouter(prefix="/subscriptions", tags=["subscriptions"])
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
-MinAmountQuery = Annotated[Decimal | None, Query(default=None)]
-MaxAmountQuery = Annotated[Decimal | None, Query(default=None)]
+MinAmountQuery = Annotated[Decimal | None, Query()]
+MaxAmountQuery = Annotated[Decimal | None, Query()]
 
 
 @router.get("", response_model=SubscriptionListResponse, status_code=status.HTTP_200_OK)

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     email_backend: str = "console"
     email_from: str = "no-reply@mysubscription-tracker.local"
     app_base_url: str = "http://localhost:8000"
+    disable_rate_limiting: bool = False
     aws_region: str = "us-east-1"
     aws_bucket_name: str | None = None
     upload_job_backend: str = "inline"

--- a/backend/src/core/rate_limiter.py
+++ b/backend/src/core/rate_limiter.py
@@ -4,6 +4,8 @@ from time import monotonic
 
 from fastapi import HTTPException, Request, status
 
+from src.config import get_settings
+
 
 class InMemoryRateLimiter:
     def __init__(self) -> None:
@@ -34,6 +36,9 @@ rate_limiter = InMemoryRateLimiter()
 
 def rate_limit(bucket: str, *, limit: int = 5, window_seconds: int = 60) -> Callable[..., None]:
     def dependency(request: Request) -> None:
+        if get_settings().disable_rate_limiting:
+            return
+
         client_host = request.client.host if request.client else "anonymous"
         rate_limiter.check(
             f"{bucket}:{client_host}",

--- a/backend/tests/api/test_integration_flows.py
+++ b/backend/tests/api/test_integration_flows.py
@@ -1,0 +1,222 @@
+from datetime import timedelta
+
+from src.core.security import create_token
+
+
+def _auth_payload(client, email: str) -> dict[str, object]:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "full_name": "Integration Owner",
+            "password": "super-secret",
+        },
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def _auth_headers(payload: dict[str, object]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {payload['access_token']}"}
+
+
+def _build_pdf_statement(lines: list[str]) -> bytes:
+    def _escape(value: str) -> str:
+        return value.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+    stream = "BT\n/F1 12 Tf\n72 720 Td\n"
+    for index, line in enumerate(lines):
+        if index == 0:
+            stream += f"({_escape(line)}) Tj\n"
+        else:
+            stream += f"0 -18 Td ({_escape(line)}) Tj\n"
+    stream += "ET\n"
+
+    objects = [
+        "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+        (
+            "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n"
+        ),
+        "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+        (
+            f"5 0 obj\n<< /Length {len(stream.encode('latin1'))} >>\n"
+            f"stream\n{stream}endstream\nendobj\n"
+        ),
+    ]
+
+    content = "%PDF-1.4\n"
+    offsets: list[int] = []
+    for obj in objects:
+        offsets.append(len(content.encode("latin1")))
+        content += obj
+
+    xref_offset = len(content.encode("latin1"))
+    content += f"xref\n0 {len(objects) + 1}\n"
+    content += "0000000000 65535 f \n"
+    for offset in offsets:
+        content += f"{offset:010d} 00000 n \n"
+    content += (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    )
+    return content.encode("latin1")
+
+
+def test_backend_integration_flow_covers_auth_catalog_subscriptions_and_uploads(client) -> None:
+    auth_payload = _auth_payload(client, "integration@example.com")
+    headers = _auth_headers(auth_payload)
+
+    login_response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "integration@example.com", "password": "super-secret"},
+    )
+    assert login_response.status_code == 200
+
+    category_response = client.post(
+        "/api/v1/categories",
+        headers=headers,
+        json={"name": "Streaming", "description": "Recurring entertainment"},
+    )
+    assert category_response.status_code == 201
+    category_id = category_response.json()["id"]
+
+    payment_method_response = client.post(
+        "/api/v1/payment-methods",
+        headers=headers,
+        json={"label": "Primary Card", "provider": "Visa", "last4": "4242", "is_default": True},
+    )
+    assert payment_method_response.status_code == 201
+    payment_method_id = payment_method_response.json()["id"]
+
+    subscription_response = client.post(
+        "/api/v1/subscriptions",
+        headers=headers,
+        json={
+            "name": "Netflix Family",
+            "vendor": "Netflix",
+            "amount": "15.49",
+            "currency": "USD",
+            "cadence": "monthly",
+            "status": "active",
+            "start_date": "2026-01-01",
+            "next_charge_date": "2026-02-01",
+            "category_id": category_id,
+            "payment_method_id": payment_method_id,
+            "website_url": "https://www.netflix.com",
+            "notes": "Integration flow coverage",
+        },
+    )
+    assert subscription_response.status_code == 201
+    created_subscription = subscription_response.json()
+
+    filtered_response = client.get(
+        "/api/v1/subscriptions",
+        headers=headers,
+        params={
+            "search": "netflix",
+            "status": "active",
+            "payment_method_id": payment_method_id,
+            "min_amount": "10.00",
+            "max_amount": "20.00",
+        },
+    )
+    assert filtered_response.status_code == 200
+    assert filtered_response.json()["items"][0]["id"] == created_subscription["id"]
+
+    csv_upload_response = client.post(
+        "/api/v1/uploads",
+        headers=headers,
+        files={
+            "file": (
+                "hulu.csv",
+                (
+                    "Posting Date,Details,Amount\n"
+                    "01/01/2026,HULU,-8.99\n"
+                    "02/01/2026,HULU,-8.99\n"
+                    "03/01/2026,HULU,-8.99\n"
+                ),
+                "text/csv",
+            )
+        },
+    )
+    assert csv_upload_response.status_code == 201
+
+    pdf_upload_response = client.post(
+        "/api/v1/uploads",
+        headers=headers,
+        files={
+            "file": (
+                "netflix.pdf",
+                _build_pdf_statement(
+                    [
+                        "CHASE STATEMENT 2026",
+                        "04/01 NETFLIX 15.49",
+                        "05/01 NETFLIX 15.49",
+                        "06/01 NETFLIX 15.49",
+                    ]
+                ),
+                "application/pdf",
+            )
+        },
+    )
+    assert pdf_upload_response.status_code == 201
+
+    uploads_response = client.get("/api/v1/uploads", headers=headers)
+    assert uploads_response.status_code == 200
+    assert uploads_response.json()["total"] == 2
+    assert {item["status"] for item in uploads_response.json()["items"]} == {"completed"}
+
+    subscriptions_after_uploads = client.get("/api/v1/subscriptions", headers=headers)
+    assert subscriptions_after_uploads.status_code == 200
+    names = {item["name"] for item in subscriptions_after_uploads.json()["items"]}
+    assert {"Netflix Family", "Hulu"} <= names
+
+    update_category_response = client.patch(
+        f"/api/v1/categories/{category_id}",
+        headers=headers,
+        json={"name": "Streaming Services", "description": "Updated label"},
+    )
+    assert update_category_response.status_code == 200
+
+    update_payment_method_response = client.patch(
+        f"/api/v1/payment-methods/{payment_method_id}",
+        headers=headers,
+        json={"label": "Updated Card", "provider": "Visa", "last4": "1111", "is_default": True},
+    )
+    assert update_payment_method_response.status_code == 200
+
+    delete_subscription_response = client.delete(
+        f"/api/v1/subscriptions/{created_subscription['id']}",
+        headers=headers,
+    )
+    assert delete_subscription_response.status_code == 204
+
+
+def test_expired_access_tokens_are_rejected_and_refresh_requires_refresh_tokens(client) -> None:
+    auth_payload = _auth_payload(client, "expired-flow@example.com")
+    headers = _auth_headers(auth_payload)
+
+    expired_access_token, _ = create_token(
+        subject=str(auth_payload["user"]["id"]),
+        token_type="access",
+        expires_delta=timedelta(seconds=-1),
+    )
+
+    me_response = client.get(
+        "/api/v1/auth/me",
+        headers={"Authorization": f"Bearer {expired_access_token}"},
+    )
+    assert me_response.status_code == 401
+    assert me_response.json()["detail"] == "Invalid or expired token."
+
+    wrong_refresh_response = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": auth_payload["access_token"]},
+    )
+    assert wrong_refresh_response.status_code == 401
+    assert wrong_refresh_response.json()["detail"] == "Refresh token required."
+
+    delete_response = client.delete("/api/v1/auth/me/data", headers=headers)
+    assert delete_response.status_code == 204

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,10 +1,15 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import { AUTH_STATE_PATH } from "./tests/e2e/support/session";
+
 export default defineConfig({
+  globalSetup: "./tests/e2e/global-setup.ts",
   testDir: "./tests/e2e",
   timeout: 30_000,
+  workers: 1,
   use: {
     baseURL: "http://127.0.0.1:3000",
+    storageState: AUTH_STATE_PATH,
     trace: "on-first-retry",
   },
   projects: [
@@ -25,9 +30,17 @@ export default defineConfig({
       use: { ...devices["Pixel 7"] },
     },
   ],
-  webServer: {
-    command: "npm run dev",
-    url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: [
+    {
+      command: "zsh ../backend/scripts/start_playwright_server.sh",
+      url: "http://127.0.0.1:8000/api/v1/health",
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command:
+        "NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000/api/v1 npm run start -- --hostname 127.0.0.1 --port 3000",
+      url: "http://127.0.0.1:3000",
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: "zsh ../backend/scripts/start_playwright_server.sh",
+      command: "bash ../backend/scripts/start_playwright_server.sh",
       url: "http://127.0.0.1:8000/api/v1/health",
       reuseExistingServer: !process.env.CI,
     },

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -575,7 +575,7 @@ export default function SettingsPage() {
                 Toggle the shell between light and dark modes without leaving the workspace.
               </p>
               <div className="mt-4">
-                <ThemeToggle />
+                <ThemeToggle testId="settings-theme-toggle" />
               </div>
             </div>
 

--- a/frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx
@@ -281,6 +281,7 @@ export default function SubscriptionDetailPage() {
               }}
               paymentMethods={paymentMethods}
               submitLabel="Save changes"
+              testId="subscription-edit-form"
               title="Edit subscription"
             />
           ) : null}

--- a/frontend/src/app/(app)/subscriptions/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/page.tsx
@@ -273,6 +273,7 @@ export default function SubscriptionsPage() {
           }}
           paymentMethods={paymentMethods}
           submitLabel="Save subscription"
+          testId="subscription-create-form"
           title="Add a subscription"
         />
       </div>

--- a/frontend/src/app/(app)/uploads/page.tsx
+++ b/frontend/src/app/(app)/uploads/page.tsx
@@ -61,8 +61,7 @@ export default function UploadsPage() {
       return;
     }
 
-    const stillExists = selectedUploadId !== null && uploads.some((upload) => upload.id === selectedUploadId);
-    if (!stillExists) {
+    if (selectedUploadId === null) {
       startTransition(() => {
         setSelectedUploadId(uploads[0]?.id ?? null);
       });

--- a/frontend/src/components/app-shell/app-shell.tsx
+++ b/frontend/src/components/app-shell/app-shell.tsx
@@ -254,7 +254,10 @@ export function AppShell({ children }: AppShellProps) {
                 <p className="text-xs uppercase tracking-[0.32em] text-black/45">
                   {currentNavItem.label}
                 </p>
-                <h1 className="mt-1 truncate text-2xl font-semibold text-ink sm:text-3xl">
+                <h1
+                  className="mt-1 truncate text-2xl font-semibold text-ink sm:text-3xl"
+                  data-testid="app-shell-route-title"
+                >
                   {meta.title}
                 </h1>
               </div>

--- a/frontend/src/components/auth/protected-route.tsx
+++ b/frontend/src/components/auth/protected-route.tsx
@@ -10,21 +10,25 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 export function ProtectedRoute({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isReady } = useAuth();
 
   useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
     if (!isAuthenticated) {
       const nextPath = pathname ? `?next=${encodeURIComponent(pathname)}` : "";
       router.replace(`/login${nextPath}`);
     }
-  }, [isAuthenticated, pathname, router]);
+  }, [isAuthenticated, isReady, pathname, router]);
 
-  if (!isAuthenticated) {
+  if (!isReady || !isAuthenticated) {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
-        <LoadingSpinner label="Checking session" size="lg" />
+        <LoadingSpinner label={isReady ? "Checking session" : "Restoring session"} size="lg" />
         <p className="text-xs uppercase tracking-[0.28em] text-black/45">
-          Redirecting to secure sign-in
+          {isReady ? "Redirecting to secure sign-in" : "Restoring secure workspace"}
         </p>
       </div>
     );

--- a/frontend/src/components/providers/auth-provider.tsx
+++ b/frontend/src/components/providers/auth-provider.tsx
@@ -3,12 +3,14 @@
 import type { ReactNode } from "react";
 import { createContext, useEffect, useState } from "react";
 
+import { AUTH_STORAGE_KEY } from "@/lib/constants";
 import { apiClient } from "@/lib/api-client";
 import type { AuthResponse, LoginInput, RegisterInput, User } from "@/types";
 
 type AuthContextValue = {
   accessToken: string | null;
   isAuthenticated: boolean;
+  isReady: boolean;
   isRefreshing: boolean;
   login: (input: LoginInput) => Promise<void>;
   logout: () => void;
@@ -18,6 +20,46 @@ type AuthContextValue = {
 };
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
+
+function isAuthResponse(value: unknown): value is AuthResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const session = value as Partial<AuthResponse>;
+  return (
+    typeof session.access_token === "string" &&
+    typeof session.refresh_token === "string" &&
+    typeof session.token_type === "string" &&
+    typeof session.access_token_expires_at === "string" &&
+    typeof session.refresh_token_expires_at === "string" &&
+    Boolean(session.user) &&
+    typeof session.user?.email === "string"
+  );
+}
+
+function readStoredSession() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const stored = window.localStorage.getItem(AUTH_STORAGE_KEY);
+  if (!stored) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(stored) as unknown;
+    if (isAuthResponse(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to clearing the malformed session payload.
+  }
+
+  window.localStorage.removeItem(AUTH_STORAGE_KEY);
+  return null;
+}
 
 function getRefreshDelay(expiresAt: string): number {
   const remainingMs = new Date(expiresAt).getTime() - Date.now();
@@ -31,6 +73,7 @@ function getRefreshDelay(expiresAt: string): number {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<AuthResponse | null>(null);
+  const [isReady, setIsReady] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const applySession = (nextSession: AuthResponse) => {
@@ -42,6 +85,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
+    setSession(readStoredSession());
+    setIsReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isReady || typeof window === "undefined") {
+      return;
+    }
+
+    if (session) {
+      window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(session));
+      return;
+    }
+
+    window.localStorage.removeItem(AUTH_STORAGE_KEY);
+  }, [isReady, session]);
+
+  useEffect(() => {
+    if (!isReady) {
+      return undefined;
+    }
+
     if (!session?.refresh_token) {
       return undefined;
     }
@@ -63,11 +128,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [session]);
+  }, [isReady, session]);
 
   const value: AuthContextValue = {
     accessToken: session?.access_token ?? null,
     isAuthenticated: Boolean(session?.access_token),
+    isReady,
     isRefreshing,
     login: async (input: LoginInput) => {
       const nextSession = await apiClient.login(input);

--- a/frontend/src/components/subscriptions/subscription-form.tsx
+++ b/frontend/src/components/subscriptions/subscription-form.tsx
@@ -25,6 +25,7 @@ type SubscriptionFormProps = {
   onSubmit: (payload: SubscriptionUpsertInput) => Promise<void>;
   paymentMethods: PaymentMethod[];
   submitLabel: string;
+  testId?: string;
   title: string;
 };
 
@@ -45,6 +46,7 @@ export function SubscriptionForm({
   onSubmit,
   paymentMethods,
   submitLabel,
+  testId,
   title,
 }: SubscriptionFormProps) {
   const {
@@ -75,6 +77,7 @@ export function SubscriptionForm({
 
       <form
         className="space-y-6 pt-6"
+        data-testid={testId}
         onSubmit={handleSubmit(async (values) => {
           await onSubmit(toSubscriptionPayload(values));
           if (!initialSubscription) {

--- a/frontend/src/components/ui/theme-toggle.tsx
+++ b/frontend/src/components/ui/theme-toggle.tsx
@@ -9,9 +9,10 @@ import { cn } from "@/lib/utils";
 type ThemeToggleProps = {
   className?: string;
   compact?: boolean;
+  testId?: string;
 };
 
-export function ThemeToggle({ className, compact = false }: ThemeToggleProps) {
+export function ThemeToggle({ className, compact = false, testId }: ThemeToggleProps) {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
@@ -31,6 +32,7 @@ export function ThemeToggle({ className, compact = false }: ThemeToggleProps) {
         compact && "w-11 px-0",
         className,
       )}
+      data-testid={testId}
       onClick={() => setTheme(nextTheme)}
       title={label}
       type="button"

--- a/frontend/src/components/uploads/upload-history-list.tsx
+++ b/frontend/src/components/uploads/upload-history-list.tsx
@@ -77,6 +77,7 @@ export function UploadHistoryList({
                 "group grid w-full gap-4 px-5 py-4 text-left transition sm:px-6",
                 isSelected ? "bg-[#f7f0e7]" : "hover:bg-black/[0.025]",
               )}
+              data-upload-file-name={upload.file_name}
               key={upload.id}
               onClick={() => onSelect(upload.id)}
               type="button"

--- a/frontend/src/components/uploads/upload-processing-panel.tsx
+++ b/frontend/src/components/uploads/upload-processing-panel.tsx
@@ -130,7 +130,13 @@ export function UploadProcessingPanel({ upload, visualStep }: UploadProcessingPa
           <p className="text-xs uppercase tracking-[0.32em] text-white/45">Queue notes</p>
           <div className="space-y-3 text-sm leading-6 text-white/72">
             <p>
-              Current backend status: <span className="font-semibold capitalize text-white">{upload.status}</span>
+              Current backend status:{" "}
+              <span
+                className="font-semibold capitalize text-white"
+                data-testid="upload-current-status"
+              >
+                {upload.status}
+              </span>
             </p>
             <p>
               Last sync: <span className="text-white">{formatTimestamp(upload.last_synced_at)}</span>

--- a/frontend/src/components/uploads/upload-processing-panel.tsx
+++ b/frontend/src/components/uploads/upload-processing-panel.tsx
@@ -61,7 +61,9 @@ export function UploadProcessingPanel({ upload, visualStep }: UploadProcessingPa
           <ServiceLogo provider={upload.provider} size="lg" />
           <div className="space-y-2">
             <p className="text-xs uppercase tracking-[0.32em] text-white/45">Selected file</p>
-            <h3 className="text-2xl font-semibold">{upload.file_name}</h3>
+            <h3 className="text-2xl font-semibold" data-testid="upload-selected-file-name">
+              {upload.file_name}
+            </h3>
             <p className="text-sm text-white/62">{formatProvider(upload.provider)}</p>
           </div>
         </div>

--- a/frontend/src/hooks/use-filters.ts
+++ b/frontend/src/hooks/use-filters.ts
@@ -90,6 +90,7 @@ export function useFilters(options: UseFiltersOptions = {}) {
   const searchParams = useSearchParams();
   const [filters, setFilters] = useState<SubscriptionFilterState>(() => readFilterState(searchParams));
   const debouncedSearch = useDebounce(filters.search, searchDelay);
+  const effectiveSearch = filters.search.trim() ? debouncedSearch.trim() : "";
 
   useEffect(() => {
     const nextFilters = readFilterState(searchParams);
@@ -105,7 +106,7 @@ export function useFilters(options: UseFiltersOptions = {}) {
       max_amount: filters.maxAmount || undefined,
       min_amount: filters.minAmount || undefined,
       payment_method_id: filters.paymentMethodId === "all" ? undefined : filters.paymentMethodId,
-      search: debouncedSearch.trim() || undefined,
+      search: effectiveSearch || undefined,
       status: filters.status === "all" ? undefined : filters.status,
     };
 
@@ -127,7 +128,7 @@ export function useFilters(options: UseFiltersOptions = {}) {
       router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
     });
   }, [
-    debouncedSearch,
+    effectiveSearch,
     filters.cadence,
     filters.categoryId,
     filters.maxAmount,
@@ -146,7 +147,7 @@ export function useFilters(options: UseFiltersOptions = {}) {
     min_amount: parseAmount(filters.minAmount),
     payment_method_id:
       filters.paymentMethodId === "all" ? undefined : Number(filters.paymentMethodId),
-    search: debouncedSearch.trim() || undefined,
+    search: effectiveSearch || undefined,
     status: filters.status === "all" ? undefined : filters.status,
   };
 

--- a/frontend/src/hooks/use-filters.ts
+++ b/frontend/src/hooks/use-filters.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { startTransition, useEffect, useState } from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 
 import { useDebounce } from "@/hooks/use-debounce";
 import { subscriptionCadenceOptions, subscriptionStatusOptions } from "@/lib/validators";
@@ -83,18 +83,63 @@ function areStatesEqual(left: SubscriptionFilterState, right: SubscriptionFilter
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function mergePendingFilterState(
+  current: SubscriptionFilterState,
+  next: SubscriptionFilterState,
+  pendingQueries: string[],
+) {
+  if (pendingQueries.length === 0) {
+    return next;
+  }
+
+  const pendingStates = pendingQueries.map((query) => readFilterState(new URLSearchParams(query)));
+
+  const shouldPreserveValue = <Key extends keyof SubscriptionFilterState>(key: Key) =>
+    current[key] !== defaultFilterState[key] &&
+    next[key] === defaultFilterState[key] &&
+    pendingStates.some((state) => state[key] === current[key]);
+
+  return {
+    cadence: shouldPreserveValue("cadence") ? current.cadence : next.cadence,
+    categoryId: shouldPreserveValue("categoryId") ? current.categoryId : next.categoryId,
+    maxAmount: shouldPreserveValue("maxAmount") ? current.maxAmount : next.maxAmount,
+    minAmount: shouldPreserveValue("minAmount") ? current.minAmount : next.minAmount,
+    paymentMethodId: shouldPreserveValue("paymentMethodId")
+      ? current.paymentMethodId
+      : next.paymentMethodId,
+    search: shouldPreserveValue("search") ? current.search : next.search,
+    status: shouldPreserveValue("status") ? current.status : next.status,
+  };
+}
+
 export function useFilters(options: UseFiltersOptions = {}) {
   const { searchDelay = 300 } = options;
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
   const [filters, setFilters] = useState<SubscriptionFilterState>(() => readFilterState(searchParams));
+  const pendingQuerySyncsRef = useRef<string[]>([]);
   const debouncedSearch = useDebounce(filters.search, searchDelay);
   const effectiveSearch = filters.search.trim() ? debouncedSearch.trim() : "";
 
   useEffect(() => {
+    const currentQuery = searchParams.toString();
+    const pendingIndex = pendingQuerySyncsRef.current.indexOf(currentQuery);
+
+    if (pendingIndex !== -1) {
+      pendingQuerySyncsRef.current = pendingQuerySyncsRef.current.slice(pendingIndex + 1);
+      return;
+    }
+
     const nextFilters = readFilterState(searchParams);
-    setFilters((current) => (areStatesEqual(current, nextFilters) ? current : nextFilters));
+    setFilters((current) => {
+      const mergedFilters = mergePendingFilterState(
+        current,
+        nextFilters,
+        pendingQuerySyncsRef.current,
+      );
+      return areStatesEqual(current, mergedFilters) ? current : mergedFilters;
+    });
   }, [searchParams]);
 
   useEffect(() => {
@@ -122,6 +167,10 @@ export function useFilters(options: UseFiltersOptions = {}) {
     const currentQuery = searchParams.toString();
     if (nextQuery === currentQuery) {
       return;
+    }
+
+    if (pendingQuerySyncsRef.current.at(-1) !== nextQuery) {
+      pendingQuerySyncsRef.current.push(nextQuery);
     }
 
     startTransition(() => {

--- a/frontend/src/hooks/use-uploads.ts
+++ b/frontend/src/hooks/use-uploads.ts
@@ -28,6 +28,8 @@ export function useUploadHistory() {
     enabled: Boolean(accessToken),
     queryFn: () => apiClient.getUploads(accessToken!),
     queryKey: uploadKeys.history,
+    refetchIntervalInBackground: true,
+    refetchOnMount: "always",
     refetchInterval: (query) => {
       const items = query.state.data?.items ?? [];
       return items.some((item) => item.status === "queued" || item.status === "processing")
@@ -44,6 +46,8 @@ export function useUploadStatus(uploadId: number | null) {
     enabled: Boolean(accessToken) && uploadId !== null,
     queryFn: () => apiClient.getUploadStatus(accessToken!, uploadId!),
     queryKey: uploadId === null ? ["uploads", "status", "idle"] : uploadKeys.status(uploadId),
+    refetchIntervalInBackground: true,
+    refetchOnMount: "always",
     refetchInterval: (query) => {
       const upload = query.state.data;
       return upload?.status === "queued" || upload?.status === "processing" ? 1_250 : false;
@@ -60,6 +64,7 @@ export function useCreateUpload() {
       apiClient.uploadFile(token, file, onProgress),
     onSuccess: (upload) => {
       queryClient.setQueryData(uploadKeys.status(upload.id), upload);
+      void queryClient.invalidateQueries({ queryKey: uploadKeys.status(upload.id) });
       void queryClient.invalidateQueries({ queryKey: uploadKeys.history });
     },
   });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,2 +1,3 @@
 export const APP_NAME = "MySubscription Tracker";
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
+export const AUTH_STORAGE_KEY = "mysubscription.auth";

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -16,7 +16,7 @@ test("registers, logs in, and logs out through the UI", async ({ page }) => {
   await page.getByRole("button", { name: "Create account" }).click();
 
   await expect(page).toHaveURL(/\/dashboard$/);
-  await expect(page.getByRole("heading", { name: "Smart dashboard snapshot" })).toBeVisible();
+  await expect(page.getByTestId("app-shell-route-title")).toBeVisible();
 
   await page.locator("button[aria-haspopup='menu']").click();
   await page.getByRole("menuitem", { name: "Sign out" }).click();
@@ -59,7 +59,7 @@ test("refreshes the session before expiry", async ({ page, request }) => {
   });
 
   await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
-  await expect(page.getByRole("heading", { name: "Smart dashboard snapshot" })).toBeVisible();
+  await expect(page.getByTestId("app-shell-route-title")).toBeVisible();
 
   await expect
     .poll(

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+import { AUTH_STORAGE_KEY } from "../../src/lib/constants";
+import { registerTestUser, seedSession, uniqueEmail } from "./support/session";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("registers, logs in, and logs out through the UI", async ({ page }) => {
+  const email = uniqueEmail("auth-ui");
+  const password = "super-secret";
+
+  await page.goto("/register");
+  await page.getByLabel("Full name").fill("Taylor Tester");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Create account" }).click();
+
+  await expect(page).toHaveURL(/\/dashboard$/);
+  await expect(page.getByRole("heading", { name: "Smart dashboard snapshot" })).toBeVisible();
+
+  await page.locator("button[aria-haspopup='menu']").click();
+  await page.getByRole("menuitem", { name: "Sign out" }).click();
+  await page.getByRole("button", { name: "Sign out" }).click();
+
+  await expect(page).toHaveURL(/\/login/);
+
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  await expect(page).toHaveURL(/\/dashboard$/);
+});
+
+test("shows an error for invalid credentials", async ({ page, request }) => {
+  const email = uniqueEmail("invalid-login");
+
+  await registerTestUser(request, {
+    email,
+    fullName: "Invalid Login User",
+  });
+
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill("wrong-password");
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  await expect(page.getByText("The email or password did not match an active account.")).toBeVisible();
+});
+
+test("refreshes the session before expiry", async ({ page, request }) => {
+  const { session } = await registerTestUser(request, {
+    email: uniqueEmail("refresh"),
+    fullName: "Refresh User",
+  });
+
+  await seedSession(page, {
+    ...session,
+    access_token_expires_at: new Date(Date.now() + 1_500).toISOString(),
+  });
+
+  const refreshResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/auth/refresh") &&
+      response.request().method() === "POST" &&
+      response.ok(),
+  );
+
+  await page.goto("/dashboard");
+  await refreshResponse;
+
+  const storedSession = await page.evaluate((key) => {
+    const value = window.localStorage.getItem(key);
+    return value ? (JSON.parse(value) as { access_token: string }) : null;
+  }, AUTH_STORAGE_KEY);
+
+  expect(storedSession?.access_token).not.toBe(session.access_token);
+  await expect(page).toHaveURL(/\/dashboard$/);
+});
+
+test("redirects to login when refresh fails", async ({ page, request }) => {
+  const { session } = await registerTestUser(request, {
+    email: uniqueEmail("expired"),
+    fullName: "Expired Session User",
+  });
+
+  await seedSession(page, {
+    ...session,
+    access_token_expires_at: new Date(Date.now() + 1_500).toISOString(),
+    refresh_token: "invalid-refresh-token",
+  });
+
+  await page.goto("/dashboard");
+
+  await expect(page).toHaveURL(/\/login\?next=%2Fdashboard/);
+});

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -58,22 +58,23 @@ test("refreshes the session before expiry", async ({ page, request }) => {
     access_token_expires_at: new Date(Date.now() + 1_500).toISOString(),
   });
 
-  const refreshResponse = page.waitForResponse(
-    (response) =>
-      response.url().endsWith("/auth/refresh") &&
-      response.request().method() === "POST" &&
-      response.ok(),
-  );
+  await page.goto("/dashboard", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: "Smart dashboard snapshot" })).toBeVisible();
 
-  await page.goto("/dashboard");
-  await refreshResponse;
+  await expect
+    .poll(
+      async () =>
+        page.evaluate((key) => {
+          const value = window.localStorage.getItem(key);
+          return value ? (JSON.parse(value) as { access_token: string }).access_token : null;
+        }, AUTH_STORAGE_KEY),
+      {
+        message: "Expected the auth provider to refresh the access token before expiry.",
+        timeout: 15_000,
+      },
+    )
+    .not.toBe(session.access_token);
 
-  const storedSession = await page.evaluate((key) => {
-    const value = window.localStorage.getItem(key);
-    return value ? (JSON.parse(value) as { access_token: string }) : null;
-  }, AUTH_STORAGE_KEY);
-
-  expect(storedSession?.access_token).not.toBe(session.access_token);
   await expect(page).toHaveURL(/\/dashboard$/);
 });
 

--- a/frontend/tests/e2e/dashboard.spec.ts
+++ b/frontend/tests/e2e/dashboard.spec.ts
@@ -35,7 +35,7 @@ test("renders the dashboard with its widget structure", async ({ page, request }
 
   await page.goto("/dashboard");
 
-  await expect(page.getByRole("heading", { name: "Smart dashboard snapshot" })).toBeVisible();
+  await expect(page.getByTestId("app-shell-route-title")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Monthly spend" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Category breakdown" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Upcoming renewals" })).toBeVisible();

--- a/frontend/tests/e2e/dashboard.spec.ts
+++ b/frontend/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createCategory,
+  createPaymentMethod,
+  createSubscription,
+  resetWorkspace,
+  uniqueLabel,
+} from "./support/session";
+
+test.beforeEach(async ({ request }) => {
+  await resetWorkspace(request);
+});
+
+test("renders the dashboard with its widget structure", async ({ page, request }) => {
+  const categoryId = await createCategory(request, uniqueLabel("Entertainment"));
+  const paymentMethodId = await createPaymentMethod(request, uniqueLabel("Visa"));
+
+  await createSubscription(request, {
+    amount: "15.49",
+    category_id: categoryId,
+    name: "Netflix",
+    next_charge_date: "2026-02-01",
+    payment_method_id: paymentMethodId,
+    start_date: "2026-01-01",
+  });
+  await createSubscription(request, {
+    amount: "8.99",
+    category_id: categoryId,
+    name: "Hulu",
+    next_charge_date: "2026-02-05",
+    payment_method_id: paymentMethodId,
+    start_date: "2026-01-05",
+  });
+
+  await page.goto("/dashboard");
+
+  await expect(page.getByRole("heading", { name: "Smart dashboard snapshot" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Monthly spend" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Category breakdown" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Upcoming renewals" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Recently ended" })).toBeVisible();
+});

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -1,0 +1,33 @@
+import { chromium, request } from "@playwright/test";
+
+import {
+  AUTH_STATE_PATH,
+  ensureAuthArtifactDir,
+  FRONTEND_BASE_URL,
+  registerTestUser,
+  saveSessionArtifact,
+  seedSession,
+} from "./support/session";
+
+export default async function globalSetup() {
+  ensureAuthArtifactDir();
+
+  const apiContext = await request.newContext();
+  const { session } = await registerTestUser(apiContext, {
+    email: "playwright.runner@example.com",
+    fullName: "Playwright Runner",
+  }).catch(async () => {
+    return registerTestUser(apiContext);
+  });
+  saveSessionArtifact(session);
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  await seedSession(page, session);
+  await page.goto(`${FRONTEND_BASE_URL}/dashboard`);
+  await page.context().storageState({ path: AUTH_STATE_PATH });
+
+  await browser.close();
+  await apiContext.dispose();
+}

--- a/frontend/tests/e2e/search-filter.spec.ts
+++ b/frontend/tests/e2e/search-filter.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createCategory,
+  createPaymentMethod,
+  createSubscription,
+  resetWorkspace,
+  uniqueLabel,
+} from "./support/session";
+
+test.beforeEach(async ({ request }) => {
+  await resetWorkspace(request);
+});
+
+test("searches and filters subscriptions from the list surface", async ({ page, request }) => {
+  const streamingCategoryId = await createCategory(request, uniqueLabel("Streaming"));
+  const workCategoryId = await createCategory(request, uniqueLabel("Work"));
+  const primaryCardId = await createPaymentMethod(request, uniqueLabel("Primary Card"));
+  const backupCardId = await createPaymentMethod(request, uniqueLabel("Backup Card"));
+
+  await createSubscription(request, {
+    amount: "15.49",
+    category_id: streamingCategoryId,
+    name: "Netflix Family",
+    payment_method_id: primaryCardId,
+    start_date: "2026-01-01",
+    status: "active",
+  });
+  await createSubscription(request, {
+    amount: "8.99",
+    category_id: streamingCategoryId,
+    name: "Hulu Basic",
+    payment_method_id: backupCardId,
+    start_date: "2026-01-05",
+    status: "paused",
+  });
+  await createSubscription(request, {
+    amount: "12.00",
+    category_id: workCategoryId,
+    cadence: "yearly",
+    name: "Notion Pro",
+    payment_method_id: primaryCardId,
+    start_date: "2026-01-10",
+    status: "active",
+  });
+
+  await page.goto("/subscriptions");
+
+  await page.getByPlaceholder("Search plans, vendors, notes").fill("netflix");
+  await expect(page).toHaveURL(/search=netflix/);
+  await expect(page.getByRole("heading", { name: "Netflix Family" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Hulu Basic" })).not.toBeVisible();
+
+  await page.getByLabel("Filter by status").selectOption("paused");
+  await expect(page).toHaveURL(/status=paused/);
+  await expect(page.getByRole("heading", { name: "Netflix Family" })).not.toBeVisible();
+
+  await page.getByRole("button", { name: "Reset all" }).click();
+  await page.getByLabel("Filter by cadence").selectOption("yearly");
+  await expect(page).toHaveURL(/cadence=yearly/);
+  await expect(page.getByRole("heading", { name: "Notion Pro" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Reset all" }).click();
+  await page.getByLabel("Minimum monthly amount").fill("14");
+  await page.getByLabel("Maximum monthly amount").fill("16");
+  await expect(page).toHaveURL(/min_amount=14/);
+  await expect(page.getByRole("heading", { name: "Netflix Family" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Hulu Basic" })).not.toBeVisible();
+});

--- a/frontend/tests/e2e/search-filter.spec.ts
+++ b/frontend/tests/e2e/search-filter.spec.ts
@@ -64,8 +64,10 @@ test("searches and filters subscriptions from the list surface", async ({ page, 
 
   await page.getByRole("button", { name: "Reset all" }).click();
   await page.getByLabel("Minimum monthly amount").fill("14");
+  await expect(page).toHaveURL(/min_amount=14/);
   await page.getByLabel("Maximum monthly amount").fill("16");
   await expect(page).toHaveURL(/min_amount=14/);
+  await expect(page).toHaveURL(/max_amount=16/);
   await expect(page.getByRole("heading", { name: "Netflix Family" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Hulu Basic" })).not.toBeVisible();
 });

--- a/frontend/tests/e2e/search-filter.spec.ts
+++ b/frontend/tests/e2e/search-filter.spec.ts
@@ -56,6 +56,8 @@ test("searches and filters subscriptions from the list surface", async ({ page, 
   await expect(page.getByRole("heading", { name: "Netflix Family" })).not.toBeVisible();
 
   await page.getByRole("button", { name: "Reset all" }).click();
+  await expect(page).not.toHaveURL(/search=/);
+  await expect(page).not.toHaveURL(/status=/);
   await page.getByLabel("Filter by cadence").selectOption("yearly");
   await expect(page).toHaveURL(/cadence=yearly/);
   await expect(page.getByRole("heading", { name: "Notion Pro" })).toBeVisible();

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+import { resetWorkspace, uniqueLabel } from "./support/session";
+
+test.beforeEach(async ({ request }) => {
+  await resetWorkspace(request);
+});
+
+test("adds a category and changes the theme", async ({ page }) => {
+  const categoryName = uniqueLabel("Utilities");
+
+  await page.goto("/settings");
+  await page.getByPlaceholder("Add a category name").fill(categoryName);
+  await page.getByRole("button", { name: "Add category" }).click();
+
+  await expect(page.getByRole("heading", { name: categoryName })).toBeVisible();
+
+  await page.getByRole("button", { name: /Switch to dark mode/i }).click();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+
+  await page.reload();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+});

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -15,7 +15,7 @@ test("adds a category and changes the theme", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: categoryName })).toBeVisible();
 
-  await page.getByRole("button", { name: /Switch to dark mode/i }).click();
+  await page.getByTestId("settings-theme-toggle").click();
   await expect(page.locator("html")).toHaveClass(/dark/);
 
   await page.reload();

--- a/frontend/tests/e2e/subscriptions.spec.ts
+++ b/frontend/tests/e2e/subscriptions.spec.ts
@@ -20,18 +20,19 @@ test("adds, edits, and deletes a subscription", async ({ page, request }) => {
   await createPaymentMethod(request, paymentMethodName);
 
   await page.goto("/subscriptions");
-  await page.getByLabel("Subscription name").fill(subscriptionName);
-  await page.getByLabel("Vendor").fill("Netflix");
-  await page.getByLabel("Amount").fill("15.49");
-  await page.getByLabel("Currency").fill("USD");
-  await page.getByLabel("Billing day").fill("1");
-  await page.getByLabel("Start date").fill("2026-01-01");
-  await page.getByLabel("Next charge date").fill("2026-02-01");
-  await page.getByLabel("Category").selectOption({ label: categoryName });
-  await page.getByLabel("Payment method").selectOption({ label: paymentMethodName });
-  await page.getByLabel("Website URL").fill("https://www.netflix.com");
-  await page.getByLabel("Notes").fill("Family streaming plan");
-  await page.getByRole("button", { name: "Save subscription" }).click();
+  const createForm = page.getByTestId("subscription-create-form");
+  await createForm.getByLabel("Subscription name").fill(subscriptionName);
+  await createForm.getByLabel("Vendor").fill("Netflix");
+  await createForm.getByLabel("Amount", { exact: true }).fill("15.49");
+  await createForm.getByLabel("Currency").fill("USD");
+  await createForm.getByLabel("Billing day").fill("1");
+  await createForm.getByLabel("Start date").fill("2026-01-01");
+  await createForm.getByLabel("Next charge date").fill("2026-02-01");
+  await createForm.getByLabel("Category").selectOption({ label: categoryName });
+  await createForm.getByLabel("Payment method").selectOption({ label: paymentMethodName });
+  await createForm.getByLabel("Website URL").fill("https://www.netflix.com");
+  await createForm.getByLabel("Notes").fill("Family streaming plan");
+  await createForm.getByRole("button", { name: "Save subscription" }).click();
 
   await expect(page.getByRole("heading", { name: subscriptionName })).toBeVisible();
 
@@ -39,15 +40,19 @@ test("adds, edits, and deletes a subscription", async ({ page, request }) => {
   await expect(page).toHaveURL(/\/subscriptions\/\d+$/);
 
   await page.getByRole("button", { name: "Edit subscription" }).click();
-  await page.getByLabel("Amount").fill("17.99");
-  await page.getByLabel("Notes").fill("Updated after the annual increase");
-  await page.getByRole("button", { name: "Save changes" }).click();
+  const editForm = page.getByTestId("subscription-edit-form");
+  await editForm.getByLabel("Amount", { exact: true }).fill("17.99");
+  await editForm.getByLabel("Notes").fill("Updated after the annual increase");
+  await editForm.getByRole("button", { name: "Save changes" }).click();
 
   await expect(page.getByText("Updated after the annual increase")).toBeVisible();
   await expect(page.getByText("$17.99")).toBeVisible();
 
   await page.getByRole("button", { name: "Delete subscription" }).click();
-  await page.getByRole("button", { name: "Delete subscription" }).click();
+  await page
+    .getByLabel("Delete this subscription?")
+    .getByRole("button", { name: "Delete subscription" })
+    .click();
 
   await expect(page).toHaveURL(/\/subscriptions$/);
   await expect(page.getByText(subscriptionName)).not.toBeVisible();

--- a/frontend/tests/e2e/subscriptions.spec.ts
+++ b/frontend/tests/e2e/subscriptions.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createCategory,
+  createPaymentMethod,
+  resetWorkspace,
+  uniqueLabel,
+} from "./support/session";
+
+test.beforeEach(async ({ request }) => {
+  await resetWorkspace(request);
+});
+
+test("adds, edits, and deletes a subscription", async ({ page, request }) => {
+  const categoryName = uniqueLabel("Streaming");
+  const paymentMethodName = uniqueLabel("Primary Card");
+  const subscriptionName = uniqueLabel("Netflix Family");
+
+  await createCategory(request, categoryName);
+  await createPaymentMethod(request, paymentMethodName);
+
+  await page.goto("/subscriptions");
+  await page.getByLabel("Subscription name").fill(subscriptionName);
+  await page.getByLabel("Vendor").fill("Netflix");
+  await page.getByLabel("Amount").fill("15.49");
+  await page.getByLabel("Currency").fill("USD");
+  await page.getByLabel("Billing day").fill("1");
+  await page.getByLabel("Start date").fill("2026-01-01");
+  await page.getByLabel("Next charge date").fill("2026-02-01");
+  await page.getByLabel("Category").selectOption({ label: categoryName });
+  await page.getByLabel("Payment method").selectOption({ label: paymentMethodName });
+  await page.getByLabel("Website URL").fill("https://www.netflix.com");
+  await page.getByLabel("Notes").fill("Family streaming plan");
+  await page.getByRole("button", { name: "Save subscription" }).click();
+
+  await expect(page.getByRole("heading", { name: subscriptionName })).toBeVisible();
+
+  await page.getByRole("link", { name: "Open detail" }).click();
+  await expect(page).toHaveURL(/\/subscriptions\/\d+$/);
+
+  await page.getByRole("button", { name: "Edit subscription" }).click();
+  await page.getByLabel("Amount").fill("17.99");
+  await page.getByLabel("Notes").fill("Updated after the annual increase");
+  await page.getByRole("button", { name: "Save changes" }).click();
+
+  await expect(page.getByText("Updated after the annual increase")).toBeVisible();
+  await expect(page.getByText("$17.99")).toBeVisible();
+
+  await page.getByRole("button", { name: "Delete subscription" }).click();
+  await page.getByRole("button", { name: "Delete subscription" }).click();
+
+  await expect(page).toHaveURL(/\/subscriptions$/);
+  await expect(page.getByText(subscriptionName)).not.toBeVisible();
+});

--- a/frontend/tests/e2e/support/session.ts
+++ b/frontend/tests/e2e/support/session.ts
@@ -78,13 +78,23 @@ export async function registerTestUser(
 }
 
 export async function seedSession(page: Page, session: TestSession) {
-  await page.goto(`${FRONTEND_BASE_URL}/login`);
-  await page.evaluate(
+  const payload = { key: AUTH_STORAGE_KEY, nextSession: session };
+
+  await page.addInitScript(
     ({ key, nextSession }) => {
       window.localStorage.setItem(key, JSON.stringify(nextSession));
     },
-    { key: AUTH_STORAGE_KEY, nextSession: session },
+    payload,
   );
+
+  if (page.url().startsWith(FRONTEND_BASE_URL)) {
+    await page.evaluate(
+      ({ key, nextSession }) => {
+        window.localStorage.setItem(key, JSON.stringify(nextSession));
+      },
+      payload,
+    );
+  }
 }
 
 export function ensureAuthArtifactDir() {

--- a/frontend/tests/e2e/support/session.ts
+++ b/frontend/tests/e2e/support/session.ts
@@ -1,0 +1,244 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { APIRequestContext, Page } from "@playwright/test";
+
+import { AUTH_STORAGE_KEY } from "../../../src/lib/constants";
+
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8000/api/v1";
+export const FRONTEND_BASE_URL = "http://127.0.0.1:3000";
+export const AUTH_ARTIFACT_DIR = path.resolve(process.cwd(), "test-results/.auth");
+export const AUTH_STATE_PATH = path.join(AUTH_ARTIFACT_DIR, "storage-state.json");
+export const AUTH_SESSION_PATH = path.join(AUTH_ARTIFACT_DIR, "session.json");
+
+export type TestSession = {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  access_token_expires_at: string;
+  refresh_token_expires_at: string;
+  user: {
+    email: string;
+    full_name: string;
+    id: number;
+  };
+};
+
+type SubscriptionSeed = {
+  amount: string;
+  cadence?: string;
+  category_id?: number;
+  currency?: string;
+  description?: string;
+  name: string;
+  next_charge_date?: string;
+  notes?: string;
+  payment_method_id?: number;
+  start_date: string;
+  status?: string;
+  vendor?: string;
+  website_url?: string;
+};
+
+export function uniqueEmail(prefix = "playwright") {
+  return `${prefix}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
+export function uniqueLabel(prefix: string) {
+  return `${prefix} ${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+export async function registerTestUser(
+  request: APIRequestContext,
+  {
+    email = uniqueEmail(),
+    fullName = "Playwright User",
+    password = "super-secret",
+  }: {
+    email?: string;
+    fullName?: string;
+    password?: string;
+  } = {},
+) {
+  const response = await request.post(`${API_BASE_URL}/auth/register`, {
+    data: {
+      email,
+      full_name: fullName,
+      password,
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to register ${email}: ${response.status()} ${await response.text()}`);
+  }
+
+  const session = (await response.json()) as TestSession;
+  return { email, password, session };
+}
+
+export async function seedSession(page: Page, session: TestSession) {
+  await page.goto(`${FRONTEND_BASE_URL}/login`);
+  await page.evaluate(
+    ({ key, nextSession }) => {
+      window.localStorage.setItem(key, JSON.stringify(nextSession));
+    },
+    { key: AUTH_STORAGE_KEY, nextSession: session },
+  );
+}
+
+export function ensureAuthArtifactDir() {
+  fs.mkdirSync(AUTH_ARTIFACT_DIR, { recursive: true });
+}
+
+export function saveSessionArtifact(session: TestSession) {
+  ensureAuthArtifactDir();
+  fs.writeFileSync(AUTH_SESSION_PATH, JSON.stringify(session, null, 2));
+}
+
+export function readSavedSession() {
+  return JSON.parse(fs.readFileSync(AUTH_SESSION_PATH, "utf8")) as TestSession;
+}
+
+export function buildAuthHeaders(session = readSavedSession()) {
+  return {
+    Authorization: `Bearer ${session.access_token}`,
+  };
+}
+
+export async function resetWorkspace(
+  request: APIRequestContext,
+  session = readSavedSession(),
+) {
+  const response = await request.delete(`${API_BASE_URL}/auth/me/data`, {
+    headers: buildAuthHeaders(session),
+  });
+
+  if (response.status() !== 204) {
+    throw new Error(`Failed to reset workspace: ${response.status()} ${await response.text()}`);
+  }
+}
+
+export async function createCategory(
+  request: APIRequestContext,
+  name: string,
+  session = readSavedSession(),
+) {
+  const response = await request.post(`${API_BASE_URL}/categories`, {
+    data: {
+      description: `${name} services`,
+      name,
+    },
+    headers: buildAuthHeaders(session),
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to create category ${name}: ${response.status()} ${await response.text()}`);
+  }
+
+  const payload = (await response.json()) as { id: number };
+  return payload.id;
+}
+
+export async function createPaymentMethod(
+  request: APIRequestContext,
+  label: string,
+  session = readSavedSession(),
+) {
+  const response = await request.post(`${API_BASE_URL}/payment-methods`, {
+    data: {
+      is_default: true,
+      label,
+      last4: "4242",
+      provider: "Visa",
+    },
+    headers: buildAuthHeaders(session),
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to create payment method ${label}: ${response.status()} ${await response.text()}`,
+    );
+  }
+
+  const payload = (await response.json()) as { id: number };
+  return payload.id;
+}
+
+export async function createSubscription(
+  request: APIRequestContext,
+  payload: SubscriptionSeed,
+  session = readSavedSession(),
+) {
+  const response = await request.post(`${API_BASE_URL}/subscriptions`, {
+    data: {
+      auto_renew: true,
+      cadence: "monthly",
+      currency: "USD",
+      status: "active",
+      vendor: payload.name,
+      ...payload,
+    },
+    headers: buildAuthHeaders(session),
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to create subscription ${payload.name}: ${response.status()} ${await response.text()}`,
+    );
+  }
+
+  return response.json();
+}
+
+export function buildCsvStatement(vendor: string, amount: string) {
+  return [
+    "Posting Date,Details,Amount",
+    `01/01/2026,${vendor},-${amount}`,
+    `02/01/2026,${vendor},-${amount}`,
+    `03/01/2026,${vendor},-${amount}`,
+  ].join("\n");
+}
+
+function escapePdfText(value: string) {
+  return value.replaceAll("\\", "\\\\").replaceAll("(", "\\(").replaceAll(")", "\\)");
+}
+
+export function buildPdfStatement(lines: string[]) {
+  const stream =
+    "BT\n/F1 12 Tf\n72 720 Td\n" +
+    lines
+      .map((line, index) =>
+        index === 0
+          ? `(${escapePdfText(line)}) Tj`
+          : `0 -18 Td (${escapePdfText(line)}) Tj`,
+      )
+      .join("\n") +
+    "\nET\n";
+
+  const objects = [
+    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+    "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n",
+    "4 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    `5 0 obj\n<< /Length ${Buffer.byteLength(stream, "latin1")} >>\nstream\n${stream}endstream\nendobj\n`,
+  ];
+
+  let content = "%PDF-1.4\n";
+  const offsets: number[] = [];
+
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(content, "latin1"));
+    content += object;
+  }
+
+  const xrefOffset = Buffer.byteLength(content, "latin1");
+  content += `xref\n0 ${objects.length + 1}\n`;
+  content += "0000000000 65535 f \n";
+  for (const offset of offsets) {
+    content += `${offset.toString().padStart(10, "0")} 00000 n \n`;
+  }
+  content += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(content, "latin1");
+}

--- a/frontend/tests/e2e/upload.spec.ts
+++ b/frontend/tests/e2e/upload.spec.ts
@@ -43,7 +43,7 @@ test("uploads CSV and PDF statements and shows detected subscriptions", async ({
   await csvCreate;
   await csvCompleted;
 
-  await expect(page.getByText("hulu-statement.csv")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "hulu-statement.csv" })).toBeVisible();
 
   const pdfCreate = page.waitForResponse(
     (response) =>
@@ -67,7 +67,12 @@ test("uploads CSV and PDF statements and shows detected subscriptions", async ({
   await pdfCreate;
   await pdfCompleted;
 
-  await expect(page.getByText("netflix-statement.pdf")).toBeVisible();
+  await page
+    .getByRole("button")
+    .filter({ has: page.getByText("netflix-statement.pdf", { exact: true }) })
+    .first()
+    .click();
+  await expect(page.getByRole("heading", { name: "netflix-statement.pdf" })).toBeVisible();
 
   await page.goto("/subscriptions");
   await expect(page.getByRole("heading", { name: "Hulu" })).toBeVisible();

--- a/frontend/tests/e2e/upload.spec.ts
+++ b/frontend/tests/e2e/upload.spec.ts
@@ -1,0 +1,75 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import { buildCsvStatement, buildPdfStatement, resetWorkspace } from "./support/session";
+
+async function waitForUploadCompletion(page: Page) {
+  return page.waitForResponse(async (response) => {
+    if (
+      !response.url().includes("/api/v1/uploads/") ||
+      !response.url().endsWith("/status") ||
+      response.request().method() !== "GET" ||
+      !response.ok()
+    ) {
+      return false;
+    }
+
+    const payload = (await response.json().catch(() => null)) as { status?: string } | null;
+    return payload?.status === "completed";
+  });
+}
+
+test.beforeEach(async ({ request }) => {
+  await resetWorkspace(request);
+});
+
+test("uploads CSV and PDF statements and shows detected subscriptions", async ({ page }) => {
+  await page.goto("/uploads");
+
+  const csvCreate = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/uploads") &&
+      response.request().method() === "POST" &&
+      response.ok(),
+  );
+  const csvCompleted = waitForUploadCompletion(page);
+
+  await page.getByLabel("Upload statement").setInputFiles({
+    buffer: Buffer.from(buildCsvStatement("HULU", "8.99")),
+    mimeType: "text/csv",
+    name: "hulu-statement.csv",
+  });
+
+  await csvCreate;
+  await csvCompleted;
+
+  await expect(page.getByText("hulu-statement.csv")).toBeVisible();
+
+  const pdfCreate = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/uploads") &&
+      response.request().method() === "POST" &&
+      response.ok(),
+  );
+  const pdfCompleted = waitForUploadCompletion(page);
+
+  await page.getByLabel("Upload statement").setInputFiles({
+    buffer: buildPdfStatement([
+      "CHASE STATEMENT 2026",
+      "04/01 NETFLIX 15.49",
+      "05/01 NETFLIX 15.49",
+      "06/01 NETFLIX 15.49",
+    ]),
+    mimeType: "application/pdf",
+    name: "netflix-statement.pdf",
+  });
+
+  await pdfCreate;
+  await pdfCompleted;
+
+  await expect(page.getByText("netflix-statement.pdf")).toBeVisible();
+
+  await page.goto("/subscriptions");
+  await expect(page.getByRole("heading", { name: "Hulu" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Netflix" })).toBeVisible();
+});

--- a/frontend/tests/e2e/upload.spec.ts
+++ b/frontend/tests/e2e/upload.spec.ts
@@ -3,20 +3,9 @@ import { expect, test } from "@playwright/test";
 
 import { buildCsvStatement, buildPdfStatement, resetWorkspace } from "./support/session";
 
-async function waitForUploadCompletion(page: Page) {
-  return page.waitForResponse(async (response) => {
-    if (
-      !response.url().includes("/api/v1/uploads/") ||
-      !response.url().endsWith("/status") ||
-      response.request().method() !== "GET" ||
-      !response.ok()
-    ) {
-      return false;
-    }
-
-    const payload = (await response.json().catch(() => null)) as { status?: string } | null;
-    return payload?.status === "completed";
-  });
+async function waitForUploadCompletion(page: Page, fileName: string) {
+  await expect(page.getByTestId("upload-selected-file-name")).toHaveText(fileName);
+  await expect(page.getByTestId("upload-current-status")).toHaveText("completed");
 }
 
 test.beforeEach(async ({ request }) => {
@@ -32,7 +21,6 @@ test("uploads CSV and PDF statements and shows detected subscriptions", async ({
       response.request().method() === "POST" &&
       response.ok(),
   );
-  const csvCompleted = waitForUploadCompletion(page);
 
   await page.getByLabel("Upload statement").setInputFiles({
     buffer: Buffer.from(buildCsvStatement("HULU", "8.99")),
@@ -41,7 +29,7 @@ test("uploads CSV and PDF statements and shows detected subscriptions", async ({
   });
 
   await csvCreate;
-  await csvCompleted;
+  await waitForUploadCompletion(page, "hulu-statement.csv");
 
   await expect(page.getByRole("heading", { name: "hulu-statement.csv" })).toBeVisible();
 
@@ -51,7 +39,6 @@ test("uploads CSV and PDF statements and shows detected subscriptions", async ({
       response.request().method() === "POST" &&
       response.ok(),
   );
-  const pdfCompleted = waitForUploadCompletion(page);
 
   await page.getByLabel("Upload statement").setInputFiles({
     buffer: buildPdfStatement([
@@ -65,13 +52,9 @@ test("uploads CSV and PDF statements and shows detected subscriptions", async ({
   });
 
   await pdfCreate;
-  await pdfCompleted;
+  await waitForUploadCompletion(page, "netflix-statement.pdf");
 
-  await page
-    .getByRole("button")
-    .filter({ has: page.getByText("netflix-statement.pdf", { exact: true }) })
-    .first()
-    .click();
+  await page.locator('button[data-upload-file-name="netflix-statement.pdf"]').click();
   await expect(page.getByRole("heading", { name: "netflix-statement.pdf" })).toBeVisible();
 
   await page.goto("/subscriptions");

--- a/frontend/tests/unit/hooks/use-auth.test.ts
+++ b/frontend/tests/unit/hooks/use-auth.test.ts
@@ -58,10 +58,12 @@ function AuthHarness() {
 describe("useAuth", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    window.localStorage.clear();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -86,6 +88,20 @@ describe("useAuth", () => {
     expect(screen.getByTestId("state")).toHaveTextContent("owner@example.com");
   });
 
+  it("restores a persisted session after hydration", async () => {
+    window.localStorage.setItem("mysubscription.auth", JSON.stringify(buildSession()));
+
+    render(
+      createElement(AuthProvider, null, createElement(AuthHarness)),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("state")).toHaveTextContent("owner@example.com");
+  });
+
   it("refreshes the session before the access token expires", async () => {
     vi.mocked(apiClient.login).mockResolvedValue(buildSession());
     vi.mocked(apiClient.refresh).mockResolvedValue(
@@ -105,5 +121,6 @@ describe("useAuth", () => {
     });
 
     expect(apiClient.refresh).toHaveBeenCalledWith("refresh-token");
+    expect(window.localStorage.getItem("mysubscription.auth")).toContain("refreshed-token");
   });
 });

--- a/frontend/tests/unit/hooks/use-filters.test.ts
+++ b/frontend/tests/unit/hooks/use-filters.test.ts
@@ -19,6 +19,7 @@ describe("useFilters", () => {
   beforeEach(() => {
     replace.mockReset();
     currentSearchParams = new URLSearchParams();
+    vi.useRealTimers();
   });
 
   it("reads the current URL state into filter values", () => {
@@ -54,6 +55,21 @@ describe("useFilters", () => {
         "/subscriptions?cadence=yearly&category_id=4&max_amount=42&min_amount=12&payment_method_id=8&search=hulu&status=paused",
         { scroll: false },
       );
+    });
+  });
+
+  it("clears a pending debounced search immediately when filters reset", async () => {
+    currentSearchParams = new URLSearchParams("search=netflix");
+
+    const { result } = renderHook(() => useFilters({ searchDelay: 300 }));
+
+    act(() => {
+      result.current.clearFilters();
+    });
+
+    await waitFor(() => {
+      expect(replace).not.toHaveBeenCalledWith(expect.stringContaining("search=netflix"), expect.anything());
+      expect(replace).toHaveBeenCalledWith("/subscriptions", { scroll: false });
     });
   });
 });

--- a/frontend/tests/unit/hooks/use-filters.test.ts
+++ b/frontend/tests/unit/hooks/use-filters.test.ts
@@ -72,4 +72,54 @@ describe("useFilters", () => {
       expect(replace).toHaveBeenCalledWith("/subscriptions", { scroll: false });
     });
   });
+
+  it("does not clobber local range filters when its own intermediate URL sync lands", async () => {
+    const { result, rerender } = renderHook(() => useFilters({ searchDelay: 0 }));
+
+    act(() => {
+      result.current.setMinAmount("14");
+    });
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenLastCalledWith("/subscriptions?min_amount=14", { scroll: false });
+    });
+
+    currentSearchParams = new URLSearchParams("min_amount=14");
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.filters.minAmount).toBe("14");
+      expect(result.current.filters.maxAmount).toBe("");
+    });
+
+    act(() => {
+      result.current.setMaxAmount("16");
+    });
+
+    await waitFor(() => {
+      const [nextUrl, options] = replace.mock.lastCall ?? [];
+      expect(options).toEqual({ scroll: false });
+
+      const url = new URL(String(nextUrl), "http://localhost");
+      expect(url.pathname).toBe("/subscriptions");
+      expect(url.searchParams.get("min_amount")).toBe("14");
+      expect(url.searchParams.get("max_amount")).toBe("16");
+    });
+
+    currentSearchParams = new URLSearchParams("max_amount=16");
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.filters.minAmount).toBe("14");
+      expect(result.current.filters.maxAmount).toBe("16");
+    });
+
+    currentSearchParams = new URLSearchParams("max_amount=16&min_amount=14");
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.filters.minAmount).toBe("14");
+      expect(result.current.filters.maxAmount).toBe("16");
+    });
+  });
 });


### PR DESCRIPTION
## What happened

On April 14, 2026 at 12:00 PM EDT, the automation started, ran its required preflight check, and stopped immediately. It did not do tracker lookup, branch switching, file edits, tests, commits, or pushes.

## What changed

At 1:54 PM EDT, I reran the automation bootstrap in `/Users/work/.codex/automations/daily-milestone-worker-2`. That refreshed:

- The saved dependency hashes in [[deps.env](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/state/deps.env)](/Users/work/.codex/automations/daily-milestone-worker-2/state/deps.env)
- The shared backend environment under `shared/backend/.venv`
- The shared frontend dependencies under `shared/frontend/node_modules`

No project code in `/Users/work/Desktop/My GIT/MySubscription_tracker` was changed.

## Why it happened

The automation repo it actually runs in is `/Users/work/.codex/automations/daily-milestone-worker-2/repo`, not your desktop checkout. Its preflight script compares `backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json`, and `frontend/package-lock.json` against hashes saved during the last bootstrap.

That bootstrap state was last written on April 12, 2026 at 12:11 PM EDT. After that, later milestone work changed `frontend/package.json` and `frontend/package-lock.json`, so by April 14 the saved hashes were stale. Preflight detected that mismatch and correctly refused to continue until bootstrap was rerun.

After the refresh, preflight passes again, so the blocker is cleared.

## Day 13 progress

Day 13 is on `day-13/integration-testing-e2e` and pushed to origin through `5d014eb`. I added:

- Backend integration coverage
- The Playwright harness and specs
- Auth session persistence for reliable test setup
- The backend e2e bootstrap script
- The frontend CI E2E job

GitHub write-back succeeded: `#54` is closed, `#55` is still open, and umbrella `#53` is labeled `blocked`.

## Local checks passed

- `zsh /Users/work/.codex/automations/daily-milestone-worker-2/lockfile-guard.sh "$PWD"`
- `backend/.venv/bin/pytest backend/tests`
- `backend/.venv/bin/ruff check backend/src backend/tests`
- `backend/.venv/bin/mypy backend/src`
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run build`

## Remaining blocker

The remaining blocker is local Playwright execution in this sandbox: even after installing browsers under `/tmp/ms-playwright`, Chromium launch fails with `bootstrap_check_in ... Permission denied`, so `#55` and `#53` remain open pending a browser-capable run or CI pass.

> **Day 13 E2E blocked** — Backend closed; browser-capable Playwright run still needed.