### PR TITLE
Day 19/calendar view

### DIFF
--- a/backend/src/api/router.py
+++ b/backend/src/api/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from src.api.routes import (
     auth,
+    calendar,
     categories,
     dashboard,
     expense_reports,
@@ -14,6 +15,7 @@ from src.api.routes import (
 api_router = APIRouter()
 api_router.include_router(health.router, tags=["health"])
 api_router.include_router(auth.router)
+api_router.include_router(calendar.router)
 api_router.include_router(categories.router)
 api_router.include_router(dashboard.router)
 api_router.include_router(expense_reports.router)

--- a/backend/src/api/routes/calendar.py
+++ b/backend/src/api/routes/calendar.py
@@ -1,0 +1,37 @@
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.database import get_db
+from src.dependencies import get_current_user
+from src.models.user import User
+from src.schemas.calendar import CalendarRenewalResponse
+from src.services.calendar import get_calendar_renewals
+
+router = APIRouter(prefix="/calendar", tags=["calendar"])
+DbSession = Annotated[AsyncSession, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+@router.get(
+    "",
+    response_model=CalendarRenewalResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get calendar renewals",
+    description="Return projected subscription renewal dates for the authenticated user.",
+)
+async def get_calendar_renewals_route(
+    session: DbSession,
+    current_user: CurrentUser,
+    year: int | None = Query(default=None, ge=2000, le=2100),
+    month: int | None = Query(default=None, ge=1, le=12),
+) -> CalendarRenewalResponse:
+    today = datetime.now(UTC).date()
+    return await get_calendar_renewals(
+        session,
+        user=current_user,
+        year=year or today.year,
+        month=month or today.month,
+    )

--- a/backend/src/schemas/calendar.py
+++ b/backend/src/schemas/calendar.py
@@ -1,0 +1,35 @@
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class CalendarRenewalItem(BaseModel):
+    subscription_id: int
+    name: str
+    vendor: str
+    amount: Decimal
+    currency: str
+    cadence: str
+    status: str
+    renewal_date: date
+    category_id: int | None
+    category_name: str
+    payment_method_id: int | None
+    payment_method_label: str | None
+
+
+class CalendarDay(BaseModel):
+    date: date
+    day: int
+    total_amount: Decimal
+    renewals: list[CalendarRenewalItem]
+
+
+class CalendarRenewalResponse(BaseModel):
+    year: int
+    month: int
+    period_start: date
+    period_end: date
+    total_renewals: int
+    days: list[CalendarDay]

--- a/backend/src/services/calendar.py
+++ b/backend/src/services/calendar.py
@@ -1,0 +1,222 @@
+from datetime import date, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.logging import get_logger
+from src.models.category import Category
+from src.models.payment_method import PaymentMethod
+from src.models.subscription import Subscription
+from src.models.user import User
+from src.schemas.calendar import CalendarDay, CalendarRenewalItem, CalendarRenewalResponse
+
+logger = get_logger(__name__)
+
+
+def _quantize_money(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _last_day_of_month(year: int, month: int) -> int:
+    next_month = date(year + (1 if month == 12 else 0), 1 if month == 12 else month + 1, 1)
+    return (next_month - timedelta(days=1)).day
+
+
+def _shift_months(value: date, offset: int) -> date:
+    month_index = (value.year * 12 + value.month - 1) + offset
+    year = month_index // 12
+    month = month_index % 12 + 1
+    day = min(value.day, _last_day_of_month(year, month))
+    return date(year, month, day)
+
+
+def _next_for_cadence(value: date, cadence: str) -> date:
+    normalized = cadence.lower()
+    if normalized == "weekly":
+        return value + timedelta(days=7)
+    if normalized == "quarterly":
+        return _shift_months(value, 3)
+    if normalized == "yearly":
+        return _shift_months(value, 12)
+    return _shift_months(value, 1)
+
+
+def _renewal_dates_for_period(
+    subscription: Subscription,
+    *,
+    period_start: date,
+    period_end: date,
+) -> list[date]:
+    if (
+        subscription.next_charge_date is None
+        or subscription.status != "active"
+        or not subscription.auto_renew
+    ):
+        return []
+
+    lower_bound = max(period_start, subscription.start_date)
+    upper_bound = period_end
+    if subscription.end_date is not None:
+        upper_bound = min(upper_bound, subscription.end_date)
+    if lower_bound > upper_bound or subscription.next_charge_date > upper_bound:
+        return []
+
+    cursor = subscription.next_charge_date
+    while cursor < lower_bound:
+        next_cursor = _next_for_cadence(cursor, subscription.cadence)
+        if next_cursor <= cursor:
+            return []
+        cursor = next_cursor
+
+    renewal_dates: list[date] = []
+    while cursor <= upper_bound:
+        renewal_dates.append(cursor)
+        next_cursor = _next_for_cadence(cursor, subscription.cadence)
+        if next_cursor <= cursor:
+            break
+        cursor = next_cursor
+
+    return renewal_dates
+
+
+async def get_calendar_renewals(
+    session: AsyncSession,
+    *,
+    user: User,
+    year: int,
+    month: int,
+) -> CalendarRenewalResponse:
+    period_start = date(year, month, 1)
+    period_end = date(year, month, _last_day_of_month(year, month))
+
+    subscriptions = list(
+        (
+            await session.scalars(
+                select(Subscription)
+                .where(
+                    Subscription.user_id == user.id,
+                    Subscription.status == "active",
+                    Subscription.auto_renew.is_(True),
+                    Subscription.next_charge_date.is_not(None),
+                )
+                .order_by(Subscription.next_charge_date.asc(), Subscription.id.asc())
+            )
+        ).all()
+    )
+
+    category_ids = sorted(
+        {
+            subscription.category_id
+            for subscription in subscriptions
+            if subscription.category_id is not None
+        }
+    )
+    payment_method_ids = sorted(
+        {
+            subscription.payment_method_id
+            for subscription in subscriptions
+            if subscription.payment_method_id is not None
+        }
+    )
+
+    categories = (
+        list(
+            (
+                await session.scalars(
+                    select(Category).where(
+                        Category.user_id == user.id,
+                        Category.id.in_(category_ids),
+                    )
+                )
+            ).all()
+        )
+        if category_ids
+        else []
+    )
+    payment_methods = (
+        list(
+            (
+                await session.scalars(
+                    select(PaymentMethod).where(
+                        PaymentMethod.user_id == user.id,
+                        PaymentMethod.id.in_(payment_method_ids),
+                    )
+                )
+            ).all()
+        )
+        if payment_method_ids
+        else []
+    )
+    category_map = {category.id: category.name for category in categories}
+    payment_method_map = {
+        payment_method.id: payment_method.label for payment_method in payment_methods
+    }
+
+    items_by_date: dict[date, list[CalendarRenewalItem]] = {
+        period_start + timedelta(days=offset): []
+        for offset in range((period_end - period_start).days + 1)
+    }
+
+    for subscription in subscriptions:
+        for renewal_date in _renewal_dates_for_period(
+            subscription,
+            period_start=period_start,
+            period_end=period_end,
+        ):
+            category_name = (
+                category_map.get(subscription.category_id)
+                if subscription.category_id is not None
+                else "Uncategorized"
+            ) or "Uncategorized"
+            items_by_date[renewal_date].append(
+                CalendarRenewalItem(
+                    subscription_id=subscription.id,
+                    name=subscription.name,
+                    vendor=subscription.vendor,
+                    amount=_quantize_money(Decimal(subscription.amount)),
+                    currency=subscription.currency,
+                    cadence=subscription.cadence,
+                    status=subscription.status,
+                    renewal_date=renewal_date,
+                    category_id=subscription.category_id,
+                    category_name=category_name,
+                    payment_method_id=subscription.payment_method_id,
+                    payment_method_label=(
+                        payment_method_map.get(subscription.payment_method_id)
+                        if subscription.payment_method_id is not None
+                        else None
+                    ),
+                )
+            )
+
+    days = [
+        CalendarDay(
+            date=day,
+            day=day.day,
+            total_amount=_quantize_money(
+                sum((Decimal(item.amount) for item in renewals), Decimal("0.00"))
+            ),
+            renewals=sorted(
+                renewals,
+                key=lambda item: (item.name.lower(), item.subscription_id),
+            ),
+        )
+        for day, renewals in sorted(items_by_date.items())
+    ]
+    total_renewals = sum(len(day.renewals) for day in days)
+    logger.info(
+        "calendar.renewals_listed",
+        user_id=user.id,
+        year=year,
+        month=month,
+        total_renewals=total_renewals,
+    )
+    return CalendarRenewalResponse(
+        year=year,
+        month=month,
+        period_start=period_start,
+        period_end=period_end,
+        total_renewals=total_renewals,
+        days=days,
+    )

--- a/backend/tests/api/test_calendar.py
+++ b/backend/tests/api/test_calendar.py
@@ -1,0 +1,195 @@
+from datetime import date
+
+
+def _auth_headers(client, email: str) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": email,
+            "full_name": "Calendar Owner",
+            "password": "super-secret",
+        },
+    )
+    assert response.status_code == 201
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_category(client, headers: dict[str, str], name: str = "Streaming") -> int:
+    response = client.post(
+        "/api/v1/categories",
+        headers=headers,
+        json={"name": name, "description": f"{name} renewals"},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _create_payment_method(client, headers: dict[str, str], label: str = "Primary Card") -> int:
+    response = client.post(
+        "/api/v1/payment-methods",
+        headers=headers,
+        json={"label": label, "provider": "Visa", "last4": "4242", "is_default": True},
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _create_subscription(
+    client,
+    headers: dict[str, str],
+    *,
+    name: str,
+    amount: str,
+    cadence: str,
+    next_charge_date: str,
+    category_id: int | None = None,
+    payment_method_id: int | None = None,
+    status: str = "active",
+    auto_renew: bool = True,
+) -> int:
+    response = client.post(
+        "/api/v1/subscriptions",
+        headers=headers,
+        json={
+            "name": name,
+            "vendor": name,
+            "amount": amount,
+            "currency": "USD",
+            "cadence": cadence,
+            "status": status,
+            "start_date": "2026-01-01",
+            "next_charge_date": next_charge_date,
+            "category_id": category_id,
+            "payment_method_id": payment_method_id,
+            "auto_renew": auto_renew,
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def test_calendar_lists_projected_monthly_and_weekly_renewals(client) -> None:
+    owner_headers = _auth_headers(client, "calendar-owner@example.com")
+    other_headers = _auth_headers(client, "calendar-other@example.com")
+    category_id = _create_category(client, owner_headers, "Entertainment")
+    payment_method_id = _create_payment_method(client, owner_headers)
+
+    monthly_id = _create_subscription(
+        client,
+        owner_headers,
+        name="Netflix",
+        amount="15.00",
+        cadence="monthly",
+        next_charge_date="2026-04-12",
+        category_id=category_id,
+        payment_method_id=payment_method_id,
+    )
+    weekly_id = _create_subscription(
+        client,
+        owner_headers,
+        name="Meal Box",
+        amount="5.00",
+        cadence="weekly",
+        next_charge_date="2026-04-03",
+        category_id=category_id,
+    )
+    quarterly_id = _create_subscription(
+        client,
+        owner_headers,
+        name="Quarterly Tool",
+        amount="30.00",
+        cadence="quarterly",
+        next_charge_date="2026-05-28",
+    )
+    _create_subscription(
+        client,
+        owner_headers,
+        name="Paused Plan",
+        amount="12.00",
+        cadence="monthly",
+        next_charge_date="2026-05-10",
+        status="paused",
+    )
+    _create_subscription(
+        client,
+        owner_headers,
+        name="Manual Plan",
+        amount="12.00",
+        cadence="monthly",
+        next_charge_date="2026-05-20",
+        auto_renew=False,
+    )
+    _create_subscription(
+        client,
+        other_headers,
+        name="Other Account",
+        amount="99.00",
+        cadence="monthly",
+        next_charge_date="2026-05-12",
+    )
+
+    response = client.get(
+        "/api/v1/calendar",
+        headers=owner_headers,
+        params={"year": 2026, "month": 5},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["year"] == 2026
+    assert payload["month"] == 5
+    assert payload["period_start"] == "2026-05-01"
+    assert payload["period_end"] == "2026-05-31"
+    assert payload["total_renewals"] == 7
+    assert len(payload["days"]) == 31
+
+    renewals_by_date = {
+        day["date"]: day
+        for day in payload["days"]
+        if day["renewals"]
+    }
+    assert sorted(renewals_by_date) == [
+        "2026-05-01",
+        "2026-05-08",
+        "2026-05-12",
+        "2026-05-15",
+        "2026-05-22",
+        "2026-05-28",
+        "2026-05-29",
+    ]
+    assert renewals_by_date["2026-05-12"]["total_amount"] == "15.00"
+    assert renewals_by_date["2026-05-12"]["renewals"][0] == {
+        "subscription_id": monthly_id,
+        "name": "Netflix",
+        "vendor": "Netflix",
+        "amount": "15.00",
+        "currency": "USD",
+        "cadence": "monthly",
+        "status": "active",
+        "renewal_date": "2026-05-12",
+        "category_id": category_id,
+        "category_name": "Entertainment",
+        "payment_method_id": payment_method_id,
+        "payment_method_label": "Primary Card",
+    }
+    assert renewals_by_date["2026-05-01"]["renewals"][0]["subscription_id"] == weekly_id
+    assert renewals_by_date["2026-05-28"]["renewals"][0]["subscription_id"] == quarterly_id
+
+
+def test_calendar_defaults_to_current_month_and_validates_query(client) -> None:
+    headers = _auth_headers(client, "calendar-default@example.com")
+    today = date.today()
+
+    response = client.get("/api/v1/calendar", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["year"] == today.year
+    assert response.json()["month"] == today.month
+
+    invalid_response = client.get(
+        "/api/v1/calendar",
+        headers=headers,
+        params={"year": 2026, "month": 13},
+    )
+    assert invalid_response.status_code == 422

--- a/frontend/src/app/(app)/calendar/page.tsx
+++ b/frontend/src/app/(app)/calendar/page.tsx
@@ -1,37 +1,45 @@
+"use client";
+
 import Link from "next/link";
-import { ArrowRight, CalendarDays } from "lucide-react";
+import { useState } from "react";
+import { ArrowRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { EmptyState } from "@/components/ui/empty-state";
+import { CalendarWorkspace } from "@/components/calendar/calendar-workspace";
 import { PageHeader } from "@/components/ui/page-header";
+import { useCalendarRenewals } from "@/hooks/use-calendar";
 
 export default function CalendarPage() {
+  const [selectedMonth, setSelectedMonth] = useState(() => {
+    const today = new Date();
+    return new Date(today.getFullYear(), today.getMonth(), 1);
+  });
+  const calendarQuery = useCalendarRenewals(
+    selectedMonth.getFullYear(),
+    selectedMonth.getMonth() + 1,
+  );
+
   return (
-    <div className="space-y-8">
+    <div className="space-y-8 animate-page-enter">
       <PageHeader
         action={
           <Button asChild className="rounded-full px-5" variant="outline">
-            <Link href="/dashboard">
-              View the renewal queue
+            <Link href="/subscriptions">
+              Manage schedules
               <ArrowRight className="ml-2 size-4" />
             </Link>
           </Button>
         }
-        description="The shell now supports a dedicated scheduling surface so reminder and renewal views can land without navigation churn."
-        eyebrow="Calendar"
-        title="Renewal timing gets its own lane"
+        description="Review projected renewal dates across active plans, move month to month, and open the day detail when a billing cluster needs attention."
+        eyebrow="Day 19 calendar"
+        title="Renewal calendar"
       />
 
-      <EmptyState
-        action={
-          <Button asChild className="rounded-full px-5" variant="outline">
-            <Link href="/subscriptions">Review upcoming renewals in subscriptions</Link>
-          </Button>
-        }
-        description="Calendar grids, reminder windows, and cross-household renewal planning are future work. Day 4 only establishes the operator shell that will contain them."
-        eyebrow="Future reminder work"
-        icon={<CalendarDays className="size-5" />}
-        title="No timeline widgets yet."
+      <CalendarWorkspace
+        calendar={calendarQuery.data}
+        isLoading={calendarQuery.isLoading && !calendarQuery.data}
+        onMonthChange={setSelectedMonth}
+        selectedMonth={selectedMonth}
       />
     </div>
   );

--- a/frontend/src/components/calendar/calendar-workspace.tsx
+++ b/frontend/src/components/calendar/calendar-workspace.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState, useTransition } from "react";
+import {
+  ArrowRight,
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  Clock3,
+  CreditCard,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { formatCurrency } from "@/components/ui/currency-display";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { CalendarDay, CalendarRenewalItem, CalendarRenewalResponse } from "@/types";
+
+type CalendarWorkspaceProps = {
+  calendar?: CalendarRenewalResponse;
+  isLoading?: boolean;
+  onMonthChange: (nextMonth: Date) => void;
+  selectedMonth: Date;
+};
+
+type MonthCell = {
+  currentMonth: boolean;
+  date: string;
+  day: number;
+  renewals: CalendarRenewalItem[];
+  totalAmount: string;
+};
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function toDate(value: string) {
+  return new Date(`${value}T00:00:00`);
+}
+
+function toIsoDate(value: Date) {
+  const year = value.getFullYear();
+  const month = `${value.getMonth() + 1}`.padStart(2, "0");
+  const day = `${value.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function formatDate(value: string, options: Intl.DateTimeFormatOptions) {
+  return new Intl.DateTimeFormat("en-US", options).format(toDate(value));
+}
+
+function shiftMonth(value: Date, offset: number) {
+  return new Date(value.getFullYear(), value.getMonth() + offset, 1);
+}
+
+function getMonthLabel(value: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    year: "numeric",
+  }).format(value);
+}
+
+function buildMonthCells(calendar: CalendarRenewalResponse | undefined, selectedMonth: Date) {
+  const dayMap = new Map<string, CalendarDay>(
+    (calendar?.days ?? []).map((day) => [day.date, day]),
+  );
+  const monthStart = new Date(selectedMonth.getFullYear(), selectedMonth.getMonth(), 1);
+  const gridStart = new Date(monthStart);
+  gridStart.setDate(monthStart.getDate() - monthStart.getDay());
+
+  return Array.from({ length: 42 }, (_, index): MonthCell => {
+    const date = new Date(gridStart);
+    date.setDate(gridStart.getDate() + index);
+    const isoDate = toIsoDate(date);
+    const calendarDay = dayMap.get(isoDate);
+
+    return {
+      currentMonth: date.getMonth() === selectedMonth.getMonth(),
+      date: isoDate,
+      day: date.getDate(),
+      renewals: calendarDay?.renewals ?? [],
+      totalAmount: calendarDay?.total_amount ?? "0.00",
+    };
+  });
+}
+
+function getInitialSelectedDate(calendar: CalendarRenewalResponse | undefined, selectedMonth: Date) {
+  const today = new Date();
+  if (
+    today.getFullYear() === selectedMonth.getFullYear()
+    && today.getMonth() === selectedMonth.getMonth()
+  ) {
+    return toIsoDate(today);
+  }
+
+  return calendar?.days.find((day) => day.renewals.length > 0)?.date ?? toIsoDate(selectedMonth);
+}
+
+function getRenewalStatusLabel(renewalCount: number) {
+  if (renewalCount === 0) {
+    return "No renewals";
+  }
+
+  return `${renewalCount} renewal${renewalCount === 1 ? "" : "s"}`;
+}
+
+function RenewalList({ renewals }: { renewals: CalendarRenewalItem[] }) {
+  if (renewals.length === 0) {
+    return (
+      <p className="rounded-[1.2rem] border border-black/10 bg-stone/70 px-4 py-3 text-sm leading-6 text-black/58">
+        No scheduled renewals on this date.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {renewals.map((renewal) => (
+        <div
+          className="rounded-[1.25rem] border border-black/10 bg-white/88 p-4 shadow-line"
+          key={`${renewal.subscription_id}-${renewal.renewal_date}`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p className="truncate text-base font-semibold text-ink">{renewal.name}</p>
+              <p className="mt-1 text-sm text-black/58">
+                {renewal.category_name} - {renewal.cadence}
+              </p>
+            </div>
+            <p className="shrink-0 text-sm font-semibold text-ink">
+              {formatCurrency({
+                currency: renewal.currency,
+                value: Number(renewal.amount),
+              })}
+            </p>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2 text-xs text-black/56">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-black/10 bg-stone/65 px-3 py-1.5">
+              <Clock3 className="size-3.5" />
+              {formatDate(renewal.renewal_date, { day: "numeric", month: "short" })}
+            </span>
+            {renewal.payment_method_label ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-black/10 bg-stone/65 px-3 py-1.5">
+                <CreditCard className="size-3.5" />
+                {renewal.payment_method_label}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function CalendarWorkspace({
+  calendar,
+  isLoading = false,
+  onMonthChange,
+  selectedMonth,
+}: CalendarWorkspaceProps) {
+  const [selectedDate, setSelectedDate] = useState(() =>
+    getInitialSelectedDate(calendar, selectedMonth),
+  );
+  const [isPending, startTransition] = useTransition();
+  const monthCells = useMemo(
+    () => buildMonthCells(calendar, selectedMonth),
+    [calendar, selectedMonth],
+  );
+  const selectedCell =
+    monthCells.find((cell) => cell.date === selectedDate && cell.currentMonth)
+    ?? monthCells.find((cell) => cell.currentMonth)
+    ?? monthCells[0];
+  const monthLabel = getMonthLabel(selectedMonth);
+  const selectedDayLabel = formatDate(selectedCell.date, {
+    day: "numeric",
+    month: "long",
+    weekday: "long",
+    year: "numeric",
+  });
+
+  useEffect(() => {
+    setSelectedDate(getInitialSelectedDate(calendar, selectedMonth));
+  }, [calendar, selectedMonth]);
+
+  const handleMonthChange = (offset: number) => {
+    startTransition(() => {
+      onMonthChange(shiftMonth(selectedMonth, offset));
+    });
+  };
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.85fr)]">
+      <section className="rounded-[2rem] border border-black/10 bg-white/76 p-4 shadow-line backdrop-blur sm:p-6">
+        <div className="flex flex-col gap-4 border-b border-black/10 pb-5 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.32em] text-black/42">Renewal calendar</p>
+            <h2 className="mt-2 text-3xl font-semibold tracking-tight text-ink">{monthLabel}</h2>
+            <p className="mt-2 text-sm leading-6 text-black/62">
+              {calendar?.total_renewals ?? 0} projected renewal
+              {(calendar?.total_renewals ?? 0) === 1 ? "" : "s"} in this month.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              aria-label="Previous month"
+              className="size-11 rounded-full p-0"
+              onClick={() => handleMonthChange(-1)}
+              type="button"
+              variant="outline"
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <Button
+              aria-label="Next month"
+              className="size-11 rounded-full p-0"
+              onClick={() => handleMonthChange(1)}
+              type="button"
+              variant="outline"
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-5 grid grid-cols-7 gap-2 text-center text-xs uppercase tracking-[0.24em] text-black/38">
+          {WEEKDAY_LABELS.map((label) => (
+            <span key={label}>{label}</span>
+          ))}
+        </div>
+
+        <div className="mt-3 grid grid-cols-7 gap-2">
+          {monthCells.map((cell) => {
+            const isSelected = cell.date === selectedCell.date;
+            const hasRenewals = cell.renewals.length > 0;
+
+            return (
+              <div className="relative min-w-0" key={cell.date}>
+                <button
+                  aria-label={`${formatDate(cell.date, {
+                    day: "numeric",
+                    month: "long",
+                  })}: ${getRenewalStatusLabel(cell.renewals.length)}`}
+                  aria-pressed={isSelected}
+                  className={cn(
+                    "flex aspect-square w-full min-w-0 flex-col justify-between rounded-[1.15rem] border p-2 text-left transition sm:p-3",
+                    cell.currentMonth
+                      ? "border-black/10 bg-stone/65 text-ink hover:border-black/20 hover:bg-white"
+                      : "border-transparent bg-transparent text-black/24",
+                    isSelected ? "border-[#101922] bg-white shadow-line" : "",
+                  )}
+                  onClick={() => setSelectedDate(cell.date)}
+                  type="button"
+                >
+                  <span className="text-sm font-semibold">{cell.day}</span>
+                  <span className="flex h-5 items-end gap-1 overflow-hidden">
+                    {cell.renewals.slice(0, 3).map((renewal) => (
+                      <span
+                        aria-hidden="true"
+                        className="size-2 rounded-full bg-ember"
+                        key={`${cell.date}-${renewal.subscription_id}`}
+                      />
+                    ))}
+                    {cell.renewals.length > 3 ? (
+                      <span className="text-[10px] font-semibold text-black/50">
+                        +{cell.renewals.length - 3}
+                      </span>
+                    ) : null}
+                  </span>
+                </button>
+
+                {isSelected && hasRenewals ? (
+                  <div
+                    aria-label={`Renewals for ${selectedDayLabel}`}
+                    className="absolute left-1/2 top-[calc(100%+0.5rem)] z-20 hidden w-72 -translate-x-1/2 rounded-[1.35rem] border border-black/10 bg-white/96 p-4 text-left shadow-line backdrop-blur lg:block"
+                    role="dialog"
+                  >
+                    <p className="text-xs uppercase tracking-[0.26em] text-black/42">
+                      {formatDate(cell.date, { day: "numeric", month: "short" })}
+                    </p>
+                    <div className="mt-3 space-y-2">
+                      {cell.renewals.slice(0, 3).map((renewal) => (
+                        <div className="flex items-center justify-between gap-3" key={renewal.subscription_id}>
+                          <span className="truncate text-sm font-medium text-ink">
+                            {renewal.name}
+                          </span>
+                          <span className="text-xs font-semibold text-black/58">
+                            {formatCurrency({
+                              currency: renewal.currency,
+                              value: Number(renewal.amount),
+                            })}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+
+        {isLoading || isPending ? (
+          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+            <Skeleton className="h-12 w-full rounded-2xl" />
+            <Skeleton className="h-12 w-full rounded-2xl" />
+            <Skeleton className="h-12 w-full rounded-2xl" />
+          </div>
+        ) : null}
+      </section>
+
+      <aside className="space-y-4">
+        <section className="rounded-[2rem] border border-black/10 bg-[#101922] p-6 text-white shadow-line">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/42">Selected day</p>
+              <h2 className="mt-3 text-2xl font-semibold tracking-tight">{selectedDayLabel}</h2>
+            </div>
+            <span className="inline-flex size-12 items-center justify-center rounded-[1rem] bg-white/10">
+              <CalendarDays className="size-5" />
+            </span>
+          </div>
+
+          <div className="mt-6 grid grid-cols-2 gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.24em] text-white/38">Renewals</p>
+              <p className="mt-2 text-3xl font-semibold">{selectedCell.renewals.length}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.24em] text-white/38">Total</p>
+              <p className="mt-2 text-3xl font-semibold">
+                {formatCurrency({
+                  value: Number(selectedCell.totalAmount),
+                })}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {calendar && calendar.total_renewals === 0 && !isLoading ? (
+          <EmptyState
+            action={
+              <Button asChild className="rounded-full px-5" variant="outline">
+                <Link href="/subscriptions">
+                  Add renewal dates
+                  <ArrowRight className="ml-2 size-4" />
+                </Link>
+              </Button>
+            }
+            description="Active subscriptions with auto-renewal and next charge dates will appear in the calendar."
+            icon={<CalendarDays className="size-5" />}
+            title="No renewals scheduled this month"
+          />
+        ) : (
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-5 shadow-line backdrop-blur">
+            <div className="mb-4 flex items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.3em] text-black/42">Day detail</p>
+                <h3 className="mt-1 text-xl font-semibold text-ink">
+                  {getRenewalStatusLabel(selectedCell.renewals.length)}
+                </h3>
+              </div>
+            </div>
+            <RenewalList renewals={selectedCell.renewals} />
+          </section>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/hooks/use-calendar.ts
+++ b/frontend/src/hooks/use-calendar.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { useAuth } from "@/hooks/use-auth";
+import { apiClient } from "@/lib/api-client";
+
+const calendarKeys = {
+  month: (year: number, month: number) => ["calendar", year, month] as const,
+};
+
+export function useCalendarRenewals(year: number, month: number) {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken),
+    queryFn: () => apiClient.getCalendarRenewals(accessToken!, year, month),
+    placeholderData: (previousData) => previousData,
+    queryKey: calendarKeys.month(year, month),
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2,6 +2,7 @@ import { API_BASE_URL } from "@/lib/constants";
 import type {
   AnalyticsRangeKey,
   AuthResponse,
+  CalendarRenewalResponse,
   Category,
   CategoryInput,
   CategoryListResponse,
@@ -294,6 +295,12 @@ export const apiClient = {
     return request<void>(`/uploads/${uploadId}`, {
       method: "DELETE",
     }, { token });
+  },
+  getCalendarRenewals(token: string, year: number, month: number) {
+    return request<CalendarRenewalResponse>("/calendar", undefined, {
+      query: { month, year },
+      token,
+    });
   },
   deleteWorkspaceData(token: string) {
     return request<void>("/auth/me/data", {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -403,3 +403,34 @@ export type SubscriptionUpsertInput = {
   vendor: string;
   website_url?: string;
 };
+
+export type CalendarRenewalItem = {
+  subscription_id: number;
+  name: string;
+  vendor: string;
+  amount: string;
+  currency: string;
+  cadence: string;
+  status: string;
+  renewal_date: string;
+  category_id: number | null;
+  category_name: string;
+  payment_method_id: number | null;
+  payment_method_label: string | null;
+};
+
+export type CalendarDay = {
+  date: string;
+  day: number;
+  total_amount: string;
+  renewals: CalendarRenewalItem[];
+};
+
+export type CalendarRenewalResponse = {
+  year: number;
+  month: number;
+  period_start: string;
+  period_end: string;
+  total_renewals: number;
+  days: CalendarDay[];
+};

--- a/frontend/tests/unit/components/calendar-workspace.test.tsx
+++ b/frontend/tests/unit/components/calendar-workspace.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CalendarWorkspace } from "@/components/calendar/calendar-workspace";
+import type { CalendarRenewalResponse } from "@/types";
+
+const calendar: CalendarRenewalResponse = {
+  days: Array.from({ length: 31 }, (_, index) => {
+    const day = index + 1;
+    const date = `2026-05-${String(day).padStart(2, "0")}`;
+
+    return {
+      date,
+      day,
+      renewals:
+        day === 12
+          ? [
+              {
+                amount: "15.00",
+                cadence: "monthly",
+                category_id: 1,
+                category_name: "Entertainment",
+                currency: "USD",
+                name: "Netflix",
+                payment_method_id: 4,
+                payment_method_label: "Primary Card",
+                renewal_date: date,
+                status: "active",
+                subscription_id: 7,
+                vendor: "Netflix",
+              },
+              {
+                amount: "9.99",
+                cadence: "monthly",
+                category_id: 2,
+                category_name: "Productivity",
+                currency: "USD",
+                name: "Dropbox",
+                payment_method_id: null,
+                payment_method_label: null,
+                renewal_date: date,
+                status: "active",
+                subscription_id: 8,
+                vendor: "Dropbox",
+              },
+            ]
+          : [],
+      total_amount: day === 12 ? "24.99" : "0.00",
+    };
+  }),
+  month: 5,
+  period_end: "2026-05-31",
+  period_start: "2026-05-01",
+  total_renewals: 2,
+  year: 2026,
+};
+
+describe("CalendarWorkspace", () => {
+  it("renders the month grid with renewal markers", () => {
+    render(
+      <CalendarWorkspace
+        calendar={calendar}
+        onMonthChange={vi.fn()}
+        selectedMonth={new Date(2026, 4, 1)}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { level: 2, name: "May 2026" })).toBeInTheDocument();
+    expect(screen.getByText("2 projected renewals in this month.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "May 12: 2 renewals" })).toBeInTheDocument();
+  });
+
+  it("shows the selected-day popover and detail list", () => {
+    render(
+      <CalendarWorkspace
+        calendar={calendar}
+        onMonthChange={vi.fn()}
+        selectedMonth={new Date(2026, 4, 1)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "May 12: 2 renewals" }));
+
+    const popover = screen.getByRole("dialog", {
+      name: "Renewals for Tuesday, May 12, 2026",
+    });
+    expect(within(popover).getByText("Netflix")).toBeInTheDocument();
+    expect(within(popover).getByText("$15.00")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 3, name: "2 renewals" })).toBeInTheDocument();
+    expect(screen.getByText("Primary Card")).toBeInTheDocument();
+  });
+
+  it("requests adjacent months from the controls", () => {
+    const onMonthChange = vi.fn();
+
+    render(
+      <CalendarWorkspace
+        calendar={calendar}
+        onMonthChange={onMonthChange}
+        selectedMonth={new Date(2026, 4, 1)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next month" }));
+    expect(onMonthChange).toHaveBeenCalledWith(new Date(2026, 5, 1));
+  });
+});


### PR DESCRIPTION
Day 19 is complete and closed.

Implemented and pushed origin/day-19/calendar-view at 0df14e8 with 11 per-file commits. Completed child issues #72 and #73, then closed umbrella issue #71 and milestone 19. The next scheduled target is Day 20 on day-20/multi-currency-support.

Verification passed: lockfile guard, backend pytest/ruff/mypy, frontend tests/lint/build/typecheck. Repo is clean apart from expected untracked backend/.venv and frontend/node_modules.