### PR TITLE
Day 17/auto renewal processing

### DIFF
--- a/backend/src/api/routes/subscriptions.py
+++ b/backend/src/api/routes/subscriptions.py
@@ -20,6 +20,8 @@ from src.services.subscription import (
     get_subscription_or_404,
     get_subscription_payment_history,
     list_subscriptions,
+    serialize_subscription,
+    serialize_subscriptions,
     update_subscription,
 )
 
@@ -73,7 +75,7 @@ async def get_subscriptions(
         limit=limit,
     )
     return SubscriptionListResponse(
-        items=[SubscriptionResponse.model_validate(item) for item in items],
+        items=await serialize_subscriptions(session, items),
         total=total,
         limit=limit,
         offset=offset,
@@ -92,7 +94,7 @@ async def create_subscription_route(
     current_user: CurrentUser,
 ) -> SubscriptionResponse:
     subscription = await create_subscription(session, user=current_user, payload=payload)
-    return SubscriptionResponse.model_validate(subscription)
+    return await serialize_subscription(session, subscription)
 
 
 @router.get(
@@ -129,7 +131,7 @@ async def get_subscription(
         subscription_id=subscription_id,
         user=current_user,
     )
-    return SubscriptionResponse.model_validate(subscription)
+    return await serialize_subscription(session, subscription)
 
 
 @router.patch(
@@ -150,7 +152,7 @@ async def update_subscription_route(
         user=current_user,
         payload=payload,
     )
-    return SubscriptionResponse.model_validate(subscription)
+    return await serialize_subscription(session, subscription)
 
 
 @router.delete(

--- a/backend/src/schemas/subscription.py
+++ b/backend/src/schemas/subscription.py
@@ -1,8 +1,9 @@
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Literal
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 def _normalize_money_currency(value: str) -> str:
@@ -205,6 +206,16 @@ class SubscriptionUpdate(BaseModel):
         return value
 
 
+class SubscriptionRenewalSnapshot(BaseModel):
+    state: Literal["inactive", "overdue", "scheduled", "trialing"]
+    last_renewed_at: datetime | None = None
+    next_charge_date: date | None = None
+    days_until_charge: int | None = None
+    days_overdue: int | None = None
+    trial_ends_at: date | None = None
+    trial_days_remaining: int | None = None
+
+
 class SubscriptionResponse(BaseModel):
     id: int
     user_id: int
@@ -226,6 +237,9 @@ class SubscriptionResponse(BaseModel):
     notes: str | None
     created_at: datetime
     updated_at: datetime
+    renewal: SubscriptionRenewalSnapshot = Field(
+        default_factory=lambda: SubscriptionRenewalSnapshot(state="inactive")
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/src/services/subscription.py
+++ b/backend/src/services/subscription.py
@@ -1,5 +1,6 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import ROUND_HALF_UP, Decimal
+from typing import Literal
 
 from fastapi import HTTPException, status
 from sqlalchemy import func, or_, select
@@ -18,6 +19,8 @@ from src.schemas.subscription import (
     SubscriptionPaymentHistoryResponse,
     SubscriptionPaymentHistorySummary,
     SubscriptionPriceChangeResponse,
+    SubscriptionRenewalSnapshot,
+    SubscriptionResponse,
     SubscriptionUpdate,
 )
 
@@ -120,6 +123,108 @@ async def list_subscriptions(
         max_amount=str(max_amount) if max_amount is not None else None,
     )
     return items, int(total or 0)
+
+
+def _build_subscription_renewal_snapshot(
+    subscription: Subscription,
+    *,
+    last_renewed_at: datetime | None,
+    as_of: date,
+) -> SubscriptionRenewalSnapshot:
+    last_renewed_date = last_renewed_at.date() if last_renewed_at is not None else None
+    next_charge_date = subscription.next_charge_date
+
+    is_trialing = (
+        subscription.status != "cancelled"
+        and subscription.auto_renew
+        and next_charge_date is not None
+        and subscription.start_date <= as_of
+        and next_charge_date >= as_of
+        and last_renewed_date is None
+    )
+    is_overdue = (
+        subscription.status != "cancelled"
+        and subscription.auto_renew
+        and next_charge_date is not None
+        and next_charge_date < as_of
+        and (last_renewed_date is None or last_renewed_date < next_charge_date)
+    )
+
+    state: Literal["inactive", "overdue", "scheduled", "trialing"] = "inactive"
+    if is_overdue:
+        state = "overdue"
+    elif is_trialing:
+        state = "trialing"
+    elif subscription.status != "cancelled" and next_charge_date is not None:
+        state = "scheduled"
+
+    return SubscriptionRenewalSnapshot(
+        state=state,
+        last_renewed_at=last_renewed_at,
+        next_charge_date=next_charge_date,
+        days_until_charge=(
+            (next_charge_date - as_of).days
+            if next_charge_date is not None and next_charge_date >= as_of
+            else None
+        ),
+        days_overdue=((as_of - next_charge_date).days if is_overdue and next_charge_date else None),
+        trial_ends_at=next_charge_date if is_trialing else None,
+        trial_days_remaining=(
+            (next_charge_date - as_of).days
+            if is_trialing and next_charge_date is not None
+            else None
+        ),
+    )
+
+
+async def serialize_subscriptions(
+    session: AsyncSession,
+    subscriptions: list[Subscription],
+    *,
+    as_of: date | None = None,
+) -> list[SubscriptionResponse]:
+    if not subscriptions:
+        return []
+
+    reference_date = as_of or datetime.now(UTC).date()
+    latest_payment_rows = await session.execute(
+        select(
+            PaymentHistory.subscription_id,
+            func.max(PaymentHistory.paid_at).label("last_renewed_at"),
+        )
+        .where(
+            PaymentHistory.subscription_id.in_(
+                [subscription.id for subscription in subscriptions]
+            )
+        )
+        .group_by(PaymentHistory.subscription_id)
+    )
+    latest_payment_by_subscription = {
+        subscription_id: _as_utc_datetime(last_renewed_at)
+        for subscription_id, last_renewed_at in latest_payment_rows.all()
+        if subscription_id is not None and last_renewed_at is not None
+    }
+
+    responses: list[SubscriptionResponse] = []
+    for subscription in subscriptions:
+        response = SubscriptionResponse.model_validate(subscription)
+        response.renewal = _build_subscription_renewal_snapshot(
+            subscription,
+            last_renewed_at=latest_payment_by_subscription.get(subscription.id),
+            as_of=reference_date,
+        )
+        responses.append(response)
+    return responses
+
+
+async def serialize_subscription(
+    session: AsyncSession,
+    subscription: Subscription,
+    *,
+    as_of: date | None = None,
+) -> SubscriptionResponse:
+    responses = await serialize_subscriptions(session, [subscription], as_of=as_of)
+    return responses[0]
 
 
 async def get_subscription_or_404(

--- a/backend/tests/api/test_subscriptions.py
+++ b/backend/tests/api/test_subscriptions.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, timedelta
 
 
 def _auth_headers(client, email: str) -> dict[str, str]:
@@ -276,3 +276,65 @@ def test_subscriptions_enforce_validation_and_ownership(client) -> None:
         invalid_range_response.json()["detail"]
         == "min_amount must be less than or equal to max_amount."
     )
+
+
+def test_subscriptions_include_renewal_state_metadata(client) -> None:
+    owner_headers = _auth_headers(client, "renewals@example.com")
+    today = date.today()
+
+    trial_response = client.post(
+        "/api/v1/subscriptions",
+        headers=owner_headers,
+        json={
+            "name": "Music Trial",
+            "vendor": "Music Trial",
+            "amount": "9.99",
+            "currency": "USD",
+            "cadence": "monthly",
+            "status": "active",
+            "start_date": str(today - timedelta(days=9)),
+            "next_charge_date": str(today + timedelta(days=5)),
+            "auto_renew": True,
+        },
+    )
+    assert trial_response.status_code == 201
+
+    overdue_response = client.post(
+        "/api/v1/subscriptions",
+        headers=owner_headers,
+        json={
+            "name": "Overdue Plan",
+            "vendor": "Overdue Plan",
+            "amount": "19.99",
+            "currency": "USD",
+            "cadence": "monthly",
+            "status": "active",
+            "start_date": str(today - timedelta(days=60)),
+            "next_charge_date": str(today - timedelta(days=3)),
+            "auto_renew": True,
+        },
+    )
+    assert overdue_response.status_code == 201
+
+    trial_payload = client.get(
+        f"/api/v1/subscriptions/{trial_response.json()['id']}",
+        headers=owner_headers,
+    ).json()
+    overdue_payload = client.get(
+        f"/api/v1/subscriptions/{overdue_response.json()['id']}",
+        headers=owner_headers,
+    ).json()
+    listed = client.get("/api/v1/subscriptions", headers=owner_headers).json()["items"]
+
+    assert trial_payload["renewal"]["state"] == "trialing"
+    assert trial_payload["renewal"]["last_renewed_at"] is None
+    assert trial_payload["renewal"]["trial_ends_at"] == str(today + timedelta(days=5))
+    assert trial_payload["renewal"]["trial_days_remaining"] == 5
+
+    assert overdue_payload["renewal"]["state"] == "overdue"
+    assert overdue_payload["renewal"]["days_overdue"] == 3
+    assert overdue_payload["renewal"]["trial_days_remaining"] is None
+
+    renewal_by_name = {item["name"]: item["renewal"] for item in listed}
+    assert renewal_by_name["Music Trial"]["state"] == "trialing"
+    assert renewal_by_name["Overdue Plan"]["state"] == "overdue"

--- a/backend/tests/services/test_detection_engine.py
+++ b/backend/tests/services/test_detection_engine.py
@@ -277,3 +277,122 @@ def test_sync_user_subscriptions_records_price_change_events(app) -> None:
         assert events[0].payload["new_amount"] == "18.00"
 
     asyncio.run(exercise())
+
+
+def test_sync_user_subscriptions_reactivates_existing_subscription_after_matching_charge(
+    app,
+) -> None:
+    async def exercise() -> None:
+        async with database_module.SessionLocal() as session:
+            user = User(
+                email="renewal-reactivation@example.com",
+                full_name="Renewal Reactivation Owner",
+                hashed_password="hashed",
+            )
+            session.add(user)
+            await session.flush()
+
+            subscription = Subscription(
+                user_id=user.id,
+                category_id=None,
+                payment_method_id=None,
+                name="Netflix",
+                vendor="Netflix",
+                description="Imported earlier",
+                website_url=None,
+                amount=Decimal("15.49"),
+                currency="USD",
+                cadence="monthly",
+                status="paused",
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 3, 31),
+                next_charge_date=date(2026, 3, 31),
+                day_of_month=1,
+                auto_renew=True,
+                notes="Waiting for the next renewal event.",
+            )
+            session.add(subscription)
+            await session.flush()
+
+            session.add_all(
+                [
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="nf-1",
+                        posted_at=date(2026, 1, 1),
+                        merchant="Netflix",
+                        description="NETFLIX COM LOS GATOS",
+                        amount=Decimal("-15.49"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=True,
+                        raw_payload={"is_known_service": True},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="nf-2",
+                        posted_at=date(2026, 2, 1),
+                        merchant="Netflix",
+                        description="NETFLIX COM LOS GATOS",
+                        amount=Decimal("-15.49"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=True,
+                        raw_payload={"is_known_service": True},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="nf-3",
+                        posted_at=date(2026, 3, 1),
+                        merchant="Netflix",
+                        description="NETFLIX COM LOS GATOS",
+                        amount=Decimal("-15.49"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=True,
+                        raw_payload={"is_known_service": True},
+                    ),
+                    RawTransaction(
+                        user_id=user.id,
+                        data_source_id=None,
+                        external_id="nf-4",
+                        posted_at=date(2026, 4, 1),
+                        merchant="Netflix",
+                        description="NETFLIX COM LOS GATOS",
+                        amount=Decimal("-15.49"),
+                        currency="USD",
+                        transaction_type="debit",
+                        subscription_candidate=True,
+                        raw_payload={"is_known_service": True},
+                    ),
+                ]
+            )
+            await session.commit()
+
+        await sync_user_subscriptions(user_id=1, as_of=date(2026, 4, 2))
+
+        async with database_module.SessionLocal() as session:
+            refreshed_subscription = await session.scalar(
+                select(Subscription).where(Subscription.user_id == 1)
+            )
+            payment_history = list(
+                (
+                    await session.scalars(
+                        select(PaymentHistory)
+                        .where(PaymentHistory.subscription_id == refreshed_subscription.id)
+                        .order_by(PaymentHistory.paid_at.asc())
+                    )
+                ).all()
+            )
+
+        assert refreshed_subscription is not None
+        assert refreshed_subscription.status == "active"
+        assert refreshed_subscription.end_date is None
+        assert refreshed_subscription.next_charge_date == date(2026, 5, 1)
+        assert len(payment_history) == 4
+        assert payment_history[-1].paid_at.date() == date(2026, 4, 1)
+
+    asyncio.run(exercise())

--- a/frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx
@@ -14,6 +14,7 @@ import { useState } from "react";
 
 import { SubscriptionForm } from "@/components/subscriptions/subscription-form";
 import { PaymentTimeline } from "@/components/subscriptions/payment-timeline";
+import { RenewalBadge } from "@/components/subscriptions/renewal-badge";
 import { StatusBadge } from "@/components/subscriptions/status-badge";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Button } from "@/components/ui/button";
@@ -35,11 +36,9 @@ function formatDate(value: string | null) {
     return "Not set";
   }
 
-  const parts = value.split("-").map((part) => Number(part));
-  const date =
-    parts.length === 3 && parts.every((part) => Number.isFinite(part))
-      ? new Date(parts[0], parts[1] - 1, parts[2])
-      : new Date(value);
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? new Date(`${value}T12:00:00Z`)
+    : new Date(value);
   if (Number.isNaN(date.getTime())) {
     return value;
   }
@@ -47,6 +46,7 @@ function formatDate(value: string | null) {
   return new Intl.DateTimeFormat("en-US", {
     day: "numeric",
     month: "long",
+    timeZone: "UTC",
     year: "numeric",
   }).format(date);
 }
@@ -126,7 +126,7 @@ export default function SubscriptionDetailPage() {
             </Button>
           </div>
         }
-        description="Review billing terms, change lifecycle status, update details, or remove the plan from the Day 5 management surface."
+        description="Review billing terms, monitor renewal health, update details, or remove the plan from the subscriptions workspace."
         eyebrow="Subscription detail"
         title={subscription.name}
       />
@@ -146,6 +146,7 @@ export default function SubscriptionDetailPage() {
 
             <div className="space-y-3">
               <StatusBadge className="w-fit" status={subscription.status} />
+              <RenewalBadge className="w-fit" renewal={subscription.renewal} />
               <CurrencyDisplay
                 className="block text-3xl font-semibold text-ink"
                 currency={subscription.currency}
@@ -168,6 +169,16 @@ export default function SubscriptionDetailPage() {
                   <dd>{formatDate(subscription.next_charge_date)}</dd>
                 </div>
                 <div>
+                  <dt className="font-medium text-ink">Last renewed</dt>
+                  <dd>
+                    {subscription.renewal.last_renewed_at
+                      ? formatDate(subscription.renewal.last_renewed_at)
+                      : subscription.renewal.state === "trialing"
+                        ? "Waiting for the first renewal"
+                        : "Not recorded yet"}
+                  </dd>
+                </div>
+                <div>
                   <dt className="font-medium text-ink">End date</dt>
                   <dd>{formatDate(subscription.end_date)}</dd>
                 </div>
@@ -175,6 +186,23 @@ export default function SubscriptionDetailPage() {
                   <dt className="font-medium text-ink">Auto renew</dt>
                   <dd>{subscription.auto_renew ? "Enabled" : "Disabled"}</dd>
                 </div>
+                {subscription.renewal.state === "overdue" && subscription.renewal.days_overdue !== null ? (
+                  <div>
+                    <dt className="font-medium text-ink">Renewal alert</dt>
+                    <dd>Overdue by {subscription.renewal.days_overdue} days</dd>
+                  </div>
+                ) : null}
+                {subscription.renewal.state === "trialing" &&
+                subscription.renewal.trial_ends_at !== null &&
+                subscription.renewal.trial_days_remaining !== null ? (
+                  <div>
+                    <dt className="font-medium text-ink">Trial window</dt>
+                    <dd>
+                      Ends {formatDate(subscription.renewal.trial_ends_at)} with{" "}
+                      {subscription.renewal.trial_days_remaining} days remaining
+                    </dd>
+                  </div>
+                ) : null}
               </dl>
             </div>
 

--- a/frontend/src/components/subscriptions/renewal-badge.tsx
+++ b/frontend/src/components/subscriptions/renewal-badge.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle, Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { SubscriptionRenewal } from "@/types";
+
+type RenewalBadgeProps = {
+  className?: string;
+  renewal: SubscriptionRenewal;
+};
+
+function formatDays(value: number) {
+  return `${value} day${value === 1 ? "" : "s"}`;
+}
+
+export function RenewalBadge({ className, renewal }: RenewalBadgeProps) {
+  if (renewal.state === "overdue" && renewal.days_overdue !== null) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-rose-700",
+          className,
+        )}
+      >
+        <AlertTriangle className="size-3.5" />
+        Overdue by {formatDays(renewal.days_overdue)}
+      </span>
+    );
+  }
+
+  if (renewal.state === "trialing" && renewal.trial_days_remaining !== null) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-sky-700",
+          className,
+        )}
+      >
+        <Sparkles className="size-3.5" />
+        Trial ends in {formatDays(renewal.trial_days_remaining)}
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/components/subscriptions/subscription-card.tsx
+++ b/frontend/src/components/subscriptions/subscription-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowRight, Globe2 } from "lucide-react";
 
+import { RenewalBadge } from "@/components/subscriptions/renewal-badge";
 import { StatusBadge } from "@/components/subscriptions/status-badge";
 import { Button } from "@/components/ui/button";
 import { CurrencyDisplay } from "@/components/ui/currency-display";
@@ -20,11 +21,9 @@ function formatDate(value: string | null) {
     return "No date set";
   }
 
-  const parts = value.split("-").map((part) => Number(part));
-  const date =
-    parts.length === 3 && parts.every((part) => Number.isFinite(part))
-      ? new Date(parts[0], parts[1] - 1, parts[2])
-      : new Date(value);
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? new Date(`${value}T12:00:00Z`)
+    : new Date(value);
   if (Number.isNaN(date.getTime())) {
     return value;
   }
@@ -32,6 +31,7 @@ function formatDate(value: string | null) {
   return new Intl.DateTimeFormat("en-US", {
     day: "numeric",
     month: "short",
+    timeZone: "UTC",
     year: "numeric",
   }).format(date);
 }
@@ -95,7 +95,11 @@ export function SubscriptionCard({
 
         <div className="flex flex-wrap items-center gap-3 text-sm text-black/58">
           <StatusBadge status={subscription.status} />
+          <RenewalBadge renewal={subscription.renewal} />
           <span>Renews {formatDate(subscription.next_charge_date ?? subscription.start_date)}</span>
+          {subscription.renewal.last_renewed_at ? (
+            <span>Last renewed {formatDate(subscription.renewal.last_renewed_at)}</span>
+          ) : null}
           {paymentMethodLabel ? <span>Paid with {paymentMethodLabel}</span> : null}
           {hostLabel ? (
             <span className="inline-flex items-center gap-1.5">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -229,6 +229,17 @@ export type UploadListResponse = {
 
 export type SubscriptionStatus = "active" | "paused" | "cancelled";
 export type SubscriptionCadence = "weekly" | "monthly" | "quarterly" | "yearly";
+export type SubscriptionRenewalState = "inactive" | "overdue" | "scheduled" | "trialing";
+
+export type SubscriptionRenewal = {
+  state: SubscriptionRenewalState;
+  last_renewed_at: string | null;
+  next_charge_date: string | null;
+  days_until_charge: number | null;
+  days_overdue: number | null;
+  trial_ends_at: string | null;
+  trial_days_remaining: number | null;
+};
 
 export type Subscription = {
   id: number;
@@ -249,6 +260,7 @@ export type Subscription = {
   day_of_month: number | null;
   auto_renew: boolean;
   notes: string | null;
+  renewal: SubscriptionRenewal;
   created_at: string;
   updated_at: string;
 };

--- a/frontend/tests/unit/components/subscription-card.test.tsx
+++ b/frontend/tests/unit/components/subscription-card.test.tsx
@@ -19,6 +19,15 @@ const subscription: Subscription = {
   next_charge_date: "2026-05-01",
   notes: "Shared with household",
   payment_method_id: 9,
+  renewal: {
+    days_overdue: null,
+    days_until_charge: 10,
+    last_renewed_at: "2026-04-01T00:00:00Z",
+    next_charge_date: "2026-05-01",
+    state: "scheduled",
+    trial_days_remaining: null,
+    trial_ends_at: null,
+  },
   start_date: "2026-04-01",
   status: "active",
   updated_at: "2026-04-06T00:00:00Z",
@@ -40,6 +49,7 @@ describe("SubscriptionCard", () => {
 
     expect(screen.getByText("Netflix Family")).toBeVisible();
     expect(screen.getByText("Streaming")).toBeVisible();
+    expect(screen.getByText("Last renewed Apr 1, 2026")).toBeVisible();
     expect(screen.getByText("Paid with Visa ending in 4242")).toBeVisible();
     expect(screen.getByRole("link", { name: /open detail/i })).toHaveAttribute(
       "href",
@@ -52,5 +62,23 @@ describe("SubscriptionCard", () => {
 
     expect(screen.getByText("Renews May 1, 2026")).toBeVisible();
     expect(screen.getByText("$15.49")).toBeVisible();
+  });
+
+  it("surfaces renewal alerts for overdue plans", () => {
+    render(
+      <SubscriptionCard
+        subscription={{
+          ...subscription,
+          renewal: {
+            ...subscription.renewal,
+            days_overdue: 3,
+            days_until_charge: null,
+            state: "overdue",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Overdue by 3 days")).toBeVisible();
   });
 });


### PR DESCRIPTION
<html><head></head><body><h1>Day 17 — Auto-Renewal Processing Complete</h1>
<h2>Milestone Overview</h2>

Field | Detail
-- | --
Day | 17
Branch | day-17/auto-renewal-processing
Umbrella Issue | #65
Child Issues | #66, #67
Final Commit | 0c0fdc1
Commits Pushed | 10 per-file commits → origin/day-17/auto-renewal-processing


<hr>
<h2>GitHub Write-Back</h2>
<ul>
<li>✅ Completion comments posted on <code>#66</code>, <code>#67</code>, and <code>#65</code></li>
<li>✅ Child issues <code>#66</code> and <code>#67</code> closed before umbrella <code>#65</code></li>
<li>✅ Umbrella issue <code>#65</code> closed</li>
<li>✅ Milestone <code>17</code> closed</li>
</ul>
<hr>
<h2>Next Steps</h2>
<blockquote>
<p>No Day 17 work remains. The next scheduled run should advance to <strong>Day 18</strong> on <code>day-18/category-analytics</code>.</p>
</blockquote></body></html># Day 17 — Auto-Renewal Processing Complete

## Milestone Overview

| Field | Detail |
|---|---|
| **Day** | 17 |
| **Branch** | `day-17/auto-renewal-processing` |
| **Umbrella Issue** | `#65` |
| **Child Issues** | `#66`, `#67` |
| **Final Commit** | `0c0fdc1` |
| **Commits Pushed** | 10 per-file commits → `origin/day-17/auto-renewal-processing` |

---

## Work Completed

### Backend

Subscription responses now expose computed renewal metadata.

- [`[backend/src/services/subscription.py](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/services/subscription.py)`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/services/subscription.py)
- [`[backend/src/schemas/subscription.py](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/schemas/subscription.py)`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/schemas/subscription.py)

### Frontend

Subscriptions UI now shows **last-renewed**, **overdue**, and **trial** indicators.

- [`[frontend/src/components/subscriptions/renewal-badge.tsx](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/components/subscriptions/renewal-badge.tsx)`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/components/subscriptions/renewal-badge.tsx)
- [`[frontend/src/components/subscriptions/subscription-card.tsx](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/components/subscriptions/subscription-card.tsx)`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/components/subscriptions/subscription-card.tsx)
- [`[frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/app/(app)/subscriptions/%5BsubscriptionId%5D/page.tsx)`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/app/(app)/subscriptions/[subscriptionId]/page.tsx)

---

## Verification

All checks passed ✅

| Check | Command |
|---|---|
| Lockfile guard | `lockfile-guard.sh` |
| Python tests | `backend/.venv/bin/pytest backend/tests` |
| Python linting | `backend/.venv/bin/ruff check backend/src backend/tests` |
| Python type check | `backend/.venv/bin/mypy backend/src` |
| JS linting | `npm run lint` |
| JS tests | `npm test` |
| JS type check | `npm run typecheck` |
| JS build | `npm run build` |

---

## GitHub Write-Back

- ✅ Completion comments posted on `#66`, `#67`, and `#65`
- ✅ Child issues `#66` and `#67` closed before umbrella `#65`
- ✅ Umbrella issue `#65` closed
- ✅ Milestone `17` closed

---

## Next Steps

> No Day 17 work remains. The next scheduled run should advance to **Day 18** on `day-18/category-analytics`.