### PR TITLE
Day 15/mvp polish landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Mark the Day 15 MVP milestone complete with a polished landing page, global error handling, and final security/logging hardening.
+- Ship the MVP surface across subscriptions, uploads, dashboard widgets, onboarding, settings, and authentication flows.
 - Bootstrap backend FastAPI structure, logging, database layer, storage and email abstractions.
 - Bootstrap frontend Next.js app shell, providers, and test harness.
 - Add Docker Compose, Makefile, and GitHub Actions workflows for Day 1.

--- a/backend/alembic/versions/20260416_0005_user_scoped_categories.py
+++ b/backend/alembic/versions/20260416_0005_user_scoped_categories.py
@@ -1,0 +1,107 @@
+"""Convert categories to user-scoped records."""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260416_0005"
+down_revision = "20260407_0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "categories",
+        sa.Column(
+            "user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+        ),
+    )
+    op.drop_index("ix_categories_name", table_name="categories")
+    op.drop_index("ix_categories_slug", table_name="categories")
+
+    connection = op.get_bind()
+    categories = sa.table(
+        "categories",
+        sa.column("id", sa.Integer()),
+        sa.column("user_id", sa.Integer()),
+        sa.column("name", sa.String()),
+        sa.column("slug", sa.String()),
+        sa.column("description", sa.String()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+    subscriptions = sa.table(
+        "subscriptions",
+        sa.column("category_id", sa.Integer()),
+        sa.column("user_id", sa.Integer()),
+    )
+
+    category_rows = {
+        row.id: row
+        for row in connection.execute(
+            sa.select(
+                categories.c.id,
+                categories.c.name,
+                categories.c.slug,
+                categories.c.description,
+                categories.c.created_at,
+                categories.c.updated_at,
+            )
+        )
+    }
+    category_users: dict[int, list[int]] = {}
+    for row in connection.execute(
+        sa.select(subscriptions.c.category_id, subscriptions.c.user_id)
+        .where(subscriptions.c.category_id.is_not(None))
+        .order_by(subscriptions.c.category_id.asc(), subscriptions.c.user_id.asc())
+    ):
+        if row.category_id is None:
+            continue
+        users = category_users.setdefault(row.category_id, [])
+        if row.user_id not in users:
+            users.append(row.user_id)
+
+    for category_id, row in category_rows.items():
+        users = category_users.get(category_id, [])
+        if not users:
+            connection.execute(sa.delete(categories).where(categories.c.id == category_id))
+            continue
+
+        connection.execute(
+            sa.update(categories).where(categories.c.id == category_id).values(user_id=users[0])
+        )
+
+        for user_id in users[1:]:
+            insert_result = connection.execute(
+                sa.insert(categories).values(
+                    user_id=user_id,
+                    name=row.name,
+                    slug=row.slug,
+                    description=row.description,
+                    created_at=row.created_at,
+                    updated_at=row.updated_at,
+                )
+            )
+            new_category_id = insert_result.inserted_primary_key[0]
+            connection.execute(
+                sa.update(subscriptions)
+                .where(
+                    subscriptions.c.category_id == category_id,
+                    subscriptions.c.user_id == user_id,
+                )
+                .values(category_id=new_category_id)
+            )
+
+    connection.execute(sa.delete(categories).where(categories.c.user_id.is_(None)))
+    op.alter_column("categories", "user_id", nullable=False)
+    op.create_index("ix_categories_user_id_name", "categories", ["user_id", "name"], unique=True)
+    op.create_index("ix_categories_user_id_slug", "categories", ["user_id", "slug"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_categories_user_id_slug", table_name="categories")
+    op.drop_index("ix_categories_user_id_name", table_name="categories")
+    op.create_index("ix_categories_slug", "categories", ["slug"], unique=True)
+    op.create_index("ix_categories_name", "categories", ["name"], unique=True)
+    op.drop_column("categories", "user_id")

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -31,6 +31,8 @@ CurrentUser = Annotated[User, Depends(get_current_user)]
     response_model=TokenResponse,
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(rate_limit("auth-register"))],
+    summary="Register a new user",
+    description="Create an account and return fresh access and refresh tokens for immediate use.",
 )
 async def register(
     payload: RegisterRequest,
@@ -44,6 +46,8 @@ async def register(
     response_model=TokenResponse,
     status_code=status.HTTP_200_OK,
     dependencies=[Depends(rate_limit("auth-login"))],
+    summary="Log in with email and password",
+    description="Authenticate an existing user and return new bearer tokens.",
 )
 async def login(
     payload: LoginRequest,
@@ -57,6 +61,8 @@ async def login(
     response_model=TokenResponse,
     status_code=status.HTTP_200_OK,
     dependencies=[Depends(rate_limit("auth-refresh"))],
+    summary="Refresh an authenticated session",
+    description="Exchange a valid refresh token for a new access and refresh token pair.",
 )
 async def refresh(
     payload: RefreshRequest,
@@ -65,12 +71,21 @@ async def refresh(
     return await refresh_user_tokens(session, payload.refresh_token)
 
 
-@router.get("/me", response_model=UserResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the current user profile",
+)
 async def me(current_user: CurrentUser) -> UserResponse:
     return UserResponse.model_validate(current_user)
 
 
-@router.delete("/me/data", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/me/data",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete all workspace-owned user data",
+)
 async def delete_my_workspace_data(
     session: DbSession,
     current_user: CurrentUser,

--- a/backend/src/api/routes/categories.py
+++ b/backend/src/api/routes/categories.py
@@ -25,54 +25,78 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
 
 
-@router.get("", response_model=CategoryListResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "",
+    response_model=CategoryListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List categories",
+)
 async def get_categories(
     session: DbSession,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
 ) -> CategoryListResponse:
-    items, total = await list_categories(session)
+    items, total = await list_categories(session, current_user)
     return CategoryListResponse(
         items=[CategoryResponse.model_validate(item) for item in items],
         total=total,
     )
 
 
-@router.post("", response_model=CategoryResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=CategoryResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a category",
+)
 async def create_category_route(
     payload: CategoryCreate,
     session: DbSession,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
 ) -> CategoryResponse:
-    category = await create_category(session, payload)
+    category = await create_category(session, current_user, payload)
     return CategoryResponse.model_validate(category)
 
 
-@router.get("/{category_id}", response_model=CategoryResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/{category_id}",
+    response_model=CategoryResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get a category",
+)
 async def get_category(
     category_id: int,
     session: DbSession,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
 ) -> CategoryResponse:
-    category = await get_category_or_404(session, category_id)
+    category = await get_category_or_404(session, category_id, current_user)
     return CategoryResponse.model_validate(category)
 
 
-@router.patch("/{category_id}", response_model=CategoryResponse, status_code=status.HTTP_200_OK)
+@router.patch(
+    "/{category_id}",
+    response_model=CategoryResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update a category",
+)
 async def update_category_route(
     category_id: int,
     payload: CategoryUpdate,
     session: DbSession,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
 ) -> CategoryResponse:
-    category = await update_category(session, category_id, payload)
+    category = await update_category(session, category_id, current_user, payload)
     return CategoryResponse.model_validate(category)
 
 
-@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{category_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a category",
+)
 async def delete_category_route(
     category_id: int,
     session: DbSession,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
 ) -> Response:
-    await delete_category(session, category_id)
+    await delete_category(session, category_id, current_user)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/api/routes/dashboard.py
+++ b/backend/src/api/routes/dashboard.py
@@ -22,7 +22,12 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
 
 
-@router.get("/summary", response_model=DashboardSummaryResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/summary",
+    response_model=DashboardSummaryResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get dashboard summary metrics",
+)
 async def get_dashboard_summary_route(
     session: DbSession,
     current_user: CurrentUser,
@@ -30,7 +35,12 @@ async def get_dashboard_summary_route(
     return await get_dashboard_summary(session, user=current_user)
 
 
-@router.get("/layout", response_model=DashboardLayoutResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/layout",
+    response_model=DashboardLayoutResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the saved dashboard layout",
+)
 async def get_dashboard_layout_route(
     session: DbSession,
     current_user: CurrentUser,
@@ -38,7 +48,12 @@ async def get_dashboard_layout_route(
     return await get_dashboard_layout(session, user=current_user)
 
 
-@router.put("/layout", response_model=DashboardLayoutResponse, status_code=status.HTTP_200_OK)
+@router.put(
+    "/layout",
+    response_model=DashboardLayoutResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Replace the saved dashboard layout",
+)
 async def update_dashboard_layout_route(
     payload: DashboardLayoutUpdate,
     session: DbSession,

--- a/backend/src/api/routes/health.py
+++ b/backend/src/api/routes/health.py
@@ -6,7 +6,7 @@ router = APIRouter(prefix="/health")
 logger = get_logger(__name__)
 
 
-@router.get("", status_code=status.HTTP_200_OK)
+@router.get("", status_code=status.HTTP_200_OK, summary="Check API health")
 async def health_check() -> dict[str, str]:
     logger.info("health.check", service="api", status="ok")
     return {

--- a/backend/src/api/routes/payment_methods.py
+++ b/backend/src/api/routes/payment_methods.py
@@ -25,7 +25,12 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
 
 
-@router.get("", response_model=PaymentMethodListResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "",
+    response_model=PaymentMethodListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List payment methods",
+)
 async def get_payment_methods(
     session: DbSession,
     current_user: CurrentUser,
@@ -37,7 +42,12 @@ async def get_payment_methods(
     )
 
 
-@router.post("", response_model=PaymentMethodResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=PaymentMethodResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a payment method",
+)
 async def create_payment_method_route(
     payload: PaymentMethodCreate,
     session: DbSession,
@@ -51,6 +61,7 @@ async def create_payment_method_route(
     "/{payment_method_id}",
     response_model=PaymentMethodResponse,
     status_code=status.HTTP_200_OK,
+    summary="Get a payment method",
 )
 async def get_payment_method(
     payment_method_id: int,
@@ -65,6 +76,7 @@ async def get_payment_method(
     "/{payment_method_id}",
     response_model=PaymentMethodResponse,
     status_code=status.HTTP_200_OK,
+    summary="Update a payment method",
 )
 async def update_payment_method_route(
     payment_method_id: int,
@@ -81,7 +93,11 @@ async def update_payment_method_route(
     return PaymentMethodResponse.model_validate(payment_method)
 
 
-@router.delete("/{payment_method_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{payment_method_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a payment method",
+)
 async def delete_payment_method_route(
     payment_method_id: int,
     session: DbSession,

--- a/backend/src/api/routes/subscriptions.py
+++ b/backend/src/api/routes/subscriptions.py
@@ -28,7 +28,16 @@ MinAmountQuery = Annotated[Decimal | None, Query()]
 MaxAmountQuery = Annotated[Decimal | None, Query()]
 
 
-@router.get("", response_model=SubscriptionListResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "",
+    response_model=SubscriptionListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List subscriptions",
+    description=(
+        "Return a paginated, filterable list of subscriptions "
+        "owned by the authenticated user."
+    ),
+)
 async def get_subscriptions(
     session: DbSession,
     current_user: CurrentUser,
@@ -69,7 +78,12 @@ async def get_subscriptions(
     )
 
 
-@router.post("", response_model=SubscriptionResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=SubscriptionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a subscription",
+)
 async def create_subscription_route(
     payload: SubscriptionCreate,
     session: DbSession,
@@ -83,6 +97,7 @@ async def create_subscription_route(
     "/{subscription_id}",
     response_model=SubscriptionResponse,
     status_code=status.HTTP_200_OK,
+    summary="Get a subscription",
 )
 async def get_subscription(
     subscription_id: int,
@@ -101,6 +116,7 @@ async def get_subscription(
     "/{subscription_id}",
     response_model=SubscriptionResponse,
     status_code=status.HTTP_200_OK,
+    summary="Update a subscription",
 )
 async def update_subscription_route(
     subscription_id: int,
@@ -117,7 +133,11 @@ async def update_subscription_route(
     return SubscriptionResponse.model_validate(subscription)
 
 
-@router.delete("/{subscription_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{subscription_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a subscription",
+)
 async def delete_subscription_route(
     subscription_id: int,
     session: DbSession,

--- a/backend/src/api/routes/uploads.py
+++ b/backend/src/api/routes/uploads.py
@@ -14,7 +14,12 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
 
 
-@router.post("", response_model=UploadResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "",
+    response_model=UploadResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create an upload",
+)
 async def create_upload_route(
     background_tasks: BackgroundTasks,
     session: DbSession,
@@ -29,7 +34,12 @@ async def create_upload_route(
     )
 
 
-@router.get("", response_model=UploadListResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "",
+    response_model=UploadListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List uploads",
+)
 async def list_uploads_route(
     session: DbSession,
     current_user: CurrentUser,
@@ -37,7 +47,12 @@ async def list_uploads_route(
     return await list_uploads(session, user=current_user)
 
 
-@router.get("/{upload_id}/status", response_model=UploadResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    "/{upload_id}/status",
+    response_model=UploadResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get upload processing status",
+)
 async def get_upload_status_route(
     upload_id: int,
     session: DbSession,
@@ -46,7 +61,11 @@ async def get_upload_status_route(
     return await get_upload_status(session, upload_id=upload_id, user=current_user)
 
 
-@router.delete("/{upload_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{upload_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete an upload",
+)
 async def delete_upload_route(
     upload_id: int,
     session: DbSession,

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -1,6 +1,6 @@
 from functools import lru_cache
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -29,6 +29,16 @@ class Settings(BaseSettings):
     aws_bucket_name: str | None = None
     upload_job_backend: str = "inline"
     redis_url: str = "redis://localhost:6379/0"
+
+    @model_validator(mode="after")
+    def validate_security_defaults(self) -> "Settings":
+        environment = self.environment.lower()
+        if (
+            environment not in {"development", "test"}
+            and self.jwt_secret_key == "dev-secret-change-me"
+        ):
+            raise ValueError("JWT_SECRET_KEY must be overridden outside development and test.")
+        return self
 
     model_config = SettingsConfigDict(
         env_file=".env.development",

--- a/backend/src/core/middleware.py
+++ b/backend/src/core/middleware.py
@@ -14,10 +14,20 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         structlog.contextvars.bind_contextvars(request_id=request_id)
 
         start = time.perf_counter()
-        response = await call_next(request)
-        duration_ms = round((time.perf_counter() - start) * 1000, 2)
-
         logger = structlog.get_logger("request")
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = round((time.perf_counter() - start) * 1000, 2)
+            logger.exception(
+                "http.request.failed",
+                method=request.method,
+                path=request.url.path,
+                duration_ms=duration_ms,
+            )
+            raise
+
+        duration_ms = round((time.perf_counter() - start) * 1000, 2)
         logger.info(
             "http.request.completed",
             method=request.method,

--- a/backend/src/core/rate_limiter.py
+++ b/backend/src/core/rate_limiter.py
@@ -5,6 +5,9 @@ from time import monotonic
 from fastapi import HTTPException, Request, status
 
 from src.config import get_settings
+from src.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class InMemoryRateLimiter:
@@ -23,6 +26,12 @@ class InMemoryRateLimiter:
             bucket.popleft()
 
         if len(bucket) >= limit:
+            logger.warning(
+                "rate_limit.exceeded",
+                bucket=key,
+                limit=limit,
+                window_seconds=window_seconds,
+            )
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Too many requests. Try again in a minute.",

--- a/backend/src/core/security.py
+++ b/backend/src/core/security.py
@@ -6,7 +6,11 @@ from passlib.context import CryptContext  # type: ignore[import-untyped]
 
 from src.config import get_settings
 
-pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
+pwd_context = CryptContext(
+    schemes=["pbkdf2_sha256"],
+    pbkdf2_sha256__default_rounds=390000,
+    deprecated="auto",
+)
 
 
 def hash_password(password: str) -> str:

--- a/backend/src/dependencies.py
+++ b/backend/src/dependencies.py
@@ -6,12 +6,14 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.database import get_db
+from src.core.logging import get_logger
 from src.core.security import decode_token
 from src.models.user import User
 
 bearer_scheme = HTTPBearer(auto_error=False)
 BearerCredentials = Annotated[HTTPAuthorizationCredentials | None, Depends(bearer_scheme)]
 DbSession = Annotated[AsyncSession, Depends(get_db)]
+logger = get_logger(__name__)
 
 
 async def get_current_user(
@@ -19,6 +21,7 @@ async def get_current_user(
     session: DbSession,
 ) -> User:
     if credentials is None:
+        logger.warning("auth.credentials_missing")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authentication required.",
@@ -28,6 +31,7 @@ async def get_current_user(
     try:
         payload = decode_token(credentials.credentials)
     except ValueError as exc:
+        logger.warning("auth.token_invalid")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token.",
@@ -35,6 +39,7 @@ async def get_current_user(
         ) from exc
 
     if payload["type"] != "access":
+        logger.warning("auth.token_wrong_type", token_type=payload["type"])
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Access token required.",
@@ -43,6 +48,7 @@ async def get_current_user(
 
     user = await session.scalar(select(User).where(User.id == int(payload["sub"])))
     if user is None or not user.is_active:
+        logger.warning("auth.user_unavailable", user_id=payload["sub"])
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User account is unavailable.",

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -29,7 +29,50 @@ def create_app() -> FastAPI:
     if settings.sentry_dsn:
         sentry_sdk.init(dsn=settings.sentry_dsn, environment=settings.environment)
 
-    app = FastAPI(title=settings.app_name, lifespan=lifespan)
+    app = FastAPI(
+        title=settings.app_name,
+        description=(
+            "API for subscription tracking, statement uploads, dashboard summaries, "
+            "workspace settings, and authenticated operator workflows."
+        ),
+        lifespan=lifespan,
+        openapi_tags=[
+            {"name": "health", "description": "Service readiness and uptime checks."},
+            {
+                "name": "auth",
+                "description": "Registration, login, token refresh, and workspace reset endpoints.",
+            },
+            {
+                "name": "categories",
+                "description": (
+                    "User-scoped subscription categories used across forms, "
+                    "filters, and dashboards."
+                ),
+            },
+            {
+                "name": "payment-methods",
+                "description": (
+                    "User-scoped payment rails used by subscriptions "
+                    "and payment history."
+                ),
+            },
+            {
+                "name": "subscriptions",
+                "description": "CRUD and filtering for recurring subscription records.",
+            },
+            {
+                "name": "dashboard",
+                "description": "Dashboard summary metrics and persistent widget layout state.",
+            },
+            {
+                "name": "uploads",
+                "description": (
+                    "Statement file ingestion, upload history, "
+                    "and processing status checks."
+                ),
+            },
+        ],
+    )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.backend_cors_origins,

--- a/backend/src/models/category.py
+++ b/backend/src/models/category.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String
+from sqlalchemy import ForeignKey, Index, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.models.base import Base, TimestampMixin
@@ -6,8 +6,13 @@ from src.models.base import Base, TimestampMixin
 
 class Category(TimestampMixin, Base):
     __tablename__ = "categories"
+    __table_args__ = (
+        Index("ix_categories_user_id_name", "user_id", "name", unique=True),
+        Index("ix_categories_user_id_slug", "user_id", "slug", unique=True),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String(100), unique=True)
-    slug: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(100))
+    slug: Mapped[str] = mapped_column(String(100))
     description: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/src/services/auth.py
+++ b/backend/src/services/auth.py
@@ -1,12 +1,13 @@
 from datetime import timedelta
 
 from fastapi import HTTPException, status
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config import get_settings
 from src.core.logging import get_logger
 from src.core.security import create_token, decode_token, hash_password, verify_password
+from src.models.category import Category
 from src.models.dashboard_layout import DashboardLayout
 from src.models.data_source import DataSource
 from src.models.payment_history import PaymentHistory
@@ -122,16 +123,21 @@ async def delete_user_workspace_data(session: AsyncSession, user: User) -> None:
             delete(PaymentHistory).where(PaymentHistory.subscription_id.in_(subscription_ids)),
         )
 
+    category_total = await session.scalar(
+        select(func.count()).select_from(Category).where(Category.user_id == user.id)
+    )
     await session.execute(delete(DashboardLayout).where(DashboardLayout.user_id == user.id))
     await session.execute(delete(RawTransaction).where(RawTransaction.user_id == user.id))
     await session.execute(delete(DataSource).where(DataSource.user_id == user.id))
     await session.execute(delete(Subscription).where(Subscription.user_id == user.id))
     await session.execute(delete(PaymentMethod).where(PaymentMethod.user_id == user.id))
+    await session.execute(delete(Category).where(Category.user_id == user.id))
     await session.commit()
 
     logger.info(
         "auth.workspace_data_deleted",
         user_id=user.id,
+        categories_removed=int(category_total or 0),
         dashboard_layouts_removed=True,
         payment_methods_removed=True,
         subscriptions_removed=len(subscription_ids),

--- a/backend/src/services/category.py
+++ b/backend/src/services/category.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.core.logging import get_logger
 from src.models.category import Category
 from src.models.subscription import Subscription
+from src.models.user import User
 from src.schemas.category import CategoryCreate, CategoryUpdate
 
 logger = get_logger(__name__)
@@ -20,31 +21,43 @@ def _slugify(name: str) -> str:
 async def _get_duplicate_category(
     session: AsyncSession,
     *,
+    user_id: int,
     name: str,
     exclude_id: int | None = None,
 ) -> Category | None:
-    statement = select(Category).where(func.lower(Category.name) == name.lower())
+    statement = select(Category).where(
+        Category.user_id == user_id,
+        func.lower(Category.name) == name.lower(),
+    )
     if exclude_id is not None:
         statement = statement.where(Category.id != exclude_id)
     return await session.scalar(statement)
 
 
-async def list_categories(session: AsyncSession) -> tuple[list[Category], int]:
-    items = list((await session.scalars(select(Category).order_by(Category.id.asc()))).all())
-    total = await session.scalar(select(func.count()).select_from(Category))
-    logger.info("categories.listed", total=total)
+async def list_categories(session: AsyncSession, user: User) -> tuple[list[Category], int]:
+    statement = select(Category).where(Category.user_id == user.id).order_by(Category.id.asc())
+    items = list((await session.scalars(statement)).all())
+    total = await session.scalar(
+        select(func.count()).select_from(Category).where(Category.user_id == user.id)
+    )
+    logger.info("categories.listed", user_id=user.id, total=total)
     return items, int(total or 0)
 
 
-async def get_category_or_404(session: AsyncSession, category_id: int) -> Category:
-    category = await session.get(Category, category_id)
+async def get_category_or_404(
+    session: AsyncSession,
+    category_id: int,
+    user: User,
+) -> Category:
+    statement = select(Category).where(Category.id == category_id, Category.user_id == user.id)
+    category = await session.scalar(statement)
     if category is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found.")
     return category
 
 
-async def create_category(session: AsyncSession, payload: CategoryCreate) -> Category:
-    duplicate = await _get_duplicate_category(session, name=payload.name)
+async def create_category(session: AsyncSession, user: User, payload: CategoryCreate) -> Category:
+    duplicate = await _get_duplicate_category(session, user_id=user.id, name=payload.name)
     if duplicate is not None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -52,6 +65,7 @@ async def create_category(session: AsyncSession, payload: CategoryCreate) -> Cat
         )
 
     category = Category(
+        user_id=user.id,
         name=payload.name,
         slug=_slugify(payload.name),
         description=payload.description,
@@ -59,21 +73,28 @@ async def create_category(session: AsyncSession, payload: CategoryCreate) -> Cat
     session.add(category)
     await session.commit()
     await session.refresh(category)
-    logger.info("categories.created", category_id=category.id, slug=category.slug)
+    logger.info(
+        "categories.created",
+        user_id=user.id,
+        category_id=category.id,
+        slug=category.slug,
+    )
     return category
 
 
 async def update_category(
     session: AsyncSession,
     category_id: int,
+    user: User,
     payload: CategoryUpdate,
 ) -> Category:
-    category = await get_category_or_404(session, category_id)
+    category = await get_category_or_404(session, category_id, user)
 
     changes = payload.model_dump(exclude_unset=True)
     if "name" in changes and changes["name"] is not None:
         duplicate = await _get_duplicate_category(
             session,
+            user_id=user.id,
             name=changes["name"],
             exclude_id=category.id,
         )
@@ -90,17 +111,15 @@ async def update_category(
 
     await session.commit()
     await session.refresh(category)
-    logger.info("categories.updated", category_id=category.id)
+    logger.info("categories.updated", user_id=user.id, category_id=category.id)
     return category
 
 
-async def delete_category(session: AsyncSession, category_id: int) -> None:
-    category = await get_category_or_404(session, category_id)
+async def delete_category(session: AsyncSession, category_id: int, user: User) -> None:
+    category = await get_category_or_404(session, category_id, user)
     await session.execute(
-        update(Subscription)
-        .where(Subscription.category_id == category.id)
-        .values(category_id=None)
+        update(Subscription).where(Subscription.category_id == category.id).values(category_id=None)
     )
     await session.delete(category)
     await session.commit()
-    logger.info("categories.deleted", category_id=category_id)
+    logger.info("categories.deleted", user_id=user.id, category_id=category_id)

--- a/backend/src/services/detection_engine.py
+++ b/backend/src/services/detection_engine.py
@@ -181,14 +181,23 @@ def _display_category_name(name: str) -> str:
     return " ".join(part.capitalize() for part in normalized.split()) or "General"
 
 
-async def _get_or_create_category(session: AsyncSession, category_name: str) -> Category:
+async def _get_or_create_category(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    category_name: str,
+) -> Category:
     slug = _slugify_category(category_name)
-    statement = select(Category).where(func.lower(Category.slug) == slug)
+    statement = select(Category).where(
+        Category.user_id == user_id,
+        func.lower(Category.slug) == slug,
+    )
     category = await session.scalar(statement)
     if category is not None:
         return category
 
     category = Category(
+        user_id=user_id,
         name=_display_category_name(category_name),
         slug=slug,
         description="Auto-created from detected subscription imports.",
@@ -275,7 +284,9 @@ async def sync_detected_subscriptions(
         existing_history = list(
             (
                 await session.scalars(
-                    select(PaymentHistory).where(PaymentHistory.raw_transaction_id.in_(raw_transaction_ids))
+                    select(PaymentHistory).where(
+                        PaymentHistory.raw_transaction_id.in_(raw_transaction_ids)
+                    )
                 )
             ).all()
         )
@@ -289,7 +300,9 @@ async def sync_detected_subscriptions(
     updated_count = 0
     for detection in detections:
         category = (
-            await _get_or_create_category(session, detection.category)
+            await _get_or_create_category(
+                session, user_id=user_id, category_name=detection.category
+            )
             if detection.category is not None
             else None
         )

--- a/backend/src/services/subscription.py
+++ b/backend/src/services/subscription.py
@@ -14,8 +14,9 @@ from src.schemas.subscription import SubscriptionCreate, SubscriptionUpdate
 logger = get_logger(__name__)
 
 
-async def _get_category_or_404(session: AsyncSession, category_id: int) -> Category:
-    category = await session.get(Category, category_id)
+async def _get_category_or_404(session: AsyncSession, category_id: int, user: User) -> Category:
+    statement = select(Category).where(Category.id == category_id, Category.user_id == user.id)
+    category = await session.scalar(statement)
     if category is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found.")
     return category
@@ -125,7 +126,7 @@ async def create_subscription(
     payload: SubscriptionCreate,
 ) -> Subscription:
     if payload.category_id is not None:
-        await _get_category_or_404(session, payload.category_id)
+        await _get_category_or_404(session, payload.category_id, user)
     if payload.payment_method_id is not None:
         await _get_payment_method_or_404(
             session,
@@ -156,7 +157,7 @@ async def update_subscription(
     changes = payload.model_dump(exclude_unset=True)
 
     if "category_id" in changes and changes["category_id"] is not None:
-        await _get_category_or_404(session, changes["category_id"])
+        await _get_category_or_404(session, changes["category_id"], user)
     if "payment_method_id" in changes and changes["payment_method_id"] is not None:
         await _get_payment_method_or_404(
             session,

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -100,6 +100,14 @@ def test_delete_my_workspace_data_resets_user_owned_records(client) -> None:
     assert payment_method_response.status_code == 201
     payment_method_id = payment_method_response.json()["id"]
 
+    category_response = client.post(
+        "/api/v1/categories",
+        headers=headers,
+        json={"name": "Streaming", "description": "Monthly streaming services"},
+    )
+    assert category_response.status_code == 201
+    category_id = category_response.json()["id"]
+
     subscription_response = client.post(
         "/api/v1/subscriptions",
         headers=headers,
@@ -111,6 +119,7 @@ def test_delete_my_workspace_data_resets_user_owned_records(client) -> None:
             "cadence": "monthly",
             "status": "active",
             "start_date": "2026-04-01",
+            "category_id": category_id,
             "payment_method_id": payment_method_id,
             "auto_renew": True,
         },
@@ -140,6 +149,10 @@ def test_delete_my_workspace_data_resets_user_owned_records(client) -> None:
     payment_methods_response = client.get("/api/v1/payment-methods", headers=headers)
     assert payment_methods_response.status_code == 200
     assert payment_methods_response.json()["total"] == 0
+
+    categories_response = client.get("/api/v1/categories", headers=headers)
+    assert categories_response.status_code == 200
+    assert categories_response.json()["total"] == 0
 
     reset_layout_response = client.get("/api/v1/dashboard/layout", headers=headers)
     assert reset_layout_response.status_code == 200

--- a/backend/tests/api/test_categories.py
+++ b/backend/tests/api/test_categories.py
@@ -66,3 +66,28 @@ def test_categories_support_crud_and_duplicate_protection(client) -> None:
     missing_response = client.get(f"/api/v1/categories/{created['id']}", headers=headers)
     assert missing_response.status_code == 404
     assert missing_response.json()["detail"] == "Category not found."
+
+
+def test_categories_are_user_scoped(client) -> None:
+    owner_headers = _auth_headers(client, "owner@example.com")
+    other_headers = _auth_headers(client, "other@example.com")
+
+    create_response = client.post(
+        "/api/v1/categories",
+        headers=owner_headers,
+        json={"name": "Streaming", "description": "Monthly streaming services"},
+    )
+    assert create_response.status_code == 201
+    category_id = create_response.json()["id"]
+
+    owner_list_response = client.get("/api/v1/categories", headers=owner_headers)
+    assert owner_list_response.status_code == 200
+    assert owner_list_response.json()["total"] == 1
+
+    other_list_response = client.get("/api/v1/categories", headers=other_headers)
+    assert other_list_response.status_code == 200
+    assert other_list_response.json()["total"] == 0
+
+    other_get_response = client.get(f"/api/v1/categories/{category_id}", headers=other_headers)
+    assert other_get_response.status_code == 404
+    assert other_get_response.json()["detail"] == "Category not found."

--- a/backend/tests/api/test_integration_flows.py
+++ b/backend/tests/api/test_integration_flows.py
@@ -58,8 +58,7 @@ def _build_pdf_statement(lines: list[str]) -> bytes:
     for offset in offsets:
         content += f"{offset:010d} 00000 n \n"
     content += (
-        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
-        f"startxref\n{xref_offset}\n%%EOF\n"
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n"
     )
     return content.encode("latin1")
 

--- a/backend/tests/api/test_subscriptions.py
+++ b/backend/tests/api/test_subscriptions.py
@@ -202,6 +202,23 @@ def test_subscriptions_enforce_validation_and_ownership(client) -> None:
     assert cross_user_payment_method_response.status_code == 404
     assert cross_user_payment_method_response.json()["detail"] == "Payment method not found."
 
+    other_category_id = _create_category(client, other_headers, "Other Category")
+    cross_user_category_response = client.post(
+        "/api/v1/subscriptions",
+        headers=owner_headers,
+        json={
+            "name": "Cross Account Category",
+            "vendor": "Cross Account Category",
+            "amount": "12.00",
+            "currency": "USD",
+            "cadence": "monthly",
+            "start_date": "2026-04-01",
+            "category_id": other_category_id,
+        },
+    )
+    assert cross_user_category_response.status_code == 404
+    assert cross_user_category_response.json()["detail"] == "Category not found."
+
     owner_subscription_response = client.post(
         "/api/v1/subscriptions",
         headers=owner_headers,

--- a/backend/tests/api/test_uploads.py
+++ b/backend/tests/api/test_uploads.py
@@ -1,3 +1,6 @@
+from datetime import date, timedelta
+
+
 def _auth_headers(client, email: str) -> dict[str, str]:
     response = client.post(
         "/api/v1/auth/register",
@@ -13,11 +16,7 @@ def _auth_headers(client, email: str) -> dict[str, str]:
 
 def test_upload_endpoints_process_csv_history_status_and_delete(client) -> None:
     headers = _auth_headers(client, "uploader@example.com")
-    csv_content = (
-        "Posting Date,Details,Amount\n"
-        "04/01/2026,NETFLIX,-15.49\n"
-        "04/02/2026,Hulu,-8.99\n"
-    )
+    csv_content = "Posting Date,Details,Amount\n04/01/2026,NETFLIX,-15.49\n04/02/2026,Hulu,-8.99\n"
 
     create_response = client.post(
         "/api/v1/uploads",
@@ -51,11 +50,12 @@ def test_upload_endpoints_process_csv_history_status_and_delete(client) -> None:
 
 def test_upload_processing_triggers_subscription_detection(client) -> None:
     headers = _auth_headers(client, "detection@example.com")
+    charge_dates = [date.today() - timedelta(days=60), date.today() - timedelta(days=30), date.today()]
     csv_content = (
         "Posting Date,Details,Amount\n"
-        "01/01/2026,NETFLIX,-15.49\n"
-        "02/01/2026,NETFLIX,-15.49\n"
-        "03/01/2026,NETFLIX,-15.49\n"
+        f"{charge_dates[0].strftime('%m/%d/%Y')},NETFLIX,-15.49\n"
+        f"{charge_dates[1].strftime('%m/%d/%Y')},NETFLIX,-15.49\n"
+        f"{charge_dates[2].strftime('%m/%d/%Y')},NETFLIX,-15.49\n"
     )
 
     create_response = client.post(

--- a/backend/tests/api/test_uploads.py
+++ b/backend/tests/api/test_uploads.py
@@ -50,7 +50,11 @@ def test_upload_endpoints_process_csv_history_status_and_delete(client) -> None:
 
 def test_upload_processing_triggers_subscription_detection(client) -> None:
     headers = _auth_headers(client, "detection@example.com")
-    charge_dates = [date.today() - timedelta(days=60), date.today() - timedelta(days=30), date.today()]
+    charge_dates = [
+        date.today() - timedelta(days=60),
+        date.today() - timedelta(days=30),
+        date.today(),
+    ]
     csv_content = (
         "Posting Date,Details,Amount\n"
         f"{charge_dates[0].strftime('%m/%d/%Y')},NETFLIX,-15.49\n"

--- a/backend/tests/services/test_detection_engine.py
+++ b/backend/tests/services/test_detection_engine.py
@@ -183,6 +183,7 @@ def test_sync_user_subscriptions_creates_detected_subscriptions_and_payment_hist
         assert {subscription.vendor for subscription in subscriptions} == {"Local Gym", "Netflix"}
         assert len(payment_history) == 6
         assert len(categories) == 1
+        assert categories[0].user_id == 1
         assert categories[0].slug == "entertainment"
 
         netflix = next(

--- a/backend/tests/services/test_pdf_extractor.py
+++ b/backend/tests/services/test_pdf_extractor.py
@@ -29,13 +29,7 @@ class _FakePdf:
 def test_pdf_extractor_returns_text_and_transactions(monkeypatch) -> None:
     def _open(_: object) -> _FakePdf:
         return _FakePdf(
-            [
-                _FakePage(
-                    "CHASE STATEMENT 2026\n"
-                    "04/01 NETFLIX 15.49\n"
-                    "04/02 SPOTIFY 10.99\n"
-                )
-            ]
+            [_FakePage("CHASE STATEMENT 2026\n04/01 NETFLIX 15.49\n04/02 SPOTIFY 10.99\n")]
         )
 
     monkeypatch.setattr("src.services.parsing.pdf_extractor.pdfplumber.open", _open)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-grid-layout": "^2.2.3",
         "react-hook-form": "^7.57.0",
         "recharts": "^3.8.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "zod": "^4.0.5"
       },
@@ -8518,6 +8519,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-grid-layout": "^2.2.3",
     "react-hook-form": "^7.57.0",
     "recharts": "^3.8.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.5"
   },

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { AlertTriangle, ArrowRight, RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-[linear-gradient(160deg,rgba(250,246,240,0.96),rgba(231,238,244,0.84)_42%,rgba(247,239,228,0.92))] dark:bg-[radial-gradient(circle_at_top_left,rgba(253,180,118,0.16),transparent_24%),linear-gradient(155deg,rgba(10,18,26,0.98),rgba(16,24,35,0.92)_45%,rgba(29,17,9,0.82))]">
+        <main className="mx-auto flex min-h-screen max-w-4xl items-center px-6 py-16 sm:px-10">
+          <section className="w-full rounded-[2.5rem] border border-black/10 bg-white/82 p-8 shadow-line backdrop-blur dark:border-white/10 dark:bg-white/8 dark:text-white sm:p-10">
+            <div className="inline-flex size-14 items-center justify-center rounded-[1.4rem] border border-black/10 bg-stone text-ink dark:border-white/10 dark:bg-white/10 dark:text-white">
+              <AlertTriangle className="size-6" />
+            </div>
+            <p className="mt-6 text-xs uppercase tracking-[0.32em] text-black/45 dark:text-white/45">
+              Unexpected error
+            </p>
+            <h1 className="mt-4 font-serif text-4xl leading-tight text-ink dark:text-white sm:text-5xl">
+              This view broke before the workspace could finish loading.
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-7 text-black/64 dark:text-white/64">
+              Retry the route first. If the error keeps returning, head back to the dashboard or re-open the app from the landing page.
+            </p>
+
+            <div className="mt-8 flex flex-wrap gap-4">
+              <Button className="rounded-full px-6" onClick={reset} type="button">
+                <RefreshCw className="mr-2 size-4" />
+                Try again
+              </Button>
+              <Button asChild className="rounded-full px-6" variant="outline">
+                <Link href="/dashboard">
+                  Go to dashboard
+                  <ArrowRight className="ml-2 size-4" />
+                </Link>
+              </Button>
+            </div>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -40,10 +40,27 @@ body {
     hsl(var(--background));
   color: hsl(var(--foreground));
   font-family: var(--font-space-grotesk), sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+.dark body {
+  background:
+    radial-gradient(circle at top left, rgba(245, 149, 88, 0.15), transparent 24%),
+    linear-gradient(180deg, rgba(12, 18, 27, 0.92), rgba(18, 26, 36, 0.96)),
+    hsl(var(--background));
 }
 
 ::selection {
   background: rgba(220, 93, 48, 0.18);
+}
+
+.dark ::selection {
+  background: rgba(244, 202, 173, 0.18);
+}
+
+a {
+  transition: color 180ms ease, opacity 180ms ease, transform 180ms ease;
 }
 
 @keyframes page-enter {
@@ -65,6 +82,24 @@ body {
 .animate-page-enter-delayed {
   animation: page-enter 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
   animation-delay: 0.08s;
+}
+
+@keyframes float-slow {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  50% {
+    transform: translate3d(0, -10px, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.animate-float-slow {
+  animation: float-slow 9s ease-in-out infinite;
 }
 
 .dashboard-grid-layout {

--- a/frontend/src/app/icon.svg
+++ b/frontend/src/app/icon.svg
@@ -1,0 +1,7 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="64" fill="#101922"/>
+  <path d="M56 182V74H86L128 137L170 74H200V182H170V121L136 172H120L86 121V182H56Z" fill="#F8F4EE"/>
+  <circle cx="194" cy="62" r="18" fill="#DC5D30"/>
+  <path d="M187 62H201" stroke="#101922" stroke-width="6" stroke-linecap="round"/>
+  <path d="M194 55V69" stroke="#101922" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -18,8 +18,37 @@ const instrumentSerif = Instrument_Serif({
 });
 
 export const metadata: Metadata = {
-  title: "MySubscription Tracker",
-  description: "Track recurring spending with a calm, deliberate workflow.",
+  metadataBase: new URL("http://localhost:3000"),
+  title: {
+    default: "MySubscription Tracker",
+    template: "%s | MySubscription Tracker",
+  },
+  description:
+    "Track recurring spending, import statement files, and manage renewal risk from one deliberate workspace.",
+  applicationName: "MySubscription Tracker",
+  keywords: [
+    "subscriptions",
+    "renewals",
+    "expense tracking",
+    "dashboard",
+    "statement imports",
+  ],
+  icons: {
+    icon: "/icon.svg",
+    shortcut: "/icon.svg",
+  },
+  openGraph: {
+    title: "MySubscription Tracker",
+    description:
+      "Track recurring spending, import statement files, and manage renewal risk from one deliberate workspace.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "MySubscription Tracker",
+    description:
+      "Track recurring spending, import statement files, and manage renewal risk from one deliberate workspace.",
+  },
 };
 
 export default function RootLayout({

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -20,6 +20,18 @@ const loginSchema = z.object({
 
 type LoginValues = z.infer<typeof loginSchema>;
 
+function getLoginErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message === "Invalid email or password.") {
+    return "The email or password did not match an active account.";
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "The email or password did not match an active account.";
+}
+
 function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -50,8 +62,7 @@ function LoginPageContent() {
       toast.success("Signed in.");
       router.replace(searchParams.get("next") ?? "/dashboard");
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "The email or password did not match an active account.";
+      const message = getLoginErrorMessage(error);
       toast.error(message);
       setError("root", {
         message,

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowRight } from "lucide-react";
 import { Suspense, useEffect } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 import { z } from "zod";
 
 import { AuthShell } from "@/components/auth/auth-shell";
@@ -46,10 +47,14 @@ function LoginPageContent() {
   const onSubmit = handleSubmit(async (values) => {
     try {
       await login(values);
+      toast.success("Signed in.");
       router.replace(searchParams.get("next") ?? "/dashboard");
-    } catch {
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "The email or password did not match an active account.";
+      toast.error(message);
       setError("root", {
-        message: "The email or password did not match an active account.",
+        message,
       });
     }
   });

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { ArrowRight, Compass } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl items-center px-6 py-16 sm:px-10">
+      <section className="grid w-full gap-8 rounded-[2.6rem] border border-black/10 bg-white/82 p-8 shadow-line backdrop-blur dark:border-white/10 dark:bg-white/8 dark:text-white sm:p-10 lg:grid-cols-[minmax(0,0.9fr)_auto] lg:items-end">
+        <div>
+          <div className="inline-flex size-14 items-center justify-center rounded-[1.4rem] border border-black/10 bg-stone text-ink dark:border-white/10 dark:bg-white/10 dark:text-white">
+            <Compass className="size-6" />
+          </div>
+          <p className="mt-6 text-xs uppercase tracking-[0.32em] text-black/45 dark:text-white/45">
+            Page not found
+          </p>
+          <h1 className="mt-4 font-serif text-4xl leading-tight text-ink dark:text-white sm:text-5xl">
+            The route you asked for is outside the current subscription workspace.
+          </h1>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-black/64 dark:text-white/64">
+            Use the dashboard to get back to the live product surface, or start from the landing page if you meant to sign in or create an account.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-4 lg:justify-end">
+          <Button asChild className="rounded-full px-6">
+            <Link href="/dashboard">
+              Open dashboard
+              <ArrowRight className="ml-2 size-4" />
+            </Link>
+          </Button>
+          <Button asChild className="rounded-full px-6" variant="outline">
+            <Link href="/">Back to home</Link>
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,127 +1,286 @@
 import Link from "next/link";
-import { ArrowRight, BadgeDollarSign, CalendarRange, ShieldCheck } from "lucide-react";
+import {
+  ArrowRight,
+  CalendarCheck2,
+  Radar,
+  ShieldCheck,
+  Sparkles,
+  Upload,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
-const proofPoints = [
-  "Catalog monthly and yearly plans in one view",
-  "Prepare alerts before renewal dates arrive",
-  "Keep backend and UI bootstrap ready for the next milestones",
+const featureStrip = [
+  "Manual subscription control with searchable filters",
+  "CSV and PDF imports with live processing status",
+  "Persistent dashboards, settings, and onboarding guidance",
 ];
 
-const systemAreas = [
+const steps = [
   {
-    label: "Day 1 scope",
-    value: "Bootstrap",
+    body: "Start with manual entry or drag in a bank export. The workspace keeps source files, queue state, and plan details in one operating surface.",
+    label: "01",
+    title: "Bring your billing data in",
   },
   {
-    label: "Core surfaces",
-    value: "API, theme, tests",
+    body: "The parser normalizes uploads, the detection engine spots recurring charges, and the app keeps the resulting changes visible instead of burying them.",
+    label: "02",
+    title: "Let the system detect patterns",
   },
   {
-    label: "Infra",
-    value: "CI, Docker, Make",
+    body: "Review active plans, next charges, category mix, and payment rails without hopping between disconnected admin pages.",
+    label: "03",
+    title: "Operate from one dashboard",
+  },
+  {
+    body: "Adjust categories, payment methods, theme, and workspace defaults as the product moves from MVP into the full platform roadmap.",
+    label: "04",
+    title: "Tighten the workspace over time",
+  },
+];
+
+const productEdges = [
+  {
+    body: "Recurring plans, payment rails, and lifecycle changes stay editable without leaving the authenticated shell.",
+    icon: Sparkles,
+    title: "Subscription command surface",
+  },
+  {
+    body: "Statement files move through upload, parsing, and detection with progress visibility instead of silent background jobs.",
+    icon: Upload,
+    title: "Observable statement ingestion",
+  },
+  {
+    body: "Dashboard widgets, settings, and session flows keep the MVP usable now while the later milestones layer on analytics and automation.",
+    icon: Radar,
+    title: "Built for the next milestone",
   },
 ];
 
 export default function Home() {
   return (
     <main className="overflow-hidden">
-      <section className="relative min-h-screen border-b border-black/10 bg-mesh">
-        <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-between px-6 py-8 sm:px-10 lg:px-12">
-          <header className="flex items-center justify-between py-2">
+      <section className="relative min-h-[100svh] overflow-hidden border-b border-black/10 bg-[linear-gradient(160deg,rgba(250,246,240,0.96),rgba(231,238,244,0.84)_42%,rgba(247,239,228,0.92))] dark:border-white/10 dark:bg-[radial-gradient(circle_at_top_left,rgba(253,180,118,0.16),transparent_24%),linear-gradient(155deg,rgba(10,18,26,0.98),rgba(16,24,35,0.92)_45%,rgba(29,17,9,0.82))]">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_78%_22%,rgba(220,93,48,0.18),transparent_20%),radial-gradient(circle_at_20%_18%,rgba(255,255,255,0.76),transparent_20%)] dark:bg-[radial-gradient(circle_at_78%_22%,rgba(255,151,90,0.14),transparent_18%),radial-gradient(circle_at_20%_18%,rgba(255,255,255,0.08),transparent_18%)]" />
+        <div className="relative mx-auto flex min-h-[100svh] max-w-7xl flex-col px-6 pb-12 pt-6 sm:px-10 lg:px-12">
+          <header className="flex items-center justify-between gap-4">
             <div>
-              <p className="font-serif text-2xl tracking-tight text-ink">MySubscription Tracker</p>
-              <p className="text-sm uppercase tracking-[0.3em] text-black/45">Day 1 foundation</p>
+              <p className="font-serif text-2xl tracking-tight text-ink dark:text-white">
+                MySubscription Tracker
+              </p>
+              <p className="mt-2 text-[11px] uppercase tracking-[0.34em] text-black/48 dark:text-white/45">
+                Day 15 MVP wrap
+              </p>
             </div>
-            <Button variant="ghost" className="rounded-full border border-black/10 px-5">
-              Preview shell
-            </Button>
+
+            <div className="flex items-center gap-3">
+              <Button asChild className="rounded-full px-5" variant="ghost">
+                <Link href="/login">Sign in</Link>
+              </Button>
+              <Button asChild className="rounded-full px-5">
+                <Link href="/register">
+                  Create account
+                  <ArrowRight className="ml-2 size-4" />
+                </Link>
+              </Button>
+            </div>
           </header>
 
-          <div className="grid gap-12 pb-10 pt-14 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.85fr)] lg:items-end">
-            <div className="max-w-2xl">
-              <p className="mb-4 text-sm uppercase tracking-[0.28em] text-black/45">
+          <div className="grid flex-1 gap-10 py-10 lg:grid-cols-[minmax(0,0.94fr)_minmax(360px,0.96fr)] lg:items-end lg:py-14">
+            <div className="max-w-2xl self-center">
+              <p className="animate-page-enter text-sm uppercase tracking-[0.32em] text-black/48 dark:text-white/52">
                 Calm control for recurring spend
               </p>
-              <h1 className="max-w-xl font-serif text-5xl leading-none text-ink sm:text-6xl lg:text-7xl">
-                Track every subscription before it quietly tracks you.
+              <h1 className="animate-page-enter mt-5 max-w-3xl font-serif text-5xl leading-[0.94] text-ink sm:text-6xl lg:text-7xl dark:text-white">
+                See every renewal coming before it turns into background spend.
               </h1>
-              <p className="mt-6 max-w-lg text-lg leading-8 text-black/68">
-                The first milestone establishes the product shell, data layer, CI pipelines, and
-                a composed front door for the app.
+              <p className="animate-page-enter-delayed mt-6 max-w-xl text-lg leading-8 text-black/68 dark:text-white/68">
+                Track subscriptions, ingest statement files, review dashboard signals, and keep the
+                MVP workspace polished enough to operate every week instead of revisiting once a quarter.
               </p>
-              <div className="mt-8 flex flex-wrap gap-4">
+
+              <div className="animate-page-enter-delayed mt-8 flex flex-wrap gap-4">
                 <Button asChild className="rounded-full px-6">
                   <Link href="/register">
-                    Create account
+                    Start the workspace
                     <ArrowRight className="ml-2 size-4" />
                   </Link>
                 </Button>
-                <Button asChild variant="outline" className="rounded-full border-black/15 bg-white/70 px-6">
-                  <Link href="/login">Sign in</Link>
+                <Button asChild className="rounded-full border-black/10 bg-white/78 px-6 dark:border-white/10 dark:bg-white/10 dark:text-white" variant="outline">
+                  <Link href="/dashboard">Preview the app shell</Link>
                 </Button>
+              </div>
+
+              <div className="mt-10 grid gap-4 border-t border-black/10 pt-6 text-sm text-black/62 dark:border-white/10 dark:text-white/62 sm:grid-cols-3">
+                {featureStrip.map((item) => (
+                  <p key={item}>{item}</p>
+                ))}
               </div>
             </div>
 
-            <div className="relative border-l border-black/10 pl-8">
-              <div className="absolute left-0 top-0 h-full w-px bg-gradient-to-b from-black/30 to-transparent" />
-              <div className="space-y-6">
-                {systemAreas.map((item) => (
-                  <div key={item.label} className="pb-5">
-                    <p className="text-xs uppercase tracking-[0.3em] text-black/45">{item.label}</p>
-                    <p className="mt-2 text-3xl font-semibold text-ink">{item.value}</p>
+            <div className="relative min-h-[28rem] overflow-hidden rounded-[2.8rem] border border-black/10 bg-[#101922] p-6 text-white shadow-[0_30px_120px_rgba(17,20,24,0.22)] sm:p-8 dark:border-white/10">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(244,202,173,0.22),transparent_22%),radial-gradient(circle_at_18%_88%,rgba(220,93,48,0.26),transparent_30%)]" />
+              <div className="relative flex h-full flex-col justify-between">
+                <div className="flex items-start justify-between gap-6">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.3em] text-white/45">Live surface</p>
+                    <p className="mt-3 max-w-xs text-sm leading-6 text-white/68">
+                      Imports, filters, layout persistence, and workspace defaults are already in the
+                      MVP. Day 15 tightens the front door around them.
+                    </p>
                   </div>
-                ))}
+                  <div className="rounded-full border border-white/12 px-4 py-2 text-xs uppercase tracking-[0.24em] text-white/55">
+                    MVP ready
+                  </div>
+                </div>
+
+                <div className="space-y-5">
+                  <div className="space-y-2 border-b border-white/10 pb-5">
+                    <p className="text-[11px] uppercase tracking-[0.34em] text-white/42">
+                      Import. Detect. Decide.
+                    </p>
+                    <p className="max-w-md text-4xl font-semibold leading-tight sm:text-5xl">
+                      One workspace for what is active, what is due next, and what is quietly drifting upward.
+                    </p>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-[1.1fr_0.9fr]">
+                    <div className="space-y-3 border-b border-white/10 pb-4 sm:border-b-0 sm:border-r sm:pb-0 sm:pr-4">
+                      <div className="flex items-center justify-between text-sm text-white/64">
+                        <span>Uploads + parsing</span>
+                        <span>Live</span>
+                      </div>
+                      <div className="h-2 rounded-full bg-white/10">
+                        <div className="h-full w-[72%] rounded-full bg-[#f4caad]" />
+                      </div>
+                      <div className="flex items-center justify-between text-sm text-white/64">
+                        <span>Dashboard widgets</span>
+                        <span>Live</span>
+                      </div>
+                      <div className="h-2 rounded-full bg-white/10">
+                        <div className="h-full w-[86%] rounded-full bg-white/70" />
+                      </div>
+                    </div>
+
+                    <div className="space-y-3">
+                      <div className="flex items-center gap-3 rounded-[1.4rem] border border-white/10 bg-white/6 px-4 py-3">
+                        <CalendarCheck2 className="size-4 text-[#f4caad]" />
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.22em] text-white/42">Renewals</p>
+                          <p className="text-sm text-white/74">Keep the next charge visible.</p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3 rounded-[1.4rem] border border-white/10 bg-white/6 px-4 py-3">
+                        <ShieldCheck className="size-4 text-[#f4caad]" />
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.22em] text-white/42">Guardrails</p>
+                          <p className="text-sm text-white/74">Scoped settings, logs, and safer defaults.</p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between border-t border-white/10 pt-5 text-sm text-white/52">
+                  <span>Imports, subscriptions, dashboard, settings</span>
+                  <span>Designed to keep the next move obvious</span>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="mx-auto grid max-w-6xl gap-10 px-6 py-20 sm:px-10 lg:grid-cols-[1.1fr_0.9fr] lg:px-12">
-        <div>
-          <p className="text-sm uppercase tracking-[0.3em] text-black/45">Core proof</p>
-          <h2 className="mt-4 max-w-lg font-serif text-4xl leading-tight text-ink">
-            One milestone, four foundation tracks.
-          </h2>
+      <section className="mx-auto max-w-7xl px-6 py-20 sm:px-10 lg:px-12">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.44fr)_minmax(0,1fr)]">
+          <div>
+            <p className="text-xs uppercase tracking-[0.32em] text-black/45 dark:text-white/45">
+              Features
+            </p>
+            <h2 className="mt-4 max-w-md font-serif text-4xl leading-tight text-ink dark:text-white">
+              An MVP that already behaves like a working tool.
+            </h2>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-3">
+            {productEdges.map(({ body, icon: Icon, title }) => (
+              <article
+                className="group border-t border-black/10 pt-5 transition-transform duration-300 hover:-translate-y-1 dark:border-white/10"
+                key={title}
+              >
+                <div className="inline-flex size-12 items-center justify-center rounded-[1.25rem] border border-black/10 bg-stone text-ink transition group-hover:border-black/20 group-hover:bg-white dark:border-white/10 dark:bg-white/10 dark:text-white dark:group-hover:border-white/18 dark:group-hover:bg-white/14">
+                  <Icon className="size-5" />
+                </div>
+                <h3 className="mt-5 text-2xl font-semibold tracking-tight text-ink dark:text-white">
+                  {title}
+                </h3>
+                <p className="mt-3 text-sm leading-7 text-black/64 dark:text-white/64">{body}</p>
+              </article>
+            ))}
+          </div>
         </div>
-        <ul className="space-y-5 border-t border-black/10 pt-4 text-lg text-black/70 lg:border-t-0 lg:border-l lg:pl-10 lg:pt-0">
-          {proofPoints.map((item) => (
-            <li key={item} className="flex items-start gap-3">
-              <span className="mt-2 size-2 rounded-full bg-ember" />
-              <span>{item}</span>
-            </li>
-          ))}
-        </ul>
       </section>
 
-      <section className="border-y border-black/10 bg-white/55">
-        <div className="mx-auto grid max-w-6xl gap-6 px-6 py-18 sm:px-10 lg:grid-cols-3 lg:px-12">
-          <article className="space-y-5 border-b border-black/10 pb-8 lg:border-b-0 lg:border-r lg:pb-0 lg:pr-6">
-            <BadgeDollarSign className="size-6 text-ember" />
-            <h3 className="text-2xl font-semibold text-ink">Subscription clarity</h3>
-            <p className="text-black/65">
-              Backend models and API contracts are ready for recurring products, payment methods,
-              and future reporting.
+      <section className="border-y border-black/10 bg-white/58 dark:border-white/10 dark:bg-white/5">
+        <div className="mx-auto max-w-7xl px-6 py-20 sm:px-10 lg:px-12">
+          <div className="max-w-2xl">
+            <p className="text-xs uppercase tracking-[0.32em] text-black/45 dark:text-white/45">
+              How it works
             </p>
-          </article>
-          <article className="space-y-5 border-b border-black/10 pb-8 lg:border-b-0 lg:border-r lg:px-6 lg:pb-0">
-            <CalendarRange className="size-6 text-ember" />
-            <h3 className="text-2xl font-semibold text-ink">Renewal awareness</h3>
-            <p className="text-black/65">
-              Query, theme, and test providers create the stable client shell the rest of the
-              journey will build on.
-            </p>
-          </article>
-          <article className="space-y-5 lg:pl-6">
-            <ShieldCheck className="size-6 text-ember" />
-            <h3 className="text-2xl font-semibold text-ink">Operational guardrails</h3>
-            <p className="text-black/65">
-              Docker, workflows, and scripts define the baseline checks needed before feature work
-              accelerates.
-            </p>
-          </article>
+            <h2 className="mt-4 font-serif text-4xl leading-tight text-ink dark:text-white">
+              Move from raw billing noise to a clean recurring-spend signal.
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-6 lg:grid-cols-2">
+            {steps.map((step) => (
+              <article
+                className="grid gap-4 border-t border-black/10 py-5 dark:border-white/10 sm:grid-cols-[72px_minmax(0,1fr)]"
+                key={step.label}
+              >
+                <p className="text-4xl font-semibold tracking-tight text-black/25 dark:text-white/22">
+                  {step.label}
+                </p>
+                <div>
+                  <h3 className="text-2xl font-semibold tracking-tight text-ink dark:text-white">
+                    {step.title}
+                  </h3>
+                  <p className="mt-3 max-w-xl text-sm leading-7 text-black/64 dark:text-white/64">
+                    {step.body}
+                  </p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-20 sm:px-10 lg:px-12">
+        <div className="overflow-hidden rounded-[2.8rem] border border-black/10 bg-[#101922] px-6 py-8 text-white shadow-[0_30px_120px_rgba(17,20,24,0.18)] sm:px-8 sm:py-10">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_auto] lg:items-end">
+            <div>
+              <p className="text-xs uppercase tracking-[0.32em] text-white/45">Start the MVP</p>
+              <h2 className="mt-4 max-w-2xl font-serif text-4xl leading-tight text-white sm:text-5xl">
+                Open the workspace, add the first plan, and make the next renewal impossible to miss.
+              </h2>
+              <p className="mt-4 max-w-xl text-base leading-7 text-white/68">
+                The core flows are already in place. Day 15 turns the shell into a sharper product surface and
+                closes the MVP with cleaner errors, stronger polish, and safer defaults.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-4">
+              <Button asChild className="rounded-full px-6">
+                <Link href="/register">
+                  Create account
+                  <ArrowRight className="ml-2 size-4" />
+                </Link>
+              </Button>
+              <Button asChild className="rounded-full border-white/12 bg-white/10 px-6 text-white hover:bg-white/14" variant="outline">
+                <Link href="/login">Sign in</Link>
+              </Button>
+            </div>
+          </div>
         </div>
       </section>
     </main>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowRight } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 import { z } from "zod";
 
 import { AuthShell } from "@/components/auth/auth-shell";
@@ -47,10 +48,14 @@ export default function RegisterPage() {
   const onSubmit = handleSubmit(async (values) => {
     try {
       await registerAccount(values);
+      toast.success("Account created.");
       router.replace("/dashboard");
-    } catch {
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "That account already exists or could not be created right now.";
+      toast.error(message);
       setError("root", {
-        message: "That account already exists or could not be created right now.",
+        message,
       });
     }
   });

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -21,6 +21,18 @@ const registerSchema = z.object({
 
 type RegisterValues = z.infer<typeof registerSchema>;
 
+function getRegisterErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message === "A user with that email already exists.") {
+    return "That account already exists or could not be created right now.";
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "That account already exists or could not be created right now.";
+}
+
 export default function RegisterPage() {
   const router = useRouter();
   const { isAuthenticated, register: registerAccount } = useAuth();
@@ -51,8 +63,7 @@ export default function RegisterPage() {
       toast.success("Account created.");
       router.replace("/dashboard");
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "That account already exists or could not be created right now.";
+      const message = getRegisterErrorMessage(error);
       toast.error(message);
       setError("root", {
         message,

--- a/frontend/src/components/providers/app-providers.tsx
+++ b/frontend/src/components/providers/app-providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { useState } from "react";
 
+import { AppToaster } from "@/components/providers/app-toaster";
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { OnboardingProvider } from "@/components/providers/onboarding-provider";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -27,7 +28,10 @@ export function AppProviders({ children }: { children: ReactNode }) {
     <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <OnboardingProvider>{children}</OnboardingProvider>
+          <OnboardingProvider>
+            {children}
+            <AppToaster />
+          </OnboardingProvider>
         </AuthProvider>
       </QueryClientProvider>
     </ThemeProvider>

--- a/frontend/src/components/providers/app-toaster.tsx
+++ b/frontend/src/components/providers/app-toaster.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster } from "sonner";
+
+export function AppToaster() {
+  const { resolvedTheme } = useTheme();
+
+  return (
+    <Toaster
+      closeButton
+      position="top-right"
+      richColors
+      theme={resolvedTheme === "dark" ? "dark" : "light"}
+      toastOptions={{
+        className: "font-sans",
+      }}
+    />
+  );
+}

--- a/frontend/src/hooks/use-dashboard.ts
+++ b/frontend/src/hooks/use-dashboard.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { useAuth } from "@/hooks/use-auth";
 import { apiClient } from "@/lib/api-client";
@@ -73,6 +74,7 @@ export function useUpdateDashboardLayout() {
       if (context?.previousLayout !== undefined) {
         queryClient.setQueryData(dashboardKeys.layout, context.previousLayout);
       }
+      toast.error("Could not save the dashboard layout.");
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: dashboardKeys.layout });

--- a/frontend/src/hooks/use-subscriptions.ts
+++ b/frontend/src/hooks/use-subscriptions.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { useAuth } from "@/hooks/use-auth";
 import { apiClient } from "@/lib/api-client";
@@ -86,7 +87,11 @@ export function useCreateSubscription() {
   return useMutation({
     mutationFn: (payload: SubscriptionUpsertInput) => apiClient.createSubscription(token, payload),
     onSuccess: () => {
+      toast.success("Subscription saved.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not save the subscription.");
     },
   });
 }
@@ -99,8 +104,12 @@ export function useUpdateSubscription(subscriptionId: number) {
     mutationFn: (payload: Partial<SubscriptionUpsertInput>) =>
       apiClient.updateSubscription(token, subscriptionId, payload),
     onSuccess: () => {
+      toast.success("Subscription updated.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.detail(subscriptionId) });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not update the subscription.");
     },
   });
 }
@@ -112,8 +121,12 @@ export function useDeleteSubscription(subscriptionId: number) {
   return useMutation({
     mutationFn: () => apiClient.deleteSubscription(token, subscriptionId),
     onSuccess: () => {
+      toast.success("Subscription removed.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
       queryClient.removeQueries({ queryKey: subscriptionKeys.detail(subscriptionId) });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not delete the subscription.");
     },
   });
 }
@@ -125,8 +138,12 @@ export function useCreateCategory() {
   return useMutation({
     mutationFn: (payload: CategoryInput) => apiClient.createCategory(token, payload),
     onSuccess: () => {
+      toast.success("Category saved.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.categories });
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not save the category.");
     },
   });
 }
@@ -144,8 +161,12 @@ export function useUpdateCategory() {
       payload: CategoryInput;
     }) => apiClient.updateCategory(token, categoryId, payload),
     onSuccess: () => {
+      toast.success("Category updated.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.categories });
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not update the category.");
     },
   });
 }
@@ -157,8 +178,12 @@ export function useDeleteCategory() {
   return useMutation({
     mutationFn: (categoryId: number) => apiClient.deleteCategory(token, categoryId),
     onSuccess: () => {
+      toast.success("Category deleted.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.categories });
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not delete the category.");
     },
   });
 }
@@ -170,8 +195,12 @@ export function useCreatePaymentMethod() {
   return useMutation({
     mutationFn: (payload: PaymentMethodInput) => apiClient.createPaymentMethod(token, payload),
     onSuccess: () => {
+      toast.success("Payment method saved.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.paymentMethods });
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not save the payment method.");
     },
   });
 }
@@ -189,8 +218,12 @@ export function useUpdatePaymentMethod() {
       payload: PaymentMethodInput;
     }) => apiClient.updatePaymentMethod(token, paymentMethodId, payload),
     onSuccess: () => {
+      toast.success("Payment method updated.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.paymentMethods });
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not update the payment method.");
     },
   });
 }
@@ -202,8 +235,12 @@ export function useDeletePaymentMethod() {
   return useMutation({
     mutationFn: (paymentMethodId: number) => apiClient.deletePaymentMethod(token, paymentMethodId),
     onSuccess: () => {
+      toast.success("Payment method deleted.");
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.paymentMethods });
       void queryClient.invalidateQueries({ queryKey: subscriptionKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not delete the payment method.");
     },
   });
 }
@@ -215,7 +252,11 @@ export function useDeleteWorkspaceData() {
   return useMutation({
     mutationFn: () => apiClient.deleteWorkspaceData(token),
     onSuccess: () => {
+      toast.success("Workspace data cleared.");
       void queryClient.invalidateQueries();
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not clear workspace data.");
     },
   });
 }

--- a/frontend/src/hooks/use-uploads.ts
+++ b/frontend/src/hooks/use-uploads.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 
 import { useAuth } from "@/hooks/use-auth";
 import { apiClient } from "@/lib/api-client";
@@ -67,9 +68,13 @@ export function useCreateUpload() {
     mutationFn: ({ file, onProgress }: { file: File; onProgress?: (progress: number) => void }) =>
       apiClient.uploadFile(token, file, onProgress),
     onSuccess: (upload) => {
+      toast.success(`Upload queued: ${upload.file_name}`);
       queryClient.setQueryData(uploadKeys.status(upload.id), upload);
       void queryClient.invalidateQueries({ queryKey: uploadKeys.status(upload.id) });
       void queryClient.invalidateQueries({ queryKey: uploadKeys.history });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not upload the file.");
     },
   });
 }
@@ -81,8 +86,12 @@ export function useDeleteUpload() {
   return useMutation({
     mutationFn: (uploadId: number) => apiClient.deleteUpload(token, uploadId),
     onSuccess: (_, uploadId) => {
+      toast.success("Upload removed.");
       void queryClient.invalidateQueries({ queryKey: uploadKeys.history });
       queryClient.removeQueries({ queryKey: uploadKeys.status(uploadId) });
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : "Could not delete the upload.");
     },
   });
 }

--- a/frontend/src/hooks/use-uploads.ts
+++ b/frontend/src/hooks/use-uploads.ts
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 
 import { useAuth } from "@/hooks/use-auth";
 import { apiClient } from "@/lib/api-client";
-import type { Upload } from "@/types";
+import type { Upload, UploadListResponse } from "@/types";
 
 const uploadKeys = {
   history: ["uploads", "history"] as const,
@@ -69,6 +69,14 @@ export function useCreateUpload() {
       apiClient.uploadFile(token, file, onProgress),
     onSuccess: (upload) => {
       toast.success(`Upload queued: ${upload.file_name}`);
+      queryClient.setQueryData<UploadListResponse>(uploadKeys.history, (previous) => {
+        const nextItems = [upload, ...(previous?.items ?? []).filter((item) => item.id !== upload.id)];
+
+        return {
+          items: nextItems,
+          total: nextItems.length,
+        };
+      });
       queryClient.setQueryData(uploadKeys.status(upload.id), upload);
       void queryClient.invalidateQueries({ queryKey: uploadKeys.status(upload.id) });
       void queryClient.invalidateQueries({ queryKey: uploadKeys.history });

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -27,6 +27,20 @@ type RequestOptions = {
   token?: string;
 };
 
+async function parseResponseBody(response: Response) {
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (!contentType.includes("application/json")) {
+    const text = await response.text();
+    return text.trim() || null;
+  }
+
+  try {
+    return (await response.json()) as unknown;
+  } catch {
+    return null;
+  }
+}
+
 function buildUrl(path: string, query?: RequestOptions["query"]) {
   const url = new URL(`${API_BASE_URL}${path}`);
 
@@ -61,19 +75,20 @@ async function request<T>(
   });
 
   if (!response.ok) {
-    throw new Error(`Request failed with ${response.status}`);
+    const body = await parseResponseBody(response);
+    throw new Error(getErrorMessage(response.status, body));
   }
 
   if (response.status === 204) {
     return undefined as T;
   }
 
-  const contentType = response.headers.get("Content-Type") ?? "";
-  if (!contentType.includes("application/json")) {
+  const body = await parseResponseBody(response);
+  if (body === null || typeof body !== "object") {
     return undefined as T;
   }
 
-  return response.json() as Promise<T>;
+  return body as T;
 }
 
 function getErrorMessage(status: number, response: unknown) {
@@ -110,12 +125,16 @@ function uploadFile(
     });
 
     xhr.addEventListener("load", () => {
-      const response =
-        xhr.response && typeof xhr.response === "object"
-          ? xhr.response
-          : xhr.responseText
-            ? (JSON.parse(xhr.responseText) as unknown)
-            : null;
+      let response: unknown = null;
+      if (xhr.response && typeof xhr.response === "object") {
+        response = xhr.response;
+      } else if (xhr.responseText) {
+        try {
+          response = JSON.parse(xhr.responseText) as unknown;
+        } catch {
+          response = xhr.responseText;
+        }
+      }
 
       if (xhr.status < 200 || xhr.status >= 300) {
         reject(new Error(getErrorMessage(xhr.status, response)));

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -44,7 +44,7 @@ test("shows an error for invalid credentials", async ({ page, request }) => {
   await page.getByLabel("Password").fill("wrong-password");
   await page.getByRole("button", { name: "Sign in" }).click();
 
-  await expect(page.getByText("The email or password did not match an active account.")).toBeVisible();
+  await expect(page.locator("form").getByText("The email or password did not match an active account.")).toBeVisible();
 });
 
 test("refreshes the session before expiry", async ({ page, request }) => {

--- a/frontend/tests/e2e/home.spec.ts
+++ b/frontend/tests/e2e/home.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-test("renders the day 1 shell", async ({ page }) => {
+test("renders the MVP landing page", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.getByText("MySubscription Tracker")).toBeVisible();
   await expect(page.getByRole("heading", { level: 1 })).toContainText(
-    "Track every subscription",
+    "See every renewal coming",
   );
+  await expect(page.getByText("Import. Detect. Decide.")).toBeVisible();
 });

--- a/frontend/tests/unit/app/not-found.test.tsx
+++ b/frontend/tests/unit/app/not-found.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import NotFound from "@/app/not-found";
+
+describe("NotFound", () => {
+  it("renders the custom 404 copy", () => {
+    render(<NotFound />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /The route you asked for is outside the current subscription workspace/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open dashboard/i })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+  });
+});

--- a/frontend/tests/unit/lib/api-client.test.ts
+++ b/frontend/tests/unit/lib/api-client.test.ts
@@ -129,4 +129,19 @@ describe("apiClient", () => {
       }),
     );
   });
+
+  it("surfaces API error details instead of a generic status", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Category not found." }), {
+        status: 404,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+
+    await expect(apiClient.deleteCategory("access-token", 99)).rejects.toThrow(
+      "Category not found.",
+    );
+  });
 });


### PR DESCRIPTION
**Summary**

Your two commits, `f251453` and `a80b481`, are on `origin/day-15/mvp-polish-landing-page`. The failing automation was not a broad frontend break. It was in Playwright E2E.

What happened:

- The first blocker was environmental: the machine was almost out of disk space, and `/tmp` was filling up during Playwright runs. That caused `ENOSPC` and hid the real failures.
- Once space recovered, I reran the full frontend E2E suite and found two actual issues.

Why I fixed them:

- In [auth.spec.ts](/tmp/subtracker-day15/frontend/tests/e2e/auth.spec.ts:47), the invalid-login test was asserting on text that now appears in two places: the inline form error and the toast. Playwright strict mode treats that as ambiguous, so the test failed. I scoped the assertion to the form only.
- In [use-uploads.ts](/tmp/subtracker-day15/frontend/src/hooks/use-uploads.ts:72), the uploads page had a race after a successful upload. The POST succeeded, but the history query could still be empty for a moment, which cleared the selected upload before the processing panel rendered. I fixed that by immediately inserting the new upload into the React Query history cache on success.

Result:

- `lint`, `typecheck`, `vitest`, `build`, and the full Playwright suite all pass on the patched day-15 branch.
- Final E2E result: `40 passed`.

Fix commits on `codex/fix-auth-e2e-locator`:

- `91974b6` `test(day-15): scope invalid-login e2e assertion`
- `a195af4` `fix(day-15): stabilize upload selection after create`