### PR TITLE
Day 18/category analytics

### DIFF
--- a/backend/src/api/routes/expense_reports.py
+++ b/backend/src/api/routes/expense_reports.py
@@ -1,17 +1,20 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.database import get_db
 from src.dependencies import get_current_user
 from src.models.user import User
+from src.schemas.analytics import AnalyticsRangeKey, AnalyticsResponse
 from src.schemas.expense_report import ExpenseReportListResponse, ExpenseReportResponse
+from src.services.analytics import get_expense_analytics
 from src.services.expense_report import get_expense_report_or_404, list_expense_reports
 
 router = APIRouter(prefix="/expense-reports", tags=["expense-reports"])
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 CurrentUser = Annotated[User, Depends(get_current_user)]
+AnalyticsRangeParam = Annotated[AnalyticsRangeKey, Query(alias="range")]
 
 
 @router.get(
@@ -25,6 +28,20 @@ async def list_expense_reports_route(
     current_user: CurrentUser,
 ) -> ExpenseReportListResponse:
     return await list_expense_reports(session, user=current_user)
+
+
+@router.get(
+    "/analytics",
+    response_model=AnalyticsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get analytics aggregates for the reports workspace",
+)
+async def get_expense_analytics_route(
+    session: DbSession,
+    current_user: CurrentUser,
+    range_key: AnalyticsRangeParam = "180d",
+) -> AnalyticsResponse:
+    return await get_expense_analytics(session, user=current_user, range_key=range_key)
 
 
 @router.get(

--- a/backend/src/schemas/analytics.py
+++ b/backend/src/schemas/analytics.py
@@ -1,0 +1,68 @@
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel
+
+AnalyticsRangeKey = Literal["90d", "180d", "365d"]
+
+
+class AnalyticsWindow(BaseModel):
+    key: AnalyticsRangeKey
+    label: str
+    start_date: date
+    end_date: date
+
+
+class AnalyticsSummary(BaseModel):
+    total_spend: Decimal
+    average_monthly_spend: Decimal
+    active_subscriptions: int
+    projected_monthly_savings: Decimal
+    projected_range_savings: Decimal
+
+
+class AnalyticsCategoryItem(BaseModel):
+    category_id: int | None
+    category_name: str
+    total_spend: Decimal
+    active_subscriptions: int
+    projected_monthly_savings: Decimal
+    projected_range_savings: Decimal
+
+
+class AnalyticsPaymentMethodItem(BaseModel):
+    payment_method_id: int | None
+    payment_method_label: str
+    provider: str | None = None
+    total_spend: Decimal
+    active_subscriptions: int
+
+
+class AnalyticsFrequencyItem(BaseModel):
+    cadence: str
+    label: str
+    subscription_count: int
+    monthly_equivalent: Decimal
+
+
+class AnalyticsTrendCategoryItem(BaseModel):
+    category_name: str
+    total_spend: Decimal
+
+
+class AnalyticsTrendPoint(BaseModel):
+    period_start: date
+    label: str
+    total_spend: Decimal
+    category_totals: list[AnalyticsTrendCategoryItem]
+
+
+class AnalyticsResponse(BaseModel):
+    window: AnalyticsWindow
+    summary: AnalyticsSummary
+    categories: list[AnalyticsCategoryItem]
+    payment_methods: list[AnalyticsPaymentMethodItem]
+    frequency_distribution: list[AnalyticsFrequencyItem]
+    trends: list[AnalyticsTrendPoint]
+    trend_categories: list[str]

--- a/backend/src/services/analytics.py
+++ b/backend/src/services/analytics.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, date, datetime, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.logging import get_logger
+from src.models.category import Category
+from src.models.payment_history import PaymentHistory
+from src.models.payment_method import PaymentMethod
+from src.models.subscription import Subscription
+from src.models.user import User
+from src.schemas.analytics import (
+    AnalyticsCategoryItem,
+    AnalyticsFrequencyItem,
+    AnalyticsPaymentMethodItem,
+    AnalyticsRangeKey,
+    AnalyticsResponse,
+    AnalyticsSummary,
+    AnalyticsTrendCategoryItem,
+    AnalyticsTrendPoint,
+    AnalyticsWindow,
+)
+
+logger = get_logger(__name__)
+
+WINDOW_CONFIG: dict[AnalyticsRangeKey, dict[str, int | str]] = {
+    "90d": {"days": 90, "label": "Last 90 days", "projection_months": 3},
+    "180d": {"days": 180, "label": "Last 180 days", "projection_months": 6},
+    "365d": {"days": 365, "label": "Last 365 days", "projection_months": 12},
+}
+CADENCE_LABELS = {
+    "weekly": "Weekly cadence",
+    "monthly": "Monthly cadence",
+    "quarterly": "Quarterly cadence",
+    "yearly": "Yearly cadence",
+}
+CADENCE_ORDER = {"monthly": 0, "quarterly": 1, "yearly": 2, "weekly": 3}
+TREND_CATEGORY_LIMIT = 4
+
+
+def _quantize_money(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _monthly_equivalent(subscription: Subscription) -> Decimal:
+    cadence = subscription.cadence.lower()
+    amount = Decimal(subscription.amount)
+
+    if cadence == "weekly":
+        return _quantize_money((amount * Decimal(52)) / Decimal(12))
+    if cadence == "quarterly":
+        return _quantize_money(amount / Decimal(3))
+    if cadence == "yearly":
+        return _quantize_money(amount / Decimal(12))
+    return _quantize_money(amount)
+
+
+def _month_start(value: date) -> date:
+    return value.replace(day=1)
+
+
+def _shift_months(value: date, offset: int) -> date:
+    month_index = (value.year * 12 + value.month - 1) + offset
+    year = month_index // 12
+    month = month_index % 12 + 1
+    return date(year, month, 1)
+
+
+def _category_name(subscription: Subscription, category_map: dict[int, str]) -> str:
+    if subscription.category_id is None:
+        return "Uncategorized"
+    return category_map.get(subscription.category_id, "Uncategorized")
+
+
+def _payment_method_key(
+    payment_method_id: int | None,
+    payment_method_map: dict[int, PaymentMethod],
+) -> tuple[int | None, str, str | None]:
+    if payment_method_id is None:
+        return (None, "Unassigned", None)
+
+    payment_method = payment_method_map.get(payment_method_id)
+    if payment_method is None:
+        return (payment_method_id, f"Method #{payment_method_id}", None)
+
+    provider = payment_method.provider.strip() or None
+    provider_prefix = f"{provider} " if provider else ""
+    last4 = payment_method.last4.strip() if payment_method.last4 else ""
+    suffix = f" ending {last4}" if last4 else ""
+    return (
+        payment_method.id,
+        f"{provider_prefix}{payment_method.label}{suffix}".strip(),
+        provider,
+    )
+
+
+async def get_expense_analytics(
+    session: AsyncSession,
+    *,
+    user: User,
+    range_key: AnalyticsRangeKey,
+) -> AnalyticsResponse:
+    config = WINDOW_CONFIG[range_key]
+    today = date.today()
+    window_days = int(config["days"])
+    projection_months = Decimal(str(config["projection_months"]))
+    window_start = today - timedelta(days=window_days - 1)
+    window_start_at = datetime.combine(window_start, datetime.min.time(), tzinfo=UTC)
+    window_end_at = datetime.combine(today + timedelta(days=1), datetime.min.time(), tzinfo=UTC)
+
+    subscriptions = list(
+        (
+            await session.scalars(
+                select(Subscription)
+                .where(Subscription.user_id == user.id)
+                .order_by(Subscription.id.asc())
+            )
+        ).all()
+    )
+    active_subscriptions = [
+        subscription for subscription in subscriptions if subscription.status == "active"
+    ]
+
+    category_ids = sorted(
+        {
+            subscription.category_id
+            for subscription in subscriptions
+            if subscription.category_id is not None
+        }
+    )
+    categories = (
+        list((await session.scalars(select(Category).where(Category.id.in_(category_ids)))).all())
+        if category_ids
+        else []
+    )
+    category_map = {category.id: category.name for category in categories}
+
+    payment_rows = list(
+        (
+            await session.execute(
+                select(PaymentHistory, Subscription)
+                .join(Subscription, Subscription.id == PaymentHistory.subscription_id)
+                .where(
+                    Subscription.user_id == user.id,
+                    PaymentHistory.paid_at >= window_start_at,
+                    PaymentHistory.paid_at < window_end_at,
+                )
+                .order_by(PaymentHistory.paid_at.asc(), PaymentHistory.id.asc())
+            )
+        ).all()
+    )
+
+    payment_method_ids = sorted(
+        {
+            payment_method_id
+            for payment_method_id in (
+                *(subscription.payment_method_id for subscription in subscriptions),
+                *(
+                    payment.payment_method_id or subscription.payment_method_id
+                    for payment, subscription in payment_rows
+                ),
+            )
+            if payment_method_id is not None
+        }
+    )
+    payment_methods = (
+        list(
+            (
+                await session.scalars(
+                    select(PaymentMethod).where(PaymentMethod.id.in_(payment_method_ids))
+                )
+            ).all()
+        )
+        if payment_method_ids
+        else []
+    )
+    payment_method_map = {payment_method.id: payment_method for payment_method in payment_methods}
+
+    category_spend_totals: dict[tuple[int | None, str], Decimal] = defaultdict(
+        lambda: Decimal("0.00")
+    )
+    method_spend_totals: dict[tuple[int | None, str, str | None], Decimal] = defaultdict(
+        lambda: Decimal("0.00")
+    )
+    trend_totals: dict[date, Decimal] = defaultdict(lambda: Decimal("0.00"))
+    trend_category_totals: dict[tuple[date, str], Decimal] = defaultdict(
+        lambda: Decimal("0.00")
+    )
+    total_spend = Decimal("0.00")
+
+    for payment, subscription in payment_rows:
+        amount = _quantize_money(abs(Decimal(payment.amount)))
+        total_spend += amount
+
+        category_name = _category_name(subscription, category_map)
+        category_key = (subscription.category_id, category_name)
+        category_spend_totals[category_key] += amount
+
+        payment_method_key = _payment_method_key(
+            payment.payment_method_id or subscription.payment_method_id,
+            payment_method_map,
+        )
+        method_spend_totals[payment_method_key] += amount
+
+        paid_at = payment.paid_at.astimezone(UTC) if payment.paid_at.tzinfo else payment.paid_at
+        month_key = _month_start(paid_at.date())
+        trend_totals[month_key] += amount
+        trend_category_totals[(month_key, category_name)] += amount
+
+    category_projection: dict[tuple[int | None, str], dict[str, Decimal | int]] = defaultdict(
+        lambda: {
+            "active_subscriptions": 0,
+            "projected_monthly_savings": Decimal("0.00"),
+        }
+    )
+    payment_method_projection: dict[
+        tuple[int | None, str, str | None], dict[str, int]
+    ] = defaultdict(lambda: {"active_subscriptions": 0})
+    frequency_totals: dict[str, dict[str, Decimal | int]] = defaultdict(
+        lambda: {
+            "subscription_count": 0,
+            "monthly_equivalent": Decimal("0.00"),
+        }
+    )
+
+    for subscription in active_subscriptions:
+        monthly_equivalent = _monthly_equivalent(subscription)
+        category_key = (
+            subscription.category_id,
+            _category_name(subscription, category_map),
+        )
+        category_projection_entry = category_projection[category_key]
+        category_projection_entry["active_subscriptions"] = (
+            int(category_projection_entry["active_subscriptions"]) + 1
+        )
+        category_projection_entry["projected_monthly_savings"] = Decimal(
+            category_projection_entry["projected_monthly_savings"]
+        ) + monthly_equivalent
+
+        payment_method_projection_entry = payment_method_projection[
+            _payment_method_key(subscription.payment_method_id, payment_method_map)
+        ]
+        payment_method_projection_entry["active_subscriptions"] = (
+            int(payment_method_projection_entry["active_subscriptions"]) + 1
+        )
+
+        cadence = subscription.cadence.lower()
+        frequency_entry = frequency_totals[cadence]
+        frequency_entry["subscription_count"] = int(frequency_entry["subscription_count"]) + 1
+        frequency_entry["monthly_equivalent"] = Decimal(
+            frequency_entry["monthly_equivalent"]
+        ) + monthly_equivalent
+
+    projected_monthly_savings = _quantize_money(
+        sum(
+            (
+                Decimal(entry["projected_monthly_savings"])
+                for entry in category_projection.values()
+            ),
+            Decimal("0.00"),
+        )
+    )
+    projected_range_savings = _quantize_money(projected_monthly_savings * projection_months)
+
+    categories_payload = [
+        AnalyticsCategoryItem(
+            category_id=category_id,
+            category_name=category_name,
+            total_spend=_quantize_money(category_spend_totals[(category_id, category_name)]),
+            active_subscriptions=int(
+                category_projection[(category_id, category_name)]["active_subscriptions"]
+            ),
+            projected_monthly_savings=_quantize_money(
+                Decimal(
+                    category_projection[(category_id, category_name)]["projected_monthly_savings"]
+                )
+            ),
+            projected_range_savings=_quantize_money(
+                Decimal(
+                    category_projection[(category_id, category_name)]["projected_monthly_savings"]
+                )
+                * projection_months
+            ),
+        )
+        for category_id, category_name in sorted(
+            set(category_spend_totals) | set(category_projection),
+            key=lambda item: (
+                Decimal(category_projection[item]["projected_monthly_savings"]),
+                category_spend_totals[item],
+                item[1].lower(),
+            ),
+            reverse=True,
+        )
+    ]
+
+    payment_methods_payload = [
+        AnalyticsPaymentMethodItem(
+            payment_method_id=payment_method_id,
+            payment_method_label=payment_method_label,
+            provider=provider,
+            total_spend=_quantize_money(
+                method_spend_totals[(payment_method_id, payment_method_label, provider)]
+            ),
+            active_subscriptions=int(
+                payment_method_projection[
+                    (payment_method_id, payment_method_label, provider)
+                ]["active_subscriptions"]
+            ),
+        )
+        for payment_method_id, payment_method_label, provider in sorted(
+            set(method_spend_totals) | set(payment_method_projection),
+            key=lambda item: (
+                method_spend_totals[item],
+                payment_method_projection[item]["active_subscriptions"],
+                item[1].lower(),
+            ),
+            reverse=True,
+        )
+    ]
+
+    frequency_distribution = [
+        AnalyticsFrequencyItem(
+            cadence=cadence,
+            label=CADENCE_LABELS.get(cadence, cadence.capitalize()),
+            subscription_count=int(values["subscription_count"]),
+            monthly_equivalent=_quantize_money(Decimal(values["monthly_equivalent"])),
+        )
+        for cadence, values in sorted(
+            frequency_totals.items(),
+            key=lambda item: (
+                CADENCE_ORDER.get(item[0], 99),
+                item[0],
+            ),
+        )
+    ]
+
+    trend_categories = [
+        category.category_name
+        for category in sorted(
+            categories_payload,
+            key=lambda item: (
+                item.total_spend,
+                item.projected_monthly_savings,
+                item.category_name.lower(),
+            ),
+            reverse=True,
+        )[:TREND_CATEGORY_LIMIT]
+    ]
+
+    trend_points: list[AnalyticsTrendPoint] = []
+    cursor = _month_start(window_start)
+    final_month = _month_start(today)
+    show_year = cursor.year != final_month.year
+    while cursor <= final_month:
+        trend_points.append(
+            AnalyticsTrendPoint(
+                period_start=cursor,
+                label=cursor.strftime("%b %y" if show_year else "%b"),
+                total_spend=_quantize_money(trend_totals[cursor]),
+                category_totals=[
+                    AnalyticsTrendCategoryItem(
+                        category_name=category_name,
+                        total_spend=_quantize_money(
+                            trend_category_totals[(cursor, category_name)]
+                        ),
+                    )
+                    for category_name in trend_categories
+                ],
+            )
+        )
+        cursor = _shift_months(cursor, 1)
+
+    response = AnalyticsResponse(
+        window=AnalyticsWindow(
+            key=range_key,
+            label=str(config["label"]),
+            start_date=window_start,
+            end_date=today,
+        ),
+        summary=AnalyticsSummary(
+            total_spend=_quantize_money(total_spend),
+            average_monthly_spend=_quantize_money(
+                total_spend / projection_months if projection_months else Decimal("0.00")
+            ),
+            active_subscriptions=len(active_subscriptions),
+            projected_monthly_savings=projected_monthly_savings,
+            projected_range_savings=projected_range_savings,
+        ),
+        categories=categories_payload,
+        payment_methods=payment_methods_payload,
+        frequency_distribution=frequency_distribution,
+        trends=trend_points,
+        trend_categories=trend_categories,
+    )
+    logger.info(
+        "analytics.summary.loaded",
+        user_id=user.id,
+        range_key=range_key,
+        active_subscriptions=response.summary.active_subscriptions,
+        categories=len(response.categories),
+        payment_methods=len(response.payment_methods),
+    )
+    return response

--- a/backend/tests/api/test_analytics.py
+++ b/backend/tests/api/test_analytics.py
@@ -1,0 +1,268 @@
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+from src.core import database as database_module
+from src.models.payment_history import PaymentHistory
+from src.models.subscription import Subscription
+
+
+def _auth_headers(client, email: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "full_name": "Analytics Owner",
+            "password": "super-secret",
+        },
+    )
+    assert response.status_code == 201
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _create_category(client, headers: dict[str, str], name: str) -> int:
+    response = client.post(
+        "/api/v1/categories",
+        headers=headers,
+        json={"name": name, "description": f"{name} category"},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _create_payment_method(
+    client,
+    headers: dict[str, str],
+    *,
+    label: str,
+    provider: str,
+    last4: str,
+) -> int:
+    response = client.post(
+        "/api/v1/payment-methods",
+        headers=headers,
+        json={
+            "label": label,
+            "provider": provider,
+            "last4": last4,
+            "is_default": False,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _create_subscription(
+    client,
+    headers: dict[str, str],
+    *,
+    name: str,
+    amount: str,
+    cadence: str,
+    category_id: int,
+    payment_method_id: int,
+    start_date: str,
+) -> int:
+    response = client.post(
+        "/api/v1/subscriptions",
+        headers=headers,
+        json={
+            "name": name,
+            "vendor": name,
+            "amount": amount,
+            "currency": "USD",
+            "cadence": cadence,
+            "status": "active",
+            "start_date": start_date,
+            "category_id": category_id,
+            "payment_method_id": payment_method_id,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _seed_payment_history(subscription_id: int, paid_at: datetime, amount: Decimal) -> None:
+    async def _write() -> None:
+        async with database_module.SessionLocal() as session:
+            subscription = await session.get(Subscription, subscription_id)
+            assert subscription is not None
+            session.add(
+                PaymentHistory(
+                    subscription_id=subscription.id,
+                    payment_method_id=subscription.payment_method_id,
+                    paid_at=paid_at,
+                    amount=amount,
+                    currency="USD",
+                    payment_status="settled",
+                    reference=f"{subscription_id}-{paid_at.date().isoformat()}",
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_write())
+
+
+def test_expense_analytics_returns_category_method_frequency_and_trend_data(client) -> None:
+    today = date.today()
+    current_month_start = today.replace(day=1)
+    previous_month_start = (current_month_start - timedelta(days=1)).replace(day=1)
+    two_months_back = (previous_month_start - timedelta(days=1)).replace(day=1)
+
+    headers = _auth_headers(client, "analytics@example.com")
+    other_headers = _auth_headers(client, "other-analytics@example.com")
+
+    entertainment_id = _create_category(client, headers, "Entertainment")
+    utilities_id = _create_category(client, headers, "Utilities")
+    productivity_id = _create_category(client, headers, "Productivity")
+
+    visa_id = _create_payment_method(
+        client,
+        headers,
+        label="Primary card",
+        provider="Visa",
+        last4="4242",
+    )
+    amex_id = _create_payment_method(
+        client,
+        headers,
+        label="Backup card",
+        provider="Amex",
+        last4="3005",
+    )
+
+    netflix_id = _create_subscription(
+        client,
+        headers,
+        name="Netflix",
+        amount="15.00",
+        cadence="monthly",
+        category_id=entertainment_id,
+        payment_method_id=visa_id,
+        start_date=str(today - timedelta(days=180)),
+    )
+    spotify_id = _create_subscription(
+        client,
+        headers,
+        name="Spotify",
+        amount="10.00",
+        cadence="monthly",
+        category_id=entertainment_id,
+        payment_method_id=amex_id,
+        start_date=str(today - timedelta(days=180)),
+    )
+    electric_id = _create_subscription(
+        client,
+        headers,
+        name="Electric",
+        amount="90.00",
+        cadence="quarterly",
+        category_id=utilities_id,
+        payment_method_id=amex_id,
+        start_date=str(today - timedelta(days=240)),
+    )
+    dropbox_id = _create_subscription(
+        client,
+        headers,
+        name="Dropbox",
+        amount="120.00",
+        cadence="yearly",
+        category_id=productivity_id,
+        payment_method_id=visa_id,
+        start_date=str(today - timedelta(days=400)),
+    )
+
+    _seed_payment_history(
+        netflix_id,
+        datetime.combine(current_month_start + timedelta(days=2), datetime.min.time(), tzinfo=UTC),
+        Decimal("15.00"),
+    )
+    _seed_payment_history(
+        spotify_id,
+        datetime.combine(current_month_start + timedelta(days=4), datetime.min.time(), tzinfo=UTC),
+        Decimal("10.00"),
+    )
+    _seed_payment_history(
+        electric_id,
+        datetime.combine(previous_month_start + timedelta(days=5), datetime.min.time(), tzinfo=UTC),
+        Decimal("90.00"),
+    )
+    _seed_payment_history(
+        netflix_id,
+        datetime.combine(
+            previous_month_start + timedelta(days=10),
+            datetime.min.time(),
+            tzinfo=UTC,
+        ),
+        Decimal("15.00"),
+    )
+    _seed_payment_history(
+        dropbox_id,
+        datetime.combine(two_months_back + timedelta(days=8), datetime.min.time(), tzinfo=UTC),
+        Decimal("120.00"),
+    )
+
+    analytics_response = client.get("/api/v1/expense-reports/analytics?range=180d", headers=headers)
+
+    assert analytics_response.status_code == 200
+    payload = analytics_response.json()
+    assert payload["window"]["key"] == "180d"
+    assert payload["summary"] == {
+        "total_spend": "250.00",
+        "average_monthly_spend": "41.67",
+        "active_subscriptions": 4,
+        "projected_monthly_savings": "65.00",
+        "projected_range_savings": "390.00",
+    }
+    assert payload["categories"][0] == {
+        "category_id": utilities_id,
+        "category_name": "Utilities",
+        "total_spend": "90.00",
+        "active_subscriptions": 1,
+        "projected_monthly_savings": "30.00",
+        "projected_range_savings": "180.00",
+    }
+    assert payload["categories"][1]["category_name"] == "Entertainment"
+    assert payload["categories"][1]["total_spend"] == "40.00"
+    assert payload["categories"][1]["projected_range_savings"] == "150.00"
+
+    assert payload["payment_methods"][0]["payment_method_label"] == "Visa Primary card ending 4242"
+    assert payload["payment_methods"][0]["total_spend"] == "150.00"
+    assert payload["payment_methods"][1]["payment_method_label"] == "Amex Backup card ending 3005"
+    assert payload["payment_methods"][1]["total_spend"] == "100.00"
+
+    assert payload["frequency_distribution"] == [
+        {
+            "cadence": "monthly",
+            "label": "Monthly cadence",
+            "subscription_count": 2,
+            "monthly_equivalent": "25.00",
+        },
+        {
+            "cadence": "quarterly",
+            "label": "Quarterly cadence",
+            "subscription_count": 1,
+            "monthly_equivalent": "30.00",
+        },
+        {
+            "cadence": "yearly",
+            "label": "Yearly cadence",
+            "subscription_count": 1,
+            "monthly_equivalent": "10.00",
+        },
+    ]
+
+    trend_map = {item["period_start"]: item for item in payload["trends"]}
+    assert trend_map[two_months_back.isoformat()]["total_spend"] == "120.00"
+    assert trend_map[previous_month_start.isoformat()]["total_spend"] == "105.00"
+    assert trend_map[current_month_start.isoformat()]["total_spend"] == "25.00"
+    assert "Entertainment" in payload["trend_categories"]
+    assert "Utilities" in payload["trend_categories"]
+
+    other_response = client.get(
+        "/api/v1/expense-reports/analytics?range=180d",
+        headers=other_headers,
+    )
+    assert other_response.status_code == 200
+    assert other_response.json()["summary"]["total_spend"] == "0.00"
+    assert other_response.json()["categories"] == []

--- a/frontend/src/app/(app)/reports/page.tsx
+++ b/frontend/src/app/(app)/reports/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { startTransition, useDeferredValue, useEffect, useState } from "react";
 import { ArrowRight, BarChart3, LoaderCircle, PieChart as PieChartIcon } from "lucide-react";
 import {
   Bar,
@@ -15,13 +15,14 @@ import {
   XAxis,
 } from "recharts";
 
+import { ReportAnalytics } from "@/components/reports/report-analytics";
 import { ExpenseReportCard } from "@/components/reports/expense-report-card";
 import { Button } from "@/components/ui/button";
 import { CurrencyDisplay, formatCurrency } from "@/components/ui/currency-display";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
-import { useExpenseReport, useExpenseReports } from "@/hooks/use-expense-reports";
-import type { ExpenseReport } from "@/types";
+import { useExpenseAnalytics, useExpenseReport, useExpenseReports } from "@/hooks/use-expense-reports";
+import type { AnalyticsRangeKey, ExpenseReport } from "@/types";
 
 const CATEGORY_COLORS = ["#111418", "#dc5d30", "#d9895d", "#95a6ba", "#cdb28f"];
 const EMPTY_REPORTS: ExpenseReport[] = [];
@@ -63,6 +64,9 @@ function formatGeneratedAt(value: string | null) {
 
 export default function ReportsPage() {
   const reportsQuery = useExpenseReports();
+  const [selectedRange, setSelectedRange] = useState<AnalyticsRangeKey>("180d");
+  const deferredRange = useDeferredValue(selectedRange);
+  const analyticsQuery = useExpenseAnalytics(deferredRange);
   const reports = reportsQuery.data?.items ?? EMPTY_REPORTS;
   const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
 
@@ -81,37 +85,6 @@ export default function ReportsPage() {
   const selectedReport =
     reportQuery.data ?? reports.find((report) => report.id === selectedReportId) ?? null;
 
-  if (!reportsQuery.isLoading && reports.length === 0) {
-    return (
-      <div className="space-y-8 animate-page-enter">
-        <PageHeader
-          action={
-            <Button asChild className="rounded-full px-5" variant="outline">
-              <Link href="/uploads">
-                Upload a statement
-                <ArrowRight className="ml-2 size-4" />
-              </Link>
-            </Button>
-          }
-          description="Statement-derived expense reports will appear here after uploads finish processing."
-          eyebrow="Day 16 analysis"
-          title="Expense reports"
-        />
-
-        <EmptyState
-          action={
-            <Button asChild className="rounded-full px-5" variant="outline">
-              <Link href="/uploads">Open uploads</Link>
-            </Button>
-          }
-          description="Import CSV or PDF statements to generate chart-ready spend reports with merchant and category breakdowns."
-          icon={<BarChart3 className="size-5" />}
-          title="No expense reports yet"
-        />
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-8 animate-page-enter">
       <PageHeader
@@ -123,193 +96,221 @@ export default function ReportsPage() {
             </Link>
           </Button>
         }
-        description="Review statement-derived spend reports, inspect the dominant merchants and categories, and move from upload history into chart-backed expense analysis."
-        eyebrow="Day 16 analysis"
-        title="Expense reports"
+        description="Run category analytics across the active subscription graph, compare payment-method concentration and savings potential, then drop into statement-derived report detail when you need the raw source view."
+        eyebrow="Day 18 analysis"
+        title="Reports and analytics"
       />
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(320px,0.9fr)_minmax(0,1.1fr)]">
-        <section className="space-y-4">
-          {reportsQuery.isLoading ? (
-            <div className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur">
-              <div className="flex items-center gap-3 text-sm text-black/58">
+      <ReportAnalytics
+        analytics={analyticsQuery.data}
+        isLoading={analyticsQuery.isLoading && !analyticsQuery.data}
+        onRangeChange={(range) => {
+          startTransition(() => {
+            setSelectedRange(range);
+          });
+        }}
+        selectedRange={selectedRange}
+      />
+
+      {!reportsQuery.isLoading && reports.length === 0 ? (
+        <EmptyState
+          action={
+            <Button asChild className="rounded-full px-5" variant="outline">
+              <Link href="/uploads">Open uploads</Link>
+            </Button>
+          }
+          description="Import CSV or PDF statements to populate the source report library beneath the analytics workspace."
+          icon={<BarChart3 className="size-5" />}
+          title="No uploaded report snapshots yet"
+        />
+      ) : (
+        <div className="grid gap-6 xl:grid-cols-[minmax(320px,0.9fr)_minmax(0,1.1fr)]">
+          <section className="space-y-4">
+            {reportsQuery.isLoading ? (
+              <div className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur">
+                <div className="flex items-center gap-3 text-sm text-black/58">
+                  <LoaderCircle className="size-4 animate-spin" />
+                  Loading expense reports...
+                </div>
+              </div>
+            ) : (
+              reports.map((report) => (
+                <ExpenseReportCard
+                  isActive={report.id === selectedReportId}
+                  key={report.id}
+                  onSelect={() => setSelectedReportId(report.id)}
+                  report={report}
+                />
+              ))
+            )}
+          </section>
+
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+            {!selectedReport || reportQuery.isLoading ? (
+              <div className="flex min-h-72 items-center justify-center gap-3 text-sm text-black/58">
                 <LoaderCircle className="size-4 animate-spin" />
-                Loading expense reports...
+                Loading report detail...
               </div>
-            </div>
-          ) : (
-            reports.map((report) => (
-              <ExpenseReportCard
-                isActive={report.id === selectedReportId}
-                key={report.id}
-                onSelect={() => setSelectedReportId(report.id)}
-                report={report}
-              />
-            ))
-          )}
-        </section>
-
-        <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
-          {!selectedReport || reportQuery.isLoading ? (
-            <div className="flex min-h-72 items-center justify-center gap-3 text-sm text-black/58">
-              <LoaderCircle className="size-4 animate-spin" />
-              Loading report detail...
-            </div>
-          ) : (
-            <div className="space-y-6">
-              <div className="flex flex-col gap-5 border-b border-black/10 pb-6 lg:flex-row lg:items-end lg:justify-between">
-                <div className="space-y-2">
-                  <p className="text-xs uppercase tracking-[0.32em] text-black/45">
-                    {selectedReport.summary.provider || "Statement upload"}
-                  </p>
-                  <h2 className="text-3xl font-semibold tracking-tight text-ink">
-                    {selectedReport.summary.upload_name || `Expense report #${selectedReport.id}`}
-                  </h2>
-                  <p className="max-w-2xl text-sm leading-6 text-black/62">
-                    Generated {formatGeneratedAt(selectedReport.generated_at)} with{" "}
-                    {selectedReport.summary.transaction_count} charges across{" "}
-                    {selectedReport.summary.merchant_count} merchants.
-                  </p>
-                </div>
-
-                <div className="rounded-[1.5rem] bg-[#101922] px-5 py-4 text-white">
-                  <p className="text-xs uppercase tracking-[0.28em] text-white/46">Report total</p>
-                  <CurrencyDisplay
-                    className="mt-2 block text-3xl font-semibold tracking-tight"
-                    currency={selectedReport.currency}
-                    value={Number(selectedReport.total_amount)}
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="rounded-[1.4rem] border border-black/10 bg-stone/65 p-4">
-                  <p className="text-xs uppercase tracking-[0.28em] text-black/42">Average charge</p>
-                  <CurrencyDisplay
-                    className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
-                    currency={selectedReport.currency}
-                    value={Number(selectedReport.summary.average_transaction)}
-                  />
-                </div>
-                <div className="rounded-[1.4rem] border border-black/10 bg-stone/65 p-4">
-                  <p className="text-xs uppercase tracking-[0.28em] text-black/42">Largest charge</p>
-                  <CurrencyDisplay
-                    className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
-                    currency={selectedReport.currency}
-                    value={Number(selectedReport.summary.largest_transaction)}
-                  />
-                </div>
-                <div className="rounded-[1.4rem] border border-black/10 bg-stone/65 p-4">
-                  <p className="text-xs uppercase tracking-[0.28em] text-black/42">Recurring candidates</p>
-                  <p className="mt-3 text-3xl font-semibold tracking-tight text-ink">
-                    {selectedReport.summary.recurring_transaction_count}
-                  </p>
-                </div>
-              </div>
-
-              <div className="grid gap-5 xl:grid-cols-2">
-                <section className="rounded-[1.6rem] border border-black/10 bg-white/88 p-5">
-                  <div className="flex items-center gap-3">
-                    <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
-                      <BarChart3 className="size-5" />
-                    </span>
-                    <div>
-                      <p className="text-xs uppercase tracking-[0.28em] text-black/42">Spend trend</p>
-                      <h3 className="mt-1 text-xl font-semibold text-ink">Timeline by month</h3>
-                    </div>
+            ) : (
+              <div className="space-y-6">
+                <div className="flex flex-col gap-5 border-b border-black/10 pb-6 lg:flex-row lg:items-end lg:justify-between">
+                  <div className="space-y-2">
+                    <p className="text-xs uppercase tracking-[0.32em] text-black/45">
+                      {selectedReport.summary.provider || "Statement upload"}
+                    </p>
+                    <h2 className="text-3xl font-semibold tracking-tight text-ink">
+                      {selectedReport.summary.upload_name || `Expense report #${selectedReport.id}`}
+                    </h2>
+                    <p className="max-w-2xl text-sm leading-6 text-black/62">
+                      Generated {formatGeneratedAt(selectedReport.generated_at)} with{" "}
+                      {selectedReport.summary.transaction_count} charges across{" "}
+                      {selectedReport.summary.merchant_count} merchants.
+                    </p>
                   </div>
 
-                  <div className="mt-5 h-64">
-                    <ResponsiveContainer height="100%" width="100%">
-                      <BarChart
-                        accessibilityLayer
-                        data={selectedReport.summary.spend_timeline.map((point) => ({
-                          label: point.label,
-                          total_amount: Number(point.total_amount),
-                        }))}
-                        margin={{ bottom: 0, left: -12, right: 8, top: 6 }}
-                      >
-                        <CartesianGrid stroke="rgba(17,20,24,0.08)" strokeDasharray="4 8" vertical={false} />
-                        <XAxis
-                          axisLine={false}
-                          dataKey="label"
-                          tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
-                          tickLine={false}
-                        />
-                        <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(220, 93, 48, 0.08)" }} />
-                        <Bar dataKey="total_amount" fill="#dc5d30" radius={[12, 12, 0, 0]} />
-                      </BarChart>
-                    </ResponsiveContainer>
+                  <div className="rounded-[1.5rem] bg-[#101922] px-5 py-4 text-white">
+                    <p className="text-xs uppercase tracking-[0.28em] text-white/46">Report total</p>
+                    <CurrencyDisplay
+                      className="mt-2 block text-3xl font-semibold tracking-tight"
+                      currency={selectedReport.currency}
+                      value={Number(selectedReport.total_amount)}
+                    />
                   </div>
-                </section>
+                </div>
 
-                <section className="rounded-[1.6rem] border border-black/10 bg-white/88 p-5">
-                  <div className="flex items-center gap-3">
-                    <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
-                      <PieChartIcon className="size-5" />
-                    </span>
-                    <div>
-                      <p className="text-xs uppercase tracking-[0.28em] text-black/42">Category split</p>
-                      <h3 className="mt-1 text-xl font-semibold text-ink">Where the spend landed</h3>
-                    </div>
+                <div className="grid gap-4 md:grid-cols-3">
+                  <div className="rounded-[1.4rem] border border-black/10 bg-stone/65 p-4">
+                    <p className="text-xs uppercase tracking-[0.28em] text-black/42">Average charge</p>
+                    <CurrencyDisplay
+                      className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
+                      currency={selectedReport.currency}
+                      value={Number(selectedReport.summary.average_transaction)}
+                    />
                   </div>
-
-                  <div className="mt-5 h-64">
-                    <ResponsiveContainer height="100%" width="100%">
-                      <PieChart>
-                        <Pie
-                          cx="50%"
-                          cy="50%"
-                          data={selectedReport.summary.category_breakdown.map((item) => ({
-                            label: item.category_name,
-                            total_amount: Number(item.total_amount),
-                          }))}
-                          dataKey="total_amount"
-                          innerRadius={54}
-                          outerRadius={92}
-                          paddingAngle={3}
-                        >
-                          {selectedReport.summary.category_breakdown.map((item, index) => (
-                            <Cell
-                              fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]}
-                              key={item.category_name}
-                            />
-                          ))}
-                        </Pie>
-                        <Tooltip content={<ChartTooltip />} />
-                      </PieChart>
-                    </ResponsiveContainer>
+                  <div className="rounded-[1.4rem] border border-black/10 bg-stone/65 p-4">
+                    <p className="text-xs uppercase tracking-[0.28em] text-black/42">Largest charge</p>
+                    <CurrencyDisplay
+                      className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
+                      currency={selectedReport.currency}
+                      value={Number(selectedReport.summary.largest_transaction)}
+                    />
                   </div>
-                </section>
-              </div>
+                  <div className="rounded-[1.4rem] border border-black/10 bg-stone/65 p-4">
+                    <p className="text-xs uppercase tracking-[0.28em] text-black/42">Recurring candidates</p>
+                    <p className="mt-3 text-3xl font-semibold tracking-tight text-ink">
+                      {selectedReport.summary.recurring_transaction_count}
+                    </p>
+                  </div>
+                </div>
 
-              <section className="rounded-[1.6rem] border border-black/10 bg-white/88 p-5">
-                <p className="text-xs uppercase tracking-[0.28em] text-black/42">Top merchants</p>
-                <div className="mt-4 space-y-3">
-                  {selectedReport.summary.top_merchants.map((merchant) => (
-                    <div
-                      className="flex items-center justify-between gap-4 rounded-[1.25rem] border border-black/10 bg-white px-4 py-3"
-                      key={merchant.merchant}
-                    >
+                <div className="grid gap-5 xl:grid-cols-2">
+                  <section className="rounded-[1.6rem] border border-black/10 bg-white/88 p-5">
+                    <div className="flex items-center gap-3">
+                      <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+                        <BarChart3 className="size-5" />
+                      </span>
                       <div>
-                        <p className="text-base font-semibold text-ink">{merchant.merchant}</p>
-                        <p className="mt-1 text-sm text-black/58">
-                          {merchant.transaction_count} charge{merchant.transaction_count === 1 ? "" : "s"}
-                        </p>
+                        <p className="text-xs uppercase tracking-[0.28em] text-black/42">Spend trend</p>
+                        <h3 className="mt-1 text-xl font-semibold text-ink">Timeline by month</h3>
                       </div>
-                      <CurrencyDisplay
-                        className="text-base font-semibold text-ink"
-                        currency={selectedReport.currency}
-                        value={Number(merchant.total_amount)}
-                      />
                     </div>
-                  ))}
+
+                    <div className="mt-5 h-64">
+                      <ResponsiveContainer height="100%" width="100%">
+                        <BarChart
+                          accessibilityLayer
+                          data={selectedReport.summary.spend_timeline.map((point) => ({
+                            label: point.label,
+                            total_amount: Number(point.total_amount),
+                          }))}
+                          margin={{ bottom: 0, left: -12, right: 8, top: 6 }}
+                        >
+                          <CartesianGrid
+                            stroke="rgba(17,20,24,0.08)"
+                            strokeDasharray="4 8"
+                            vertical={false}
+                          />
+                          <XAxis
+                            axisLine={false}
+                            dataKey="label"
+                            tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
+                            tickLine={false}
+                          />
+                          <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(220, 93, 48, 0.08)" }} />
+                          <Bar dataKey="total_amount" fill="#dc5d30" radius={[12, 12, 0, 0]} />
+                        </BarChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </section>
+
+                  <section className="rounded-[1.6rem] border border-black/10 bg-white/88 p-5">
+                    <div className="flex items-center gap-3">
+                      <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+                        <PieChartIcon className="size-5" />
+                      </span>
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.28em] text-black/42">Category split</p>
+                        <h3 className="mt-1 text-xl font-semibold text-ink">Where the spend landed</h3>
+                      </div>
+                    </div>
+
+                    <div className="mt-5 h-64">
+                      <ResponsiveContainer height="100%" width="100%">
+                        <PieChart>
+                          <Pie
+                            cx="50%"
+                            cy="50%"
+                            data={selectedReport.summary.category_breakdown.map((item) => ({
+                              label: item.category_name,
+                              total_amount: Number(item.total_amount),
+                            }))}
+                            dataKey="total_amount"
+                            innerRadius={54}
+                            outerRadius={92}
+                            paddingAngle={3}
+                          >
+                            {selectedReport.summary.category_breakdown.map((item, index) => (
+                              <Cell
+                                fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]}
+                                key={item.category_name}
+                              />
+                            ))}
+                          </Pie>
+                          <Tooltip content={<ChartTooltip />} />
+                        </PieChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </section>
                 </div>
-              </section>
-            </div>
-          )}
-        </section>
-      </div>
+
+                <section className="rounded-[1.6rem] border border-black/10 bg-white/88 p-5">
+                  <p className="text-xs uppercase tracking-[0.28em] text-black/42">Top merchants</p>
+                  <div className="mt-4 space-y-3">
+                    {selectedReport.summary.top_merchants.map((merchant) => (
+                      <div
+                        className="flex items-center justify-between gap-4 rounded-[1.25rem] border border-black/10 bg-white px-4 py-3"
+                        key={merchant.merchant}
+                      >
+                        <div>
+                          <p className="text-base font-semibold text-ink">{merchant.merchant}</p>
+                          <p className="mt-1 text-sm text-black/58">
+                            {merchant.transaction_count} charge{merchant.transaction_count === 1 ? "" : "s"}
+                          </p>
+                        </div>
+                        <CurrencyDisplay
+                          className="text-base font-semibold text-ink"
+                          currency={selectedReport.currency}
+                          value={Number(merchant.total_amount)}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              </div>
+            )}
+          </section>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/reports/report-analytics.tsx
+++ b/frontend/src/components/reports/report-analytics.tsx
@@ -1,0 +1,499 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { BarChart3, Clock3, Landmark, PiggyBank, TrendingUp } from "lucide-react";
+
+import { CurrencyDisplay, formatCurrency } from "@/components/ui/currency-display";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { AnalyticsRangeKey, ExpenseAnalytics } from "@/types";
+
+const RANGE_OPTIONS: Array<{ key: AnalyticsRangeKey; label: string }> = [
+  { key: "90d", label: "Last 90 days" },
+  { key: "180d", label: "Last 180 days" },
+  { key: "365d", label: "Last 365 days" },
+];
+const TREND_COLORS = ["#dc5d30", "#111418", "#d9895d", "#95a6ba"];
+const METHOD_COLORS = ["#111418", "#dc5d30", "#d9895d", "#95a6ba", "#cdb28f"];
+
+type ValueTooltipProps = {
+  active?: boolean;
+  label?: string;
+  payload?: Array<{
+    color?: string;
+    name?: string;
+    value?: number | string;
+  }>;
+};
+
+type ReportAnalyticsProps = {
+  analytics?: ExpenseAnalytics;
+  isLoading: boolean;
+  selectedRange: AnalyticsRangeKey;
+  onRangeChange: (range: AnalyticsRangeKey) => void;
+};
+
+function ValueTooltip({ active, label, payload }: ValueTooltipProps) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-[1.2rem] border border-black/10 bg-white/94 px-4 py-3 shadow-line">
+      <p className="text-xs uppercase tracking-[0.28em] text-black/42">{label}</p>
+      <div className="mt-2 space-y-2">
+        {payload.map((item) => (
+          <div className="flex items-center justify-between gap-4 text-sm" key={item.name}>
+            <span className="inline-flex items-center gap-2 text-black/62">
+              <span
+                className="size-2.5 rounded-full"
+                style={{ backgroundColor: item.color ?? "#111418" }}
+              />
+              {item.name}
+            </span>
+            <span className="font-semibold text-ink">
+              {formatCurrency({ value: Number(item.value ?? 0) })}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(`${value}T00:00:00`));
+}
+
+export function ReportAnalytics({
+  analytics,
+  isLoading,
+  selectedRange,
+  onRangeChange,
+}: ReportAnalyticsProps) {
+  const trendData = useMemo(() => {
+    if (!analytics) {
+      return [];
+    }
+
+    return analytics.trends.map((point) => {
+      const row: Record<string, number | string> = {
+        label: point.label,
+        total_spend: Number(point.total_spend),
+      };
+
+      for (const category of point.category_totals) {
+        row[category.category_name] = Number(category.total_spend);
+      }
+
+      return row;
+    });
+  }, [analytics]);
+
+  const paymentMethodData = useMemo(
+    () =>
+      (analytics?.payment_methods ?? [])
+        .filter((method) => Number(method.total_spend) > 0)
+        .map((method, index) => ({
+          color: METHOD_COLORS[index % METHOD_COLORS.length],
+          label: method.payment_method_label,
+          subscriptions: method.active_subscriptions,
+          total_spend: Number(method.total_spend),
+        })),
+    [analytics],
+  );
+
+  const savingsChartData = useMemo(
+    () =>
+      (analytics?.categories ?? [])
+        .filter((category) => Number(category.projected_range_savings) > 0)
+        .slice(0, 5)
+        .reverse()
+        .map((category) => ({
+          active_subscriptions: category.active_subscriptions,
+          category_name: category.category_name,
+          projected_monthly_savings: Number(category.projected_monthly_savings),
+          projected_range_savings: Number(category.projected_range_savings),
+        })),
+    [analytics],
+  );
+
+  const summary = analytics?.summary;
+  const hasObservedSpend = Number(summary?.total_spend ?? 0) > 0;
+  const hasProjectedSavings = savingsChartData.length > 0;
+  const hasPaymentMix = paymentMethodData.length > 0;
+
+  return (
+    <section className="space-y-6 rounded-[2.2rem] border border-black/10 bg-white/80 p-6 shadow-line backdrop-blur sm:p-7">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.32em] text-black/42">Day 18 analytics</p>
+          <div>
+            <h2 className="text-3xl font-semibold tracking-tight text-ink">Category analytics</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-black/62">
+              Compare actual spend in the selected window against the recurring savings still tied
+              up in active categories, payment rails, and renewal cadence.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {RANGE_OPTIONS.map((option) => (
+            <Button
+              className="rounded-full px-4"
+              key={option.key}
+              onClick={() => onRangeChange(option.key)}
+              type="button"
+              variant={selectedRange === option.key ? "default" : "outline"}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-[1.5rem] border border-black/10 bg-[#101922] p-5 text-white">
+          <p className="text-xs uppercase tracking-[0.28em] text-white/42">Observed spend</p>
+          <CurrencyDisplay
+            className="mt-3 block text-3xl font-semibold tracking-tight"
+            currency="USD"
+            value={Number(summary?.total_spend ?? 0)}
+          />
+          <p className="mt-3 text-sm text-white/62">{analytics ? analytics.window.label : "Selected window"}</p>
+        </div>
+
+        <div className="rounded-[1.5rem] border border-black/10 bg-stone/70 p-5">
+          <p className="text-xs uppercase tracking-[0.28em] text-black/42">Average month</p>
+          <CurrencyDisplay
+            className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
+            currency="USD"
+            value={Number(summary?.average_monthly_spend ?? 0)}
+          />
+          <p className="mt-3 text-sm text-black/58">Actual spend normalized to the selected window.</p>
+        </div>
+
+        <div className="rounded-[1.5rem] border border-black/10 bg-stone/70 p-5">
+          <p className="text-xs uppercase tracking-[0.28em] text-black/42">Active subscriptions</p>
+          <p className="mt-3 text-3xl font-semibold tracking-tight text-ink">
+            {summary?.active_subscriptions ?? 0}
+          </p>
+          <p className="mt-3 text-sm text-black/58">
+            Recurring plans contributing to the savings projection.
+          </p>
+        </div>
+
+        <div className="rounded-[1.5rem] border border-black/10 bg-stone/70 p-5">
+          <p className="text-xs uppercase tracking-[0.28em] text-black/42">Potential savings</p>
+          <CurrencyDisplay
+            className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
+            currency="USD"
+            value={Number(summary?.projected_range_savings ?? 0)}
+          />
+          <p className="mt-3 text-sm text-black/58">
+            Projected savings if the active category spend were trimmed over this window.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-2">
+        <section className="rounded-[1.7rem] border border-black/10 bg-white/90 p-5">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+              <BarChart3 className="size-5" />
+            </span>
+            <div>
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Stacked bars</p>
+              <h3 className="mt-1 text-xl font-semibold text-ink">Spend by category over time</h3>
+            </div>
+          </div>
+
+          <div className="mt-5 h-72">
+            {hasObservedSpend ? (
+              <ResponsiveContainer height="100%" width="100%">
+                <BarChart data={trendData} margin={{ bottom: 0, left: -12, right: 8, top: 6 }}>
+                  <CartesianGrid
+                    stroke="rgba(17,20,24,0.08)"
+                    strokeDasharray="4 8"
+                    vertical={false}
+                  />
+                  <XAxis
+                    axisLine={false}
+                    dataKey="label"
+                    tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
+                    tickLine={false}
+                  />
+                  <Tooltip content={<ValueTooltip />} cursor={{ fill: "rgba(220, 93, 48, 0.08)" }} />
+                  {analytics?.trend_categories.map((categoryName, index) => (
+                    <Bar
+                      dataKey={categoryName}
+                      fill={TREND_COLORS[index % TREND_COLORS.length]}
+                      key={categoryName}
+                      name={categoryName}
+                      radius={index === analytics.trend_categories.length - 1 ? [10, 10, 0, 0] : 0}
+                      stackId="categories"
+                    />
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex h-full items-center justify-center rounded-[1.4rem] border border-dashed border-black/10 bg-stone/50 px-6 text-center text-sm leading-6 text-black/58">
+                No settled payment history landed inside this window yet.
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-[1.7rem] border border-black/10 bg-white/90 p-5">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+              <TrendingUp className="size-5" />
+            </span>
+            <div>
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Line chart</p>
+              <h3 className="mt-1 text-xl font-semibold text-ink">Overall spend trend</h3>
+            </div>
+          </div>
+
+          <div className="mt-5 h-72">
+            {hasObservedSpend ? (
+              <ResponsiveContainer height="100%" width="100%">
+                <LineChart data={trendData} margin={{ bottom: 0, left: -12, right: 8, top: 6 }}>
+                  <CartesianGrid
+                    stroke="rgba(17,20,24,0.08)"
+                    strokeDasharray="4 8"
+                    vertical={false}
+                  />
+                  <XAxis
+                    axisLine={false}
+                    dataKey="label"
+                    tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    axisLine={false}
+                    tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
+                    tickFormatter={(value) => `$${value}`}
+                    tickLine={false}
+                    width={48}
+                  />
+                  <Tooltip content={<ValueTooltip />} />
+                  <Line
+                    dataKey="total_spend"
+                    dot={{ fill: "#dc5d30", r: 4 }}
+                    name="Total spend"
+                    stroke="#dc5d30"
+                    strokeWidth={3}
+                    type="monotone"
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex h-full items-center justify-center rounded-[1.4rem] border border-dashed border-black/10 bg-stone/50 px-6 text-center text-sm leading-6 text-black/58">
+                Spend history will plot here once statement imports or renewal syncs create payment rows.
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-[1.7rem] border border-black/10 bg-white/90 p-5">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+              <Landmark className="size-5" />
+            </span>
+            <div>
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Donut</p>
+              <h3 className="mt-1 text-xl font-semibold text-ink">Payment method mix</h3>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,0.9fr)_minmax(220px,0.8fr)]">
+            <div className="h-72">
+              {hasPaymentMix ? (
+                <ResponsiveContainer height="100%" width="100%">
+                  <PieChart>
+                    <Pie
+                      data={paymentMethodData}
+                      dataKey="total_spend"
+                      innerRadius={72}
+                      outerRadius={108}
+                      paddingAngle={3}
+                    >
+                      {paymentMethodData.map((entry) => (
+                        <Cell fill={entry.color} key={entry.label} />
+                      ))}
+                    </Pie>
+                    <Tooltip content={<ValueTooltip />} />
+                  </PieChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex h-full items-center justify-center rounded-[1.4rem] border border-dashed border-black/10 bg-stone/50 px-6 text-center text-sm leading-6 text-black/58">
+                  Payment-method mix appears once settled payments land inside the selected window.
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-3">
+              {paymentMethodData.map((method) => (
+                <div className="rounded-[1.3rem] border border-black/10 bg-stone/60 p-4" key={method.label}>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-ink">{method.label}</p>
+                      <p className="mt-1 text-xs uppercase tracking-[0.24em] text-black/42">
+                        {method.subscriptions} active subscriptions
+                      </p>
+                    </div>
+                    <span className="mt-1 size-3 rounded-full" style={{ backgroundColor: method.color }} />
+                  </div>
+                  <CurrencyDisplay
+                    className="mt-4 block text-2xl font-semibold tracking-tight text-ink"
+                    currency="USD"
+                    value={method.total_spend}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-[1.7rem] border border-black/10 bg-white/90 p-5">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+              <PiggyBank className="size-5" />
+            </span>
+            <div>
+              <p className="text-xs uppercase tracking-[0.28em] text-black/42">Horizontal bars</p>
+              <h3 className="mt-1 text-xl font-semibold text-ink">Potential savings</h3>
+            </div>
+          </div>
+
+          <div className="mt-5 h-72">
+            {hasProjectedSavings ? (
+              <ResponsiveContainer height="100%" width="100%">
+                <BarChart
+                  data={savingsChartData}
+                  layout="vertical"
+                  margin={{ bottom: 0, left: 32, right: 16, top: 6 }}
+                >
+                  <CartesianGrid horizontal={false} stroke="rgba(17,20,24,0.08)" strokeDasharray="4 8" />
+                  <XAxis
+                    axisLine={false}
+                    tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
+                    tickFormatter={(value) => `$${value}`}
+                    tickLine={false}
+                    type="number"
+                  />
+                  <YAxis
+                    axisLine={false}
+                    dataKey="category_name"
+                    tick={{ fill: "rgba(17,20,24,0.6)", fontSize: 12 }}
+                    tickLine={false}
+                    type="category"
+                    width={110}
+                  />
+                  <Tooltip content={<ValueTooltip />} cursor={{ fill: "rgba(220, 93, 48, 0.08)" }} />
+                  <Bar
+                    dataKey="projected_range_savings"
+                    fill="#111418"
+                    name="Projected savings"
+                    radius={[0, 10, 10, 0]}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex h-full items-center justify-center rounded-[1.4rem] border border-dashed border-black/10 bg-stone/50 px-6 text-center text-sm leading-6 text-black/58">
+                Savings projections need at least one active subscription in the workspace.
+              </div>
+            )}
+          </div>
+
+          <div className="mt-5 space-y-3">
+            {savingsChartData.map((category) => (
+              <div className="rounded-[1.3rem] border border-black/10 bg-stone/60 p-4" key={category.category_name}>
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-semibold text-ink">{category.category_name}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.24em] text-black/42">
+                      {category.active_subscriptions} active subscriptions
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <CurrencyDisplay
+                      className="block text-xl font-semibold tracking-tight text-ink"
+                      currency="USD"
+                      value={category.projected_range_savings}
+                    />
+                    <p className="mt-1 text-xs text-black/52">
+                      {formatCurrency({ value: category.projected_monthly_savings })} per month
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="rounded-[1.7rem] border border-black/10 bg-[#101922] p-5 text-white">
+        <div className="flex items-center gap-3">
+          <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-white/10 bg-white/10 text-white">
+            <Clock3 className="size-5" />
+          </span>
+          <div>
+            <p className="text-xs uppercase tracking-[0.28em] text-white/42">Frequency distribution</p>
+            <h3 className="mt-1 text-xl font-semibold text-white">Recurring cadence pressure</h3>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          {(analytics?.frequency_distribution ?? []).map((item) => (
+            <div
+              className={cn(
+                "rounded-[1.35rem] border border-white/10 bg-white/6 p-4",
+                item.subscription_count === 0 ? "text-white/40" : "text-white",
+              )}
+              key={item.cadence}
+            >
+              <p className="text-xs uppercase tracking-[0.24em] text-white/42">{item.label}</p>
+              <p className="mt-3 text-3xl font-semibold tracking-tight">{item.subscription_count}</p>
+              <p className="mt-2 text-sm text-white/64">
+                {formatCurrency({ value: Number(item.monthly_equivalent) })} in monthly-equivalent spend
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-5 text-sm text-white/58">
+          Window:{" "}
+          {analytics
+            ? `${formatDate(analytics.window.start_date)} to ${formatDate(analytics.window.end_date)}`
+            : "Loading analytics window"}
+        </p>
+      </section>
+
+      {isLoading ? (
+        <div className="rounded-[1.6rem] border border-dashed border-black/10 bg-stone/60 px-5 py-4 text-sm text-black/58">
+          Refreshing analytics for the selected date range...
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/hooks/use-expense-reports.ts
+++ b/frontend/src/hooks/use-expense-reports.ts
@@ -4,8 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useAuth } from "@/hooks/use-auth";
 import { apiClient } from "@/lib/api-client";
+import type { AnalyticsRangeKey } from "@/types";
 
 const expenseReportKeys = {
+  analytics: (range: AnalyticsRangeKey) => ["expense-reports", "analytics", range] as const,
   detail: (reportId: number) => ["expense-reports", "detail", reportId] as const,
   list: ["expense-reports", "list"] as const,
 };
@@ -18,6 +20,18 @@ export function useExpenseReports() {
     queryFn: () => apiClient.getExpenseReports(accessToken!),
     placeholderData: (previousData) => previousData,
     queryKey: expenseReportKeys.list,
+    staleTime: 30_000,
+  });
+}
+
+export function useExpenseAnalytics(range: AnalyticsRangeKey) {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken),
+    queryFn: () => apiClient.getExpenseAnalytics(accessToken!, range),
+    placeholderData: (previousData) => previousData,
+    queryKey: expenseReportKeys.analytics(range),
     staleTime: 30_000,
   });
 }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from "@/lib/constants";
 import type {
+  AnalyticsRangeKey,
   AuthResponse,
   Category,
   CategoryInput,
@@ -7,6 +8,7 @@ import type {
   DashboardLayout,
   DashboardLayoutPayload,
   DashboardSummary,
+  ExpenseAnalytics,
   ExpenseReport,
   ExpenseReportListResponse,
   HealthResponse,
@@ -238,6 +240,12 @@ export const apiClient = {
   },
   getExpenseReports(token: string) {
     return request<ExpenseReportListResponse>("/expense-reports", undefined, { token });
+  },
+  getExpenseAnalytics(token: string, range: AnalyticsRangeKey) {
+    return request<ExpenseAnalytics>("/expense-reports/analytics", undefined, {
+      query: { range },
+      token,
+    });
   },
   getExpenseReport(token: string, reportId: number) {
     return request<ExpenseReport>(`/expense-reports/${reportId}`, undefined, { token });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -204,6 +204,69 @@ export type ExpenseReportListResponse = {
   total: number;
 };
 
+export type AnalyticsRangeKey = "90d" | "180d" | "365d";
+
+export type AnalyticsWindow = {
+  key: AnalyticsRangeKey;
+  label: string;
+  start_date: string;
+  end_date: string;
+};
+
+export type AnalyticsSummary = {
+  total_spend: string;
+  average_monthly_spend: string;
+  active_subscriptions: number;
+  projected_monthly_savings: string;
+  projected_range_savings: string;
+};
+
+export type AnalyticsCategoryItem = {
+  category_id: number | null;
+  category_name: string;
+  total_spend: string;
+  active_subscriptions: number;
+  projected_monthly_savings: string;
+  projected_range_savings: string;
+};
+
+export type AnalyticsPaymentMethodItem = {
+  payment_method_id: number | null;
+  payment_method_label: string;
+  provider: string | null;
+  total_spend: string;
+  active_subscriptions: number;
+};
+
+export type AnalyticsFrequencyItem = {
+  cadence: string;
+  label: string;
+  subscription_count: number;
+  monthly_equivalent: string;
+};
+
+export type AnalyticsTrendCategoryItem = {
+  category_name: string;
+  total_spend: string;
+};
+
+export type AnalyticsTrendPoint = {
+  period_start: string;
+  label: string;
+  total_spend: string;
+  category_totals: AnalyticsTrendCategoryItem[];
+};
+
+export type ExpenseAnalytics = {
+  window: AnalyticsWindow;
+  summary: AnalyticsSummary;
+  categories: AnalyticsCategoryItem[];
+  payment_methods: AnalyticsPaymentMethodItem[];
+  frequency_distribution: AnalyticsFrequencyItem[];
+  trends: AnalyticsTrendPoint[];
+  trend_categories: string[];
+};
+
 export type UploadSourceType = "upload_csv" | "upload_pdf";
 export type UploadStatus = "queued" | "processing" | "completed" | "failed";
 

--- a/frontend/tests/unit/components/report-analytics.test.tsx
+++ b/frontend/tests/unit/components/report-analytics.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReportAnalytics } from "@/components/reports/report-analytics";
+import type { ExpenseAnalytics } from "@/types";
+
+const analytics: ExpenseAnalytics = {
+  categories: [
+    {
+      active_subscriptions: 1,
+      category_id: 1,
+      category_name: "Utilities",
+      projected_monthly_savings: "30.00",
+      projected_range_savings: "180.00",
+      total_spend: "90.00",
+    },
+    {
+      active_subscriptions: 2,
+      category_id: 2,
+      category_name: "Entertainment",
+      projected_monthly_savings: "25.00",
+      projected_range_savings: "150.00",
+      total_spend: "40.00",
+    },
+  ],
+  frequency_distribution: [
+    {
+      cadence: "monthly",
+      label: "Monthly cadence",
+      monthly_equivalent: "25.00",
+      subscription_count: 2,
+    },
+    {
+      cadence: "quarterly",
+      label: "Quarterly cadence",
+      monthly_equivalent: "30.00",
+      subscription_count: 1,
+    },
+  ],
+  payment_methods: [
+    {
+      active_subscriptions: 2,
+      payment_method_id: 11,
+      payment_method_label: "Visa Primary card ending 4242",
+      provider: "Visa",
+      total_spend: "150.00",
+    },
+    {
+      active_subscriptions: 2,
+      payment_method_id: 12,
+      payment_method_label: "Amex Backup card ending 3005",
+      provider: "Amex",
+      total_spend: "100.00",
+    },
+  ],
+  summary: {
+    active_subscriptions: 4,
+    average_monthly_spend: "41.67",
+    projected_monthly_savings: "65.00",
+    projected_range_savings: "390.00",
+    total_spend: "250.00",
+  },
+  trend_categories: ["Utilities", "Entertainment"],
+  trends: [
+    {
+      category_totals: [
+        { category_name: "Utilities", total_spend: "90.00" },
+        { category_name: "Entertainment", total_spend: "15.00" },
+      ],
+      label: "Mar",
+      period_start: "2026-03-01",
+      total_spend: "105.00",
+    },
+    {
+      category_totals: [
+        { category_name: "Utilities", total_spend: "0.00" },
+        { category_name: "Entertainment", total_spend: "25.00" },
+      ],
+      label: "Apr",
+      period_start: "2026-04-01",
+      total_spend: "25.00",
+    },
+  ],
+  window: {
+    end_date: "2026-04-19",
+    key: "180d",
+    label: "Last 180 days",
+    start_date: "2025-10-22",
+  },
+};
+
+describe("ReportAnalytics", () => {
+  it("renders the analytics workspace with mock chart data", () => {
+    render(
+      <div style={{ width: 1280 }}>
+        <ReportAnalytics
+          analytics={analytics}
+          isLoading={false}
+          onRangeChange={vi.fn()}
+          selectedRange="180d"
+        />
+      </div>,
+    );
+
+    expect(screen.getByRole("heading", { level: 2, name: "Category analytics" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Spend by category over time" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Overall spend trend" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Payment method mix" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "Potential savings" })).toBeInTheDocument();
+    expect(screen.getByText("Visa Primary card ending 4242")).toBeInTheDocument();
+    expect(screen.getByText("Utilities")).toBeInTheDocument();
+    expect(screen.getByText("Monthly cadence")).toBeInTheDocument();
+  });
+
+  it("changes the selected range when a new window is requested", () => {
+    const onRangeChange = vi.fn();
+
+    render(
+      <div style={{ width: 1280 }}>
+        <ReportAnalytics
+          analytics={analytics}
+          isLoading={false}
+          onRangeChange={onRangeChange}
+          selectedRange="180d"
+        />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Last 365 days" }));
+    expect(onRangeChange).toHaveBeenCalledWith("365d");
+  });
+});


### PR DESCRIPTION
# Day 18 Complete — `category-analytics`

## Branch & Commit

- **Branch:** `day-18/category-analytics`
- **Remote:** `origin/day-18/category-analytics`
- **Commit:** `eb4a723`

---

## What Shipped

### Backend
- New range-aware `/expense-reports/analytics` aggregate endpoint exposing:
  - Category data
  - Payment-method data
  - Cadence data
  - Trend data
  - Savings data

### Frontend
- `/reports` now includes the new **analytics workspace**
- Existing uploaded-report detail view is preserved

---

## Checks Passed

| Tool | Command |
|------|---------|
| Lockfile guard | `lockfile-guard` |
| Python tests | `backend/.venv/bin/pytest backend/tests` |
| Linting (Ruff) | `backend/.venv/bin/ruff check backend/src backend/tests` |
| Type checking (Mypy) | `backend/.venv/bin/mypy backend/src` |
| JS tests | `npm test` |
| JS linting | `npm run lint` |
| JS build | `npm run build` |
| JS type checking | `npm run typecheck` |

---

## GitHub Write-Back

- Closed issues: `#69`, `#70`, and umbrella `#68`
- **Milestone 18** closed — `open_issues = 0`

---

## Up Next

> **Day 19** — `day-19/calendar-view`