### PR TITLE
Day 14/onboarding empty states polish

### DIFF
--- a/frontend/src/app/(app)/calendar/page.tsx
+++ b/frontend/src/app/(app)/calendar/page.tsx
@@ -23,6 +23,11 @@ export default function CalendarPage() {
       />
 
       <EmptyState
+        action={
+          <Button asChild className="rounded-full px-5" variant="outline">
+            <Link href="/subscriptions">Review upcoming renewals in subscriptions</Link>
+          </Button>
+        }
         description="Calendar grids, reminder windows, and cross-household renewal planning are future work. Day 4 only establishes the operator shell that will contain them."
         eyebrow="Future reminder work"
         icon={<CalendarDays className="size-5" />}

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -1,23 +1,45 @@
 "use client";
 
 import Link from "next/link";
-import { startTransition } from "react";
+import { startTransition, useMemo } from "react";
 import { ArrowRight, Activity, LayoutTemplate } from "lucide-react";
 
+import { WorkspaceOnboarding } from "@/components/onboarding/workspace-onboarding";
 import { SnapshotBar } from "@/components/dashboard/snapshot-bar";
 import { DashboardWidgetBoard } from "@/components/dashboard/widget-board";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/ui/page-header";
 import { useDashboardLayout, useDashboardSummary, useUpdateDashboardLayout } from "@/hooks/use-dashboard";
+import { useOnboarding } from "@/hooks/use-onboarding";
+import { useSubscriptionCatalog, useSubscriptionList } from "@/hooks/use-subscriptions";
+import { useUploadHistory } from "@/hooks/use-uploads";
 import type { DashboardLayoutWidget } from "@/types";
 
 export default function DashboardPage() {
   const summaryQuery = useDashboardSummary();
   const layoutQuery = useDashboardLayout();
   const updateLayout = useUpdateDashboardLayout();
+  const subscriptionsQuery = useSubscriptionList({ limit: 1 });
+  const uploadsQuery = useUploadHistory();
+  const { categoriesQuery, paymentMethodsQuery } = useSubscriptionCatalog();
+  const { isComplete, isReady } = useOnboarding();
 
   const summary = summaryQuery.data;
   const widgets = layoutQuery.data?.widgets;
+  const isWorkspaceSnapshotLoading =
+    subscriptionsQuery.isLoading ||
+    uploadsQuery.isLoading ||
+    categoriesQuery.isLoading ||
+    paymentMethodsQuery.isLoading;
+  const hasWorkspaceData = useMemo(
+    () =>
+      (subscriptionsQuery.data?.total ?? 0) > 0 ||
+      (uploadsQuery.data?.total ?? 0) > 0 ||
+      (categoriesQuery.data?.total ?? 0) > 0 ||
+      (paymentMethodsQuery.data?.total ?? 0) > 0,
+    [categoriesQuery.data?.total, paymentMethodsQuery.data?.total, subscriptionsQuery.data?.total, uploadsQuery.data?.total],
+  );
+  const showOnboarding = isReady && !isComplete && !isWorkspaceSnapshotLoading && !hasWorkspaceData;
 
   const applyLayout = (nextWidgets: DashboardLayoutWidget[]) => {
     startTransition(() => {
@@ -29,17 +51,21 @@ export default function DashboardPage() {
     <div className="space-y-8 animate-page-enter">
       <PageHeader
         action={
-          <Button asChild className="rounded-full px-5" variant="outline">
-            <Link href="/subscriptions">
-              Open subscriptions
-              <ArrowRight className="ml-2 size-4" />
-            </Link>
-          </Button>
+          showOnboarding ? undefined : (
+            <Button asChild className="rounded-full px-5" variant="outline">
+              <Link href="/subscriptions">
+                Open subscriptions
+                <ArrowRight className="ml-2 size-4" />
+              </Link>
+            </Button>
+          )
         }
         description="Operate from a live dashboard where five persistent widgets keep spend, renewals, category mix, and subscription churn in one working surface."
         eyebrow="Day 11 widget system"
         title="Smart dashboard workspace"
       />
+
+      {showOnboarding ? <WorkspaceOnboarding /> : null}
 
       <SnapshotBar isLoading={summaryQuery.isLoading} summary={summary?.summary} />
 

--- a/frontend/src/app/(app)/payments/page.tsx
+++ b/frontend/src/app/(app)/payments/page.tsx
@@ -23,6 +23,11 @@ export default function PaymentsPage() {
       />
 
       <EmptyState
+        action={
+          <Button asChild className="rounded-full px-5" variant="outline">
+            <Link href="/settings">Add a payment rail in settings</Link>
+          </Button>
+        }
         description="The app shell now reserves a destination for cards, billing instruments, and charge fallback rules, but the underlying product behavior is intentionally deferred to later milestones."
         eyebrow="Upcoming surface"
         icon={<CreditCard className="size-5" />}

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
-import { CreditCard, FolderTree, LoaderCircle, PencilLine, ShieldAlert, Trash2, UserRound } from "lucide-react";
+import { CreditCard, FolderTree, PencilLine, ShieldAlert, Trash2, UserRound } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
+import { useOnboarding } from "@/hooks/use-onboarding";
 import {
   useCreateCategory,
   useCreatePaymentMethod,
@@ -19,7 +21,9 @@ import {
 import type { Category, PaymentMethod } from "@/types";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 type CategoryDraft = {
@@ -54,11 +58,11 @@ function getErrorMessage(error: unknown) {
   return "Something went wrong. Try again.";
 }
 
-function getCurrencySummary(currencies: string[]) {
+function getCurrencySummary(currencies: string[], preferredCurrency: string) {
   if (currencies.length === 0) {
     return {
-      detail: "No saved subscriptions yet. New plans still default to USD until the workspace fills in.",
-      label: "USD",
+      detail: `No saved subscriptions yet. New plans default to ${preferredCurrency} until live billing data takes over.`,
+      label: preferredCurrency,
     };
   }
 
@@ -104,6 +108,7 @@ function SectionShell({
 
 export default function SettingsPage() {
   const { user } = useAuth();
+  const { preferredCurrency } = useOnboarding();
   const [categoryDraft, setCategoryDraft] = useState<CategoryDraft>(emptyCategoryDraft);
   const [paymentMethodDraft, setPaymentMethodDraft] = useState<PaymentMethodDraft>(emptyPaymentMethodDraft);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
@@ -126,8 +131,12 @@ export default function SettingsPage() {
   const categories = categoriesQuery.data?.items ?? [];
   const paymentMethods = paymentMethodsQuery.data?.items ?? [];
   const currencySummary = useMemo(
-    () => getCurrencySummary((subscriptionsQuery.data?.items ?? []).map((subscription) => subscription.currency)),
-    [subscriptionsQuery.data?.items],
+    () =>
+      getCurrencySummary(
+        (subscriptionsQuery.data?.items ?? []).map((subscription) => subscription.currency),
+        preferredCurrency,
+      ),
+    [preferredCurrency, subscriptionsQuery.data?.items],
   );
 
   const isCatalogLoading = categoriesQuery.isLoading || paymentMethodsQuery.isLoading;
@@ -166,6 +175,7 @@ export default function SettingsPage() {
           title="Categories management"
         >
           <form
+            id="settings-category-create"
             className="grid gap-3 rounded-[1.6rem] border border-black/10 bg-stone/55 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)_auto]"
             onSubmit={async (event) => {
               event.preventDefault();
@@ -203,12 +213,28 @@ export default function SettingsPage() {
 
           <div className="mt-5 space-y-3">
             {categoriesQuery.isLoading ? (
-              <div className="flex items-center gap-3 text-sm text-black/58">
-                <LoaderCircle className="size-4 animate-spin" />
-                Loading categories...
-              </div>
+              Array.from({ length: 3 }).map((_, index) => (
+                <div className="rounded-[1.5rem] border border-black/10 bg-white/85 p-4" key={index}>
+                  <Skeleton className="h-5 w-32" />
+                  <Skeleton className="mt-3 h-4 w-10/12" />
+                  <div className="mt-5 flex gap-2">
+                    <Skeleton className="h-9 w-20 rounded-full" />
+                    <Skeleton className="h-9 w-24 rounded-full" />
+                  </div>
+                </div>
+              ))
             ) : categories.length === 0 ? (
-              <p className="text-sm text-black/58">No categories yet. Add the first one above.</p>
+              <EmptyState
+                action={
+                  <Button asChild className="rounded-full px-5" variant="outline">
+                    <a href="#settings-category-create">Add the first category</a>
+                  </Button>
+                }
+                description="Categories help the dashboard and search filters read like an operating tool instead of a raw list."
+                eyebrow="Category setup"
+                icon={<FolderTree className="size-5" />}
+                title="No categories yet."
+              />
             ) : (
               categories.map((category) => {
                 const isEditing = editingCategory?.id === category.id;
@@ -318,6 +344,7 @@ export default function SettingsPage() {
           title="Payment methods management"
         >
           <form
+            id="settings-payment-method-create"
             className="grid gap-3 rounded-[1.6rem] border border-black/10 bg-stone/55 p-4 md:grid-cols-2"
             onSubmit={async (event) => {
               event.preventDefault();
@@ -390,14 +417,28 @@ export default function SettingsPage() {
 
           <div className="mt-5 space-y-3">
             {paymentMethodsQuery.isLoading ? (
-              <div className="flex items-center gap-3 text-sm text-black/58">
-                <LoaderCircle className="size-4 animate-spin" />
-                Loading payment methods...
-              </div>
+              Array.from({ length: 3 }).map((_, index) => (
+                <div className="rounded-[1.5rem] border border-black/10 bg-white/85 p-4" key={index}>
+                  <Skeleton className="h-5 w-36" />
+                  <Skeleton className="mt-3 h-4 w-32" />
+                  <div className="mt-5 flex gap-2">
+                    <Skeleton className="h-9 w-20 rounded-full" />
+                    <Skeleton className="h-9 w-24 rounded-full" />
+                  </div>
+                </div>
+              ))
             ) : paymentMethods.length === 0 ? (
-              <p className="text-sm text-black/58">
-                No payment methods yet. Add the primary billing rail above.
-              </p>
+              <EmptyState
+                action={
+                  <Button asChild className="rounded-full px-5" variant="outline">
+                    <a href="#settings-payment-method-create">Add the first payment rail</a>
+                  </Button>
+                }
+                description="Save the primary billing rail here so upcoming plan management and alerting flows already have a default instrument to reference."
+                eyebrow="Billing setup"
+                icon={<CreditCard className="size-5" />}
+                title="No payment methods yet."
+              />
             ) : (
               paymentMethods.map((paymentMethod) => {
                 const isEditing = editingPaymentMethod?.id === paymentMethod.id;
@@ -565,6 +606,20 @@ export default function SettingsPage() {
               <p className="mt-2 text-2xl font-semibold text-ink">{currencySummary.label}</p>
               <p className="mt-2 text-sm leading-6 text-black/58">{currencySummary.detail}</p>
             </div>
+
+            {categories.length === 0 && paymentMethods.length === 0 ? (
+              <EmptyState
+                action={
+                  <Button asChild className="rounded-full px-5" variant="outline">
+                    <Link href="/dashboard">Return to setup guide</Link>
+                  </Button>
+                }
+                className="rounded-[1.35rem] bg-white/82 p-4 shadow-none"
+                description="This workspace is still in first-run mode. Finish the dashboard setup guide or seed categories and payment rails here."
+                eyebrow="First-run workspace"
+                title="Settings is ready for initial setup."
+              />
+            ) : null}
           </div>
 
           <div className="space-y-4">

--- a/frontend/src/app/(app)/subscriptions/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { ArrowRight, LayoutGrid, List, LoaderCircle, SlidersHorizontal, Sparkles } from "lucide-react";
+import { ArrowRight, LayoutGrid, List, SlidersHorizontal, Sparkles } from "lucide-react";
 
 import { SearchBar } from "@/components/subscriptions/search-bar";
 import { SubscriptionCard } from "@/components/subscriptions/subscription-card";
@@ -10,7 +10,9 @@ import { SubscriptionForm } from "@/components/subscriptions/subscription-form";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useFilters } from "@/hooks/use-filters";
+import { useOnboarding } from "@/hooks/use-onboarding";
 import { useCreateSubscription, useSubscriptionCatalog, useSubscriptionList } from "@/hooks/use-subscriptions";
 import { subscriptionCadenceOptions, subscriptionStatusOptions } from "@/lib/validators";
 
@@ -37,6 +39,7 @@ export default function SubscriptionsPage() {
     limit: 100,
     ...queryFilters,
   });
+  const { preferredCurrency } = useOnboarding();
 
   const categories = categoriesQuery.data?.items ?? [];
   const paymentMethods = paymentMethodsQuery.data?.items ?? [];
@@ -78,6 +81,11 @@ export default function SubscriptionsPage() {
                   Search by vendor, pin the exact billing rail, constrain price ranges, and keep
                   the filters live in the URL while you move through the workspace.
                 </p>
+                {subscriptionsQuery.isFetching && subscriptions.length > 0 ? (
+                  <p className="text-xs uppercase tracking-[0.24em] text-black/42">
+                    Updating results without clearing the list
+                  </p>
+                ) : null}
               </div>
 
               <div className="flex items-center gap-2 self-start rounded-full border border-black/10 bg-stone/70 p-1">
@@ -220,12 +228,20 @@ export default function SubscriptionsPage() {
           </section>
 
           {subscriptionsQuery.isLoading ? (
-            <div className="flex min-h-64 items-center justify-center rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
-              <div className="flex items-center gap-3 text-sm text-black/58">
-                <LoaderCircle className="size-4 animate-spin" />
-                Loading subscriptions...
-              </div>
-            </div>
+            <section className="grid gap-4 md:grid-cols-2">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div
+                  className="rounded-[1.8rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur"
+                  key={index}
+                >
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="mt-4 h-8 w-40" />
+                  <Skeleton className="mt-3 h-4 w-28" />
+                  <Skeleton className="mt-6 h-20 w-full" />
+                  <Skeleton className="mt-4 h-10 w-36" />
+                </div>
+              ))}
+            </section>
           ) : subscriptions.length === 0 ? (
             <EmptyState
               action={
@@ -233,12 +249,20 @@ export default function SubscriptionsPage() {
                   <Button className="rounded-full px-5" onClick={clearFilters} variant="outline">
                     Clear filters
                   </Button>
-                ) : undefined
+                ) : (
+                  <Button asChild className="rounded-full px-5" variant="outline">
+                    <Link href="/settings">Set up categories and payment rails</Link>
+                  </Button>
+                )
               }
-              description="No plans match the current search or filter. Save a new subscription on the right to populate the workspace."
-              eyebrow="Empty state"
+              description={
+                hasActiveFilters
+                  ? "No plans match the current search or filter. Clear the active constraints to widen the view again."
+                  : `No subscriptions are saved yet. Use the form on the right to add the first plan with ${preferredCurrency} as the default billing code.`
+              }
+              eyebrow={hasActiveFilters ? "Filtered view" : "First subscription"}
               icon={<Sparkles className="size-5" />}
-              title="No subscriptions in view."
+              title={hasActiveFilters ? "No subscriptions match these filters." : "The subscription list is still empty."}
             />
           ) : (
             <section
@@ -272,6 +296,7 @@ export default function SubscriptionsPage() {
             await createSubscription.mutateAsync(payload);
           }}
           paymentMethods={paymentMethods}
+          preferredCurrency={preferredCurrency}
           submitLabel="Save subscription"
           testId="subscription-create-form"
           title="Add a subscription"

--- a/frontend/src/app/(app)/uploads/page.tsx
+++ b/frontend/src/app/(app)/uploads/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { startTransition, useEffect, useMemo, useState } from "react";
-import { ArrowRight, FolderSearch, LoaderCircle } from "lucide-react";
+import { ArrowRight, FolderSearch } from "lucide-react";
 
 import { UploadDropzone } from "@/components/uploads/upload-dropzone";
 import { UploadHistoryList } from "@/components/uploads/upload-history-list";
@@ -10,6 +10,7 @@ import { UploadProcessingPanel } from "@/components/uploads/upload-processing-pa
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   mergeSelectedUpload,
   useCreateUpload,
@@ -115,21 +116,33 @@ export default function UploadsPage() {
       <section className="grid gap-4 lg:grid-cols-3">
         <div className="rounded-[1.7rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur">
           <p className="text-xs uppercase tracking-[0.3em] text-black/45">Total files</p>
-          <p className="mt-4 text-4xl font-semibold tracking-tight text-ink">{uploads.length}</p>
+          {uploadsQuery.isLoading ? (
+            <Skeleton className="mt-4 h-11 w-20" />
+          ) : (
+            <p className="mt-4 text-4xl font-semibold tracking-tight text-ink">{uploads.length}</p>
+          )}
           <p className="mt-2 text-sm leading-6 text-black/60">
             Every statement stays in history with deletion controls and provider detection visible.
           </p>
         </div>
         <div className="rounded-[1.7rem] border border-black/10 bg-[#101922] p-5 text-white shadow-[0_24px_80px_rgba(16,25,34,0.16)]">
           <p className="text-xs uppercase tracking-[0.3em] text-white/45">Active queue</p>
-          <p className="mt-4 text-4xl font-semibold tracking-tight">{activeUploads}</p>
+          {uploadsQuery.isLoading ? (
+            <Skeleton className="mt-4 h-11 w-20 bg-white/12" />
+          ) : (
+            <p className="mt-4 text-4xl font-semibold tracking-tight">{activeUploads}</p>
+          )}
           <p className="mt-2 text-sm leading-6 text-white/62">
             Polling stays live while anything is queued or processing so the status rail keeps moving.
           </p>
         </div>
         <div className="rounded-[1.7rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur">
           <p className="text-xs uppercase tracking-[0.3em] text-black/45">Completed ingests</p>
-          <p className="mt-4 text-4xl font-semibold tracking-tight text-ink">{completedUploads}</p>
+          {uploadsQuery.isLoading ? (
+            <Skeleton className="mt-4 h-11 w-24" />
+          ) : (
+            <p className="mt-4 text-4xl font-semibold tracking-tight text-ink">{completedUploads}</p>
+          )}
           <p className="mt-2 text-sm leading-6 text-black/60">
             Finished uploads are ready for downstream subscription review and cleanup.
           </p>
@@ -145,22 +158,45 @@ export default function UploadsPage() {
                 setSelectedUploadId(created.id);
               });
             }}
+            sectionId="upload-dropzone"
           />
           <UploadProcessingPanel upload={selectedUpload} visualStep={visualStep} />
         </div>
 
         {uploadsQuery.isLoading ? (
-          <div className="flex min-h-[24rem] items-center justify-center rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
-            <div className="flex items-center gap-3 text-sm text-black/58">
-              <LoaderCircle className="size-4 animate-spin" />
-              Loading upload history...
+          <section className="overflow-hidden rounded-[2rem] border border-black/10 bg-white/76 shadow-line backdrop-blur">
+            <div className="border-b border-black/10 px-5 py-5 sm:px-6">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="mt-4 h-8 w-44" />
+              <Skeleton className="mt-3 h-4 w-10/12" />
             </div>
-          </div>
+            <div className="space-y-4 px-5 py-5 sm:px-6">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div className="rounded-[1.4rem] border border-black/8 bg-white/88 p-4" key={index}>
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex min-w-0 items-center gap-4">
+                      <Skeleton className="size-11 rounded-[1rem]" />
+                      <div className="min-w-0 space-y-2">
+                        <Skeleton className="h-4 w-36" />
+                        <Skeleton className="h-4 w-24" />
+                      </div>
+                    </div>
+                    <Skeleton className="h-8 w-20 rounded-full" />
+                  </div>
+                  <div className="mt-4 flex gap-3">
+                    <Skeleton className="h-4 w-14" />
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
         ) : uploads.length === 0 ? (
           <EmptyState
             action={
-              <Button className="rounded-full px-5" variant="outline">
-                Queue your first file
+              <Button asChild className="rounded-full px-5" variant="outline">
+                <a href="#upload-dropzone">Queue your first file</a>
               </Button>
             }
             description="The history rail will populate after the first CSV or PDF upload and stay searchable from this workspace."

--- a/frontend/src/components/app-shell/app-shell.tsx
+++ b/frontend/src/components/app-shell/app-shell.tsx
@@ -34,6 +34,7 @@ type NavItem = {
   href: string;
   icon: typeof LayoutDashboard;
   label: string;
+  mobileLabel: string;
 };
 
 const navItems: NavItem[] = [
@@ -42,36 +43,42 @@ const navItems: NavItem[] = [
     href: "/dashboard",
     icon: LayoutDashboard,
     label: "Dashboard",
+    mobileLabel: "Home",
   },
   {
     caption: "Plans and spend",
     href: "/subscriptions",
     icon: Sparkles,
     label: "Subscriptions",
+    mobileLabel: "Plans",
   },
   {
     caption: "Statement ingest",
     href: "/uploads",
     icon: FileUp,
     label: "Uploads",
+    mobileLabel: "Files",
   },
   {
     caption: "Cards and billing",
     href: "/payments",
     icon: CreditCard,
     label: "Payments",
+    mobileLabel: "Pay",
   },
   {
     caption: "Renewal timing",
     href: "/calendar",
     icon: CalendarDays,
     label: "Calendar",
+    mobileLabel: "Dates",
   },
   {
     caption: "Workspace controls",
     href: "/settings",
     icon: Settings2,
     label: "Settings",
+    mobileLabel: "Prefs",
   },
 ];
 
@@ -349,8 +356,8 @@ export function AppShell({ children }: AppShellProps) {
           </main>
 
           <nav className="fixed inset-x-0 bottom-0 z-30 border-t border-black/10 bg-[rgba(250,248,244,0.96)] px-3 py-2 backdrop-blur md:hidden">
-            <div className="grid grid-cols-5 gap-1">
-              {navItems.map(({ href, icon: Icon, label }) => {
+            <div className="grid grid-cols-6 gap-1">
+              {navItems.map(({ href, icon: Icon, mobileLabel }) => {
                 const active = isActivePath(pathname, href);
 
                 return (
@@ -364,7 +371,7 @@ export function AppShell({ children }: AppShellProps) {
                     key={href}
                   >
                     <Icon className="size-4" />
-                    <span>{label}</span>
+                    <span>{mobileLabel}</span>
                   </Link>
                 );
               })}

--- a/frontend/src/components/dashboard/widget-board.tsx
+++ b/frontend/src/components/dashboard/widget-board.tsx
@@ -8,6 +8,7 @@ import { LayoutTemplate, LoaderCircle } from "lucide-react";
 import { DashboardWidgetCard, DashboardBoardFootnote, dashboardWidgetMeta } from "@/components/dashboard/widget-library";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { DashboardLayoutWidget, DashboardSummary, DashboardWidgetId } from "@/types";
 
@@ -168,10 +169,26 @@ export function DashboardWidgetBoard({
       </div>
 
       {isLoading ? (
-        <div className="flex min-h-[28rem] items-center justify-center">
-          <div className="flex items-center gap-3 text-sm text-black/58">
-            <LoaderCircle className="size-4 animate-spin" />
-            Loading dashboard workspace...
+        <div className="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(260px,0.75fr)]">
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div className="rounded-[1.7rem] border border-black/10 bg-white/80 p-5" key={index}>
+                <Skeleton className="h-5 w-28" />
+                <Skeleton className="mt-4 h-9 w-32" />
+                <Skeleton className="mt-6 h-24 w-full" />
+              </div>
+            ))}
+          </div>
+          <div className="rounded-[1.7rem] border border-black/10 bg-stone/60 p-5">
+            <div className="flex items-center gap-3 text-sm text-black/58">
+              <LoaderCircle className="size-4 animate-spin" />
+              Loading dashboard workspace...
+            </div>
+            <div className="mt-5 space-y-3">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-11/12" />
+            </div>
           </div>
         </div>
       ) : !summary || !widgets || widgets.length === 0 ? (

--- a/frontend/src/components/onboarding/workspace-onboarding.tsx
+++ b/frontend/src/components/onboarding/workspace-onboarding.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ArrowRight, MoonStar, Palette, Sparkles, SunMedium, WalletCards } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import { useOnboarding } from "@/hooks/use-onboarding";
+import { cn } from "@/lib/utils";
+
+const currencyOptions = [
+  { code: "USD", label: "US Dollar" },
+  { code: "EUR", label: "Euro" },
+  { code: "GBP", label: "Pound Sterling" },
+  { code: "INR", label: "Indian Rupee" },
+] as const;
+
+const setupActions = [
+  {
+    description: "Manual entry with your saved currency already filled in.",
+    href: "/subscriptions",
+    label: "Add a subscription",
+  },
+  {
+    description: "Pull a statement in and let the queue seed the workspace.",
+    href: "/uploads",
+    label: "Upload a statement",
+  },
+  {
+    description: "Tune categories, payment rails, and display settings.",
+    href: "/settings",
+    label: "Open settings",
+  },
+] as const;
+
+function StepBadge({ currentStep }: { currentStep: number }) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/76 px-4 py-2 text-xs uppercase tracking-[0.3em] text-black/48">
+      <span>Setup guide</span>
+      <span className="rounded-full bg-[#101922] px-2 py-1 text-[10px] text-white">
+        {currentStep + 1}/3
+      </span>
+    </div>
+  );
+}
+
+export function WorkspaceOnboarding() {
+  const { completeOnboarding, preferredCurrency, setPreferredCurrency } = useOnboarding();
+  const { resolvedTheme, setTheme } = useTheme();
+  const [currentStep, setCurrentStep] = useState(0);
+  const [customCurrency, setCustomCurrency] = useState(
+    currencyOptions.some((option) => option.code === preferredCurrency) ? "" : preferredCurrency,
+  );
+
+  const effectiveCurrency = useMemo(() => {
+    const normalized = customCurrency.trim().toUpperCase().slice(0, 3);
+    return normalized.length === 3 ? normalized : preferredCurrency;
+  }, [customCurrency, preferredCurrency]);
+
+  const stepContent = [
+    {
+      description: "Pick the currency you want manual entry to suggest first. You can still override any individual plan later.",
+      eyebrow: "Currency",
+      icon: <WalletCards className="size-5" />,
+      title: "Start with the billing code you see most often",
+    },
+    {
+      description: "Choose the shell mood before the workspace fills up. The setting applies immediately and stays available in Settings.",
+      eyebrow: "Theme",
+      icon: <Palette className="size-5" />,
+      title: "Set the visual mode you want to operate in",
+    },
+    {
+      description: "The quickest way to light up the dashboard is either one manual subscription or one uploaded statement. Both paths stay one click away.",
+      eyebrow: "Get started",
+      icon: <Sparkles className="size-5" />,
+      title: "Use the next action that gets real data into the workspace",
+    },
+  ] as const;
+
+  return (
+    <section className="overflow-hidden rounded-[2.25rem] border border-black/10 bg-[linear-gradient(135deg,rgba(255,255,255,0.92),rgba(247,239,230,0.95))] shadow-[0_28px_90px_rgba(17,20,24,0.12)] animate-page-enter">
+      <div className="grid gap-0 xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]">
+        <div className="border-b border-black/10 p-6 sm:p-7 xl:border-b-0 xl:border-r">
+          <StepBadge currentStep={currentStep} />
+
+          <div className="mt-6 max-w-2xl space-y-4">
+            <div className="inline-flex size-14 items-center justify-center rounded-[1.4rem] border border-black/10 bg-[#101922] text-white">
+              {stepContent[currentStep].icon}
+            </div>
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.32em] text-black/45">
+                {stepContent[currentStep].eyebrow}
+              </p>
+              <h2 className="max-w-xl text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
+                {stepContent[currentStep].title}
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-black/66">
+                {stepContent[currentStep].description}
+              </p>
+            </div>
+          </div>
+
+          {currentStep === 0 ? (
+            <div className="mt-8 space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                {currencyOptions.map((option) => {
+                  const active = effectiveCurrency === option.code;
+
+                  return (
+                    <button
+                      className={cn(
+                        "rounded-[1.5rem] border px-4 py-4 text-left transition",
+                        active
+                          ? "border-[#101922] bg-[#101922] text-white"
+                          : "border-black/10 bg-white/76 text-ink hover:border-black/20",
+                      )}
+                      key={option.code}
+                      onClick={() => {
+                        setCustomCurrency("");
+                        setPreferredCurrency(option.code);
+                      }}
+                      type="button"
+                    >
+                      <p className="text-xs uppercase tracking-[0.28em] opacity-60">{option.code}</p>
+                      <p className="mt-3 text-lg font-semibold">{option.label}</p>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <label className="block space-y-2">
+                <span className="text-xs uppercase tracking-[0.28em] text-black/42">Custom code</span>
+                <input
+                  className="h-12 w-full rounded-[1.1rem] border border-black/10 bg-white/84 px-4 text-sm uppercase text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/20"
+                  inputMode="text"
+                  maxLength={3}
+                  onBlur={() => {
+                    if (customCurrency.trim().length === 3) {
+                      setPreferredCurrency(customCurrency);
+                    }
+                  }}
+                  onChange={(event) => setCustomCurrency(event.target.value.toUpperCase())}
+                  placeholder="AUD"
+                  value={customCurrency}
+                />
+              </label>
+            </div>
+          ) : null}
+
+          {currentStep === 1 ? (
+            <div className="mt-8 grid gap-4 md:grid-cols-2">
+              {[
+                {
+                  description: "Warm surfaces, higher contrast text, and the default editorial shell.",
+                  icon: <SunMedium className="size-5" />,
+                  label: "Light mode",
+                  theme: "light",
+                },
+                {
+                  description: "Darker backdrop with the same layout, better for lower-light sessions.",
+                  icon: <MoonStar className="size-5" />,
+                  label: "Dark mode",
+                  theme: "dark",
+                },
+              ].map((option) => {
+                const active = resolvedTheme === option.theme;
+
+                return (
+                  <button
+                    className={cn(
+                      "rounded-[1.6rem] border px-5 py-5 text-left transition",
+                      active
+                        ? "border-[#101922] bg-[#101922] text-white"
+                        : "border-black/10 bg-white/80 text-ink hover:border-black/20",
+                    )}
+                    key={option.theme}
+                    onClick={() => setTheme(option.theme)}
+                    type="button"
+                  >
+                    <div className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-current/15 bg-current/10">
+                      {option.icon}
+                    </div>
+                    <h3 className="mt-4 text-xl font-semibold">{option.label}</h3>
+                    <p className={cn("mt-2 text-sm leading-6", active ? "text-white/74" : "text-black/62")}>
+                      {option.description}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {currentStep === 2 ? (
+            <div className="mt-8 grid gap-4">
+              {setupActions.map((action) => (
+                <Link
+                  className="rounded-[1.6rem] border border-black/10 bg-white/80 px-5 py-5 transition hover:border-black/20 hover:bg-white"
+                  href={action.href}
+                  key={action.href}
+                >
+                  <p className="text-lg font-semibold text-ink">{action.label}</p>
+                  <p className="mt-2 max-w-xl text-sm leading-6 text-black/62">{action.description}</p>
+                </Link>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="mt-8 flex flex-col gap-3 border-t border-black/10 pt-5 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-black/52">
+              Preferred currency: <span className="font-semibold text-ink">{effectiveCurrency}</span>
+            </p>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              {currentStep > 0 ? (
+                <Button className="rounded-full px-5" onClick={() => setCurrentStep((step) => step - 1)} type="button" variant="ghost">
+                  Back
+                </Button>
+              ) : null}
+              {currentStep < 2 ? (
+                <Button
+                  className="rounded-full px-5"
+                  onClick={() => {
+                    if (currentStep === 0 && customCurrency.trim() && customCurrency.trim().length !== 3) {
+                      return;
+                    }
+                    setCurrentStep((step) => step + 1);
+                  }}
+                  type="button"
+                >
+                  Continue
+                  <ArrowRight className="ml-2 size-4" />
+                </Button>
+              ) : (
+                <Button
+                  className="rounded-full px-5"
+                  onClick={() => completeOnboarding(effectiveCurrency)}
+                  type="button"
+                >
+                  Finish setup
+                  <ArrowRight className="ml-2 size-4" />
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <aside className="bg-[#101922] p-6 text-white sm:p-7">
+          <p className="text-xs uppercase tracking-[0.32em] text-white/42">Why this first</p>
+          <h3 className="mt-4 text-2xl font-semibold tracking-tight">A cleaner first run avoids a blank dashboard</h3>
+          <p className="mt-3 text-sm leading-6 text-white/68">
+            Day 14 is about making the workspace readable before it is full. Save one preference, keep the layout stable, then move into the first real action.
+          </p>
+
+          <div className="mt-8 space-y-4">
+            <div className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+              <p className="text-xs uppercase tracking-[0.24em] text-white/45">Responsive pass</p>
+              <p className="mt-2 text-sm leading-6 text-white/70">
+                Navigation, empty states, and setup actions now compress cleanly from phone widths up through desktop workspace layouts.
+              </p>
+            </div>
+            <div className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+              <p className="text-xs uppercase tracking-[0.24em] text-white/45">Performance pass</p>
+              <p className="mt-2 text-sm leading-6 text-white/70">
+                Query cache defaults and skeleton states keep surfaces populated while filters, uploads, and dashboard data refresh.
+              </p>
+            </div>
+            <div className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+              <p className="text-xs uppercase tracking-[0.24em] text-white/45">Next action</p>
+              <p className="mt-2 text-sm leading-6 text-white/70">
+                The dashboard becomes useful after either one manual subscription or one successful statement upload. Both are linked in the final step.
+              </p>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/providers/app-providers.tsx
+++ b/frontend/src/components/providers/app-providers.tsx
@@ -5,15 +5,30 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 
 import { AuthProvider } from "@/components/providers/auth-provider";
+import { OnboardingProvider } from "@/components/providers/onboarding-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 
 export function AppProviders({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            gcTime: 5 * 60 * 1_000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+            staleTime: 30 * 1_000,
+          },
+        },
+      }),
+  );
 
   return (
     <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <OnboardingProvider>{children}</OnboardingProvider>
+        </AuthProvider>
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/frontend/src/components/providers/onboarding-provider.tsx
+++ b/frontend/src/components/providers/onboarding-provider.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { createContext, useEffect, useState } from "react";
+
+import { ONBOARDING_STORAGE_KEY } from "@/lib/constants";
+
+type OnboardingState = {
+  completedAt: string | null;
+  preferredCurrency: string;
+};
+
+export type OnboardingContextValue = {
+  completeOnboarding: (preferredCurrency?: string) => void;
+  isComplete: boolean;
+  isReady: boolean;
+  preferredCurrency: string;
+  resetOnboarding: () => void;
+  setPreferredCurrency: (currency: string) => void;
+};
+
+const defaultOnboardingState: OnboardingState = {
+  completedAt: null,
+  preferredCurrency: "USD",
+};
+
+export const OnboardingContext = createContext<OnboardingContextValue | null>(null);
+
+function normalizeCurrency(value: string | undefined) {
+  const normalized = value?.trim().toUpperCase().slice(0, 3) ?? "";
+  return normalized.length === 3 ? normalized : "USD";
+}
+
+function isOnboardingState(value: unknown): value is OnboardingState {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const state = value as Partial<OnboardingState>;
+  return (
+    (state.completedAt === null || typeof state.completedAt === "string") &&
+    typeof state.preferredCurrency === "string"
+  );
+}
+
+function readStoredOnboardingState() {
+  if (typeof window === "undefined") {
+    return defaultOnboardingState;
+  }
+
+  const stored = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
+  if (!stored) {
+    return defaultOnboardingState;
+  }
+
+  try {
+    const parsed = JSON.parse(stored) as unknown;
+    if (isOnboardingState(parsed)) {
+      return {
+        completedAt: parsed.completedAt,
+        preferredCurrency: normalizeCurrency(parsed.preferredCurrency),
+      };
+    }
+  } catch {
+    // Fall through to clearing malformed data.
+  }
+
+  window.localStorage.removeItem(ONBOARDING_STORAGE_KEY);
+  return defaultOnboardingState;
+}
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<OnboardingState>(defaultOnboardingState);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    setState(readStoredOnboardingState());
+    setIsReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isReady || typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state));
+  }, [isReady, state]);
+
+  const value: OnboardingContextValue = {
+    completeOnboarding: (preferredCurrency) => {
+      setState((current) => ({
+        completedAt: new Date().toISOString(),
+        preferredCurrency: normalizeCurrency(preferredCurrency ?? current.preferredCurrency),
+      }));
+    },
+    isComplete: Boolean(state.completedAt),
+    isReady,
+    preferredCurrency: state.preferredCurrency,
+    resetOnboarding: () => setState(defaultOnboardingState),
+    setPreferredCurrency: (currency) => {
+      setState((current) => ({
+        ...current,
+        preferredCurrency: normalizeCurrency(currency),
+      }));
+    },
+  };
+
+  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
+}

--- a/frontend/src/components/subscriptions/subscription-form.tsx
+++ b/frontend/src/components/subscriptions/subscription-form.tsx
@@ -24,6 +24,7 @@ type SubscriptionFormProps = {
   onCancel?: () => void;
   onSubmit: (payload: SubscriptionUpsertInput) => Promise<void>;
   paymentMethods: PaymentMethod[];
+  preferredCurrency?: string;
   submitLabel: string;
   testId?: string;
   title: string;
@@ -45,6 +46,7 @@ export function SubscriptionForm({
   onCancel,
   onSubmit,
   paymentMethods,
+  preferredCurrency = "USD",
   submitLabel,
   testId,
   title,
@@ -55,13 +57,13 @@ export function SubscriptionForm({
     register,
     reset,
   } = useForm<SubscriptionFormValues>({
-    defaultValues: buildSubscriptionFormValues(initialSubscription),
+    defaultValues: buildSubscriptionFormValues(initialSubscription, preferredCurrency),
     resolver: zodResolver(subscriptionFormSchema),
   });
 
   useEffect(() => {
-    reset(buildSubscriptionFormValues(initialSubscription));
-  }, [initialSubscription, reset]);
+    reset(buildSubscriptionFormValues(initialSubscription, preferredCurrency));
+  }, [initialSubscription, preferredCurrency, reset]);
 
   const isWorking = disabled || isSubmitting;
 
@@ -81,7 +83,7 @@ export function SubscriptionForm({
         onSubmit={handleSubmit(async (values) => {
           await onSubmit(toSubscriptionPayload(values));
           if (!initialSubscription) {
-            reset(buildSubscriptionFormValues());
+            reset(buildSubscriptionFormValues(undefined, preferredCurrency));
           }
         })}
       >
@@ -138,6 +140,11 @@ export function SubscriptionForm({
                 placeholder="USD"
                 {...register("currency")}
               />
+              {!initialSubscription ? (
+                <p className="text-xs uppercase tracking-[0.24em] text-black/42">
+                  Workspace default: {preferredCurrency}
+                </p>
+              ) : null}
               <FieldError message={errors.currency?.message} />
             </div>
 

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from "@/lib/utils";
+
+type SkeletonProps = {
+  className?: string;
+};
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div aria-hidden="true" className={cn("animate-pulse rounded-[1.1rem] bg-black/[0.08]", className)} />;
+}

--- a/frontend/src/components/uploads/upload-dropzone.tsx
+++ b/frontend/src/components/uploads/upload-dropzone.tsx
@@ -40,9 +40,10 @@ function formatSize(size: number) {
 type UploadDropzoneProps = {
   disabled?: boolean;
   onUpload: (file: File, onProgress: (progress: number) => void) => Promise<void>;
+  sectionId?: string;
 };
 
-export function UploadDropzone({ disabled = false, onUpload }: UploadDropzoneProps) {
+export function UploadDropzone({ disabled = false, onUpload, sectionId }: UploadDropzoneProps) {
   const inputId = useId();
   const [dragActive, setDragActive] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -97,7 +98,10 @@ export function UploadDropzone({ disabled = false, onUpload }: UploadDropzonePro
   }
 
   return (
-    <section className="overflow-hidden rounded-[2rem] border border-black/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.86),rgba(245,239,231,0.92))] shadow-line backdrop-blur">
+    <section
+      className="overflow-hidden rounded-[2rem] border border-black/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.86),rgba(245,239,231,0.92))] shadow-line backdrop-blur"
+      id={sectionId}
+    >
       <div className="border-b border-black/10 px-5 py-5 sm:px-6">
         <p className="text-xs uppercase tracking-[0.32em] text-black/45">Ingest</p>
         <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">

--- a/frontend/src/hooks/use-dashboard.ts
+++ b/frontend/src/hooks/use-dashboard.ts
@@ -33,7 +33,9 @@ export function useDashboardSummary() {
   return useQuery({
     enabled: Boolean(accessToken),
     queryFn: () => apiClient.getDashboardSummary(accessToken!),
+    placeholderData: (previousData) => previousData,
     queryKey: dashboardKeys.summary,
+    staleTime: 30_000,
   });
 }
 
@@ -43,7 +45,9 @@ export function useDashboardLayout() {
   return useQuery({
     enabled: Boolean(accessToken),
     queryFn: () => apiClient.getDashboardLayout(accessToken!),
+    placeholderData: (previousData) => previousData,
     queryKey: dashboardKeys.layout,
+    staleTime: 30_000,
   });
 }
 

--- a/frontend/src/hooks/use-onboarding.ts
+++ b/frontend/src/hooks/use-onboarding.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useContext } from "react";
+
+import { OnboardingContext } from "@/components/providers/onboarding-provider";
+
+export function useOnboarding() {
+  const context = useContext(OnboardingContext);
+
+  if (context === null) {
+    throw new Error("useOnboarding must be used within OnboardingProvider.");
+  }
+
+  return context;
+}

--- a/frontend/src/hooks/use-subscriptions.ts
+++ b/frontend/src/hooks/use-subscriptions.ts
@@ -36,13 +36,17 @@ export function useSubscriptionCatalog() {
   const categoriesQuery = useQuery({
     enabled,
     queryFn: () => apiClient.getCategories(accessToken!),
+    placeholderData: (previousData) => previousData,
     queryKey: subscriptionKeys.categories,
+    staleTime: 60_000,
   });
 
   const paymentMethodsQuery = useQuery({
     enabled,
     queryFn: () => apiClient.getPaymentMethods(accessToken!),
+    placeholderData: (previousData) => previousData,
     queryKey: subscriptionKeys.paymentMethods,
+    staleTime: 60_000,
   });
 
   return {
@@ -57,7 +61,9 @@ export function useSubscriptionList(filters: SubscriptionFilters) {
   return useQuery({
     enabled: Boolean(accessToken),
     queryFn: () => apiClient.getSubscriptions(accessToken!, filters),
+    placeholderData: (previousData) => previousData,
     queryKey: subscriptionKeys.list(filters),
+    staleTime: 30_000,
   });
 }
 
@@ -67,7 +73,9 @@ export function useSubscription(subscriptionId: number) {
   return useQuery({
     enabled: Boolean(accessToken) && Number.isFinite(subscriptionId),
     queryFn: () => apiClient.getSubscription(accessToken!, subscriptionId),
+    placeholderData: (previousData) => previousData,
     queryKey: subscriptionKeys.detail(subscriptionId),
+    staleTime: 30_000,
   });
 }
 

--- a/frontend/src/hooks/use-uploads.ts
+++ b/frontend/src/hooks/use-uploads.ts
@@ -27,7 +27,9 @@ export function useUploadHistory() {
   return useQuery({
     enabled: Boolean(accessToken),
     queryFn: () => apiClient.getUploads(accessToken!),
+    placeholderData: (previousData) => previousData,
     queryKey: uploadKeys.history,
+    staleTime: 20_000,
     refetchIntervalInBackground: true,
     refetchOnMount: "always",
     refetchInterval: (query) => {
@@ -45,7 +47,9 @@ export function useUploadStatus(uploadId: number | null) {
   return useQuery({
     enabled: Boolean(accessToken) && uploadId !== null,
     queryFn: () => apiClient.getUploadStatus(accessToken!, uploadId!),
+    placeholderData: (previousData) => previousData,
     queryKey: uploadId === null ? ["uploads", "status", "idle"] : uploadKeys.status(uploadId),
+    staleTime: 10_000,
     refetchIntervalInBackground: true,
     refetchOnMount: "always",
     refetchInterval: (query) => {

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,3 +1,4 @@
 export const APP_NAME = "MySubscription Tracker";
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api/v1";
 export const AUTH_STORAGE_KEY = "mysubscription.auth";
+export const ONBOARDING_STORAGE_KEY = "mysubscription.onboarding";

--- a/frontend/src/lib/validators.ts
+++ b/frontend/src/lib/validators.ts
@@ -75,7 +75,10 @@ export const subscriptionFormSchema = z
 
 export type SubscriptionFormValues = z.infer<typeof subscriptionFormSchema>;
 
-export function buildSubscriptionFormValues(subscription?: Subscription | null): SubscriptionFormValues {
+export function buildSubscriptionFormValues(
+  subscription?: Subscription | null,
+  defaultCurrency = "USD",
+): SubscriptionFormValues {
   if (!subscription) {
     const today = new Date().toISOString().slice(0, 10);
     return {
@@ -83,7 +86,7 @@ export function buildSubscriptionFormValues(subscription?: Subscription | null):
       auto_renew: true,
       cadence: "monthly",
       category_id: "",
-      currency: "USD",
+      currency: defaultCurrency.trim().toUpperCase().slice(0, 3) || "USD",
       day_of_month: "",
       description: "",
       end_date: "",

--- a/frontend/tests/unit/hooks/use-onboarding.test.ts
+++ b/frontend/tests/unit/hooks/use-onboarding.test.ts
@@ -1,0 +1,90 @@
+import { act, render as rtlRender } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { OnboardingProvider } from "@/components/providers/onboarding-provider";
+import { useOnboarding } from "@/hooks/use-onboarding";
+
+function OnboardingHarness() {
+  const { completeOnboarding, isComplete, preferredCurrency, setPreferredCurrency } = useOnboarding();
+
+  return createElement(
+    "div",
+    null,
+    createElement("p", { "data-testid": "currency" }, preferredCurrency),
+    createElement("p", { "data-testid": "complete" }, isComplete ? "complete" : "incomplete"),
+    createElement(
+      "button",
+      {
+        onClick: () => setPreferredCurrency("eur"),
+        type: "button",
+      },
+      "Set currency",
+    ),
+    createElement(
+      "button",
+      {
+        onClick: () => completeOnboarding("gbp"),
+        type: "button",
+      },
+      "Complete",
+    ),
+  );
+}
+
+describe("useOnboarding", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("requires an onboarding provider", () => {
+    expect(() => rtlRender(createElement(OnboardingHarness))).toThrow(
+      "useOnboarding must be used within OnboardingProvider.",
+    );
+  });
+
+  it("restores persisted preferences after hydration", async () => {
+    window.localStorage.setItem(
+      "mysubscription.onboarding",
+      JSON.stringify({
+        completedAt: "2026-04-15T16:30:00.000Z",
+        preferredCurrency: "cad",
+      }),
+    );
+
+    const { getByTestId } = rtlRender(
+      createElement(OnboardingProvider, null, createElement(OnboardingHarness)),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(getByTestId("currency")).toHaveTextContent("CAD");
+    expect(getByTestId("complete")).toHaveTextContent("complete");
+  });
+
+  it("updates the stored currency and completion flag", async () => {
+    const { getByRole, getByTestId } = rtlRender(
+      createElement(OnboardingProvider, null, createElement(OnboardingHarness)),
+    );
+
+    await act(async () => {
+      getByRole("button", { name: "Set currency" }).click();
+    });
+
+    expect(getByTestId("currency")).toHaveTextContent("EUR");
+
+    await act(async () => {
+      getByRole("button", { name: "Complete" }).click();
+    });
+
+    expect(getByTestId("currency")).toHaveTextContent("GBP");
+    expect(getByTestId("complete")).toHaveTextContent("complete");
+    expect(window.localStorage.getItem("mysubscription.onboarding")).toContain("\"preferredCurrency\":\"GBP\"");
+  });
+});

--- a/frontend/tests/unit/lib/validators.test.ts
+++ b/frontend/tests/unit/lib/validators.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildSubscriptionFormValues,
   subscriptionFormSchema,
   toSubscriptionPayload,
 } from "@/lib/validators";
@@ -93,5 +94,11 @@ describe("subscription validators", () => {
     expect(result.error?.flatten().fieldErrors.end_date).toContain(
       "End date must be on or after the start date.",
     );
+  });
+
+  it("uses the preferred currency when building a new subscription draft", () => {
+    const draft = buildSubscriptionFormValues(undefined, "eur");
+
+    expect(draft.currency).toBe("EUR");
   });
 });


### PR DESCRIPTION
Day 14 is complete on `day-14/onboarding-empty-states-polish` and pushed at `6c6e910`. The run added a persisted onboarding guide with preferred-currency and theme setup, upgraded empty states across dashboard/subscriptions/uploads/settings/payments/calendar, tightened the mobile shell, and added skeleton/cache polish plus Day 14 unit coverage.

Verification passed with `npm test`, `npm run lint`, `npm run typecheck`, `npm run build`, and a follow-up `npm run typecheck`. The first test pass exposed a stale local frontend install missing `recharts`; `bootstrap.sh` refreshed shared deps, preflight passed again, and the rerun succeeded. GitHub sync is complete: child issue `#57` closed, umbrella issue `#56` closed, and milestone `14` closed. Remaining local repo noise is limited to untracked environment directories: `backend/.venv` and `frontend/node_modules`. The next scheduled run should advance to Day 15 on `day-15/mvp-polish-landing-page`.

::inbox-item{title="Day 14 onboarding shipped" summary="Tracker closed; next run should start Day 15"}