### PR TITLE
Day 20/multi currency support

### DIFF
--- a/backend/alembic/versions/20260421_0007_user_preferred_currency.py
+++ b/backend/alembic/versions/20260421_0007_user_preferred_currency.py
@@ -1,0 +1,27 @@
+"""Add user preferred currency."""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260421_0007"
+down_revision = "20260417_0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "preferred_currency",
+                sa.String(length=3),
+                nullable=False,
+                server_default="USD",
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("preferred_currency")

--- a/backend/src/api/router.py
+++ b/backend/src/api/router.py
@@ -4,6 +4,7 @@ from src.api.routes import (
     auth,
     calendar,
     categories,
+    currencies,
     dashboard,
     expense_reports,
     health,
@@ -17,6 +18,7 @@ api_router.include_router(health.router, tags=["health"])
 api_router.include_router(auth.router)
 api_router.include_router(calendar.router)
 api_router.include_router(categories.router)
+api_router.include_router(currencies.router)
 api_router.include_router(dashboard.router)
 api_router.include_router(expense_reports.router)
 api_router.include_router(payment_methods.router)

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -13,12 +13,14 @@ from src.schemas.auth import (
     RegisterRequest,
     TokenResponse,
     UserResponse,
+    UserUpdateRequest,
 )
 from src.services.auth import (
     delete_user_workspace_data,
     login_user,
     refresh_user_tokens,
     register_user,
+    update_user_profile,
 )
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -79,6 +81,21 @@ async def refresh(
 )
 async def me(current_user: CurrentUser) -> UserResponse:
     return UserResponse.model_validate(current_user)
+
+
+@router.patch(
+    "/me",
+    response_model=UserResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update the current user profile",
+)
+async def update_me(
+    payload: UserUpdateRequest,
+    session: DbSession,
+    current_user: CurrentUser,
+) -> UserResponse:
+    user = await update_user_profile(session, user=current_user, payload=payload)
+    return UserResponse.model_validate(user)
 
 
 @router.delete(

--- a/backend/src/api/routes/currencies.py
+++ b/backend/src/api/routes/currencies.py
@@ -1,0 +1,49 @@
+from datetime import date
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.database import get_db
+from src.dependencies import get_current_user
+from src.models.user import User
+from src.schemas.currency import ExchangeRateResponse, SupportedCurrencyListResponse
+from src.services.currency import (
+    SUPPORTED_CURRENCIES,
+    get_exchange_rate_response,
+)
+
+router = APIRouter(prefix="/currencies", tags=["currencies"])
+DbSession = Annotated[AsyncSession, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+@router.get(
+    "",
+    response_model=SupportedCurrencyListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List supported currencies",
+)
+async def list_supported_currencies(_: CurrentUser) -> SupportedCurrencyListResponse:
+    return SupportedCurrencyListResponse(items=list(SUPPORTED_CURRENCIES))
+
+
+@router.get(
+    "/rate",
+    response_model=ExchangeRateResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get an exchange rate",
+)
+async def get_exchange_rate_route(
+    session: DbSession,
+    _: CurrentUser,
+    base_currency: Annotated[str, Query(min_length=3, max_length=3)] = "USD",
+    quote_currency: Annotated[str, Query(min_length=3, max_length=3)] = "USD",
+    effective_date: date | None = None,
+) -> ExchangeRateResponse:
+    return await get_exchange_rate_response(
+        session,
+        base_currency=base_currency,
+        quote_currency=quote_currency,
+        effective_date=effective_date,
+    )

--- a/backend/src/jobs/__init__.py
+++ b/backend/src/jobs/__init__.py
@@ -1,4 +1,5 @@
 from src.jobs.csv_processing import process_csv_upload_job
+from src.jobs.currency_rates import refresh_exchange_rates_job
 from src.jobs.pdf_processing import process_pdf_upload_job
 
-__all__ = ["process_csv_upload_job", "process_pdf_upload_job"]
+__all__ = ["process_csv_upload_job", "process_pdf_upload_job", "refresh_exchange_rates_job"]

--- a/backend/src/jobs/currency_rates.py
+++ b/backend/src/jobs/currency_rates.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.core import database as database_module
+from src.services.currency import refresh_exchange_rates
+
+
+async def refresh_exchange_rates_job(
+    _: dict[str, Any],
+    *_args: Any,
+    **_kwargs: Any,
+) -> None:
+    async with database_module.SessionLocal() as session:
+        await refresh_exchange_rates(session)

--- a/backend/src/models/user.py
+++ b/backend/src/models/user.py
@@ -12,3 +12,4 @@ class User(TimestampMixin, Base):
     full_name: Mapped[str] = mapped_column(String(255))
     hashed_password: Mapped[str] = mapped_column(String(255))
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    preferred_currency: Mapped[str] = mapped_column(String(3), default="USD", nullable=False)

--- a/backend/src/schemas/analytics.py
+++ b/backend/src/schemas/analytics.py
@@ -17,6 +17,7 @@ class AnalyticsWindow(BaseModel):
 class AnalyticsSummary(BaseModel):
     total_spend: Decimal
     average_monthly_spend: Decimal
+    currency: str
     active_subscriptions: int
     projected_monthly_savings: Decimal
     projected_range_savings: Decimal
@@ -26,6 +27,7 @@ class AnalyticsCategoryItem(BaseModel):
     category_id: int | None
     category_name: str
     total_spend: Decimal
+    currency: str
     active_subscriptions: int
     projected_monthly_savings: Decimal
     projected_range_savings: Decimal
@@ -36,6 +38,7 @@ class AnalyticsPaymentMethodItem(BaseModel):
     payment_method_label: str
     provider: str | None = None
     total_spend: Decimal
+    currency: str
     active_subscriptions: int
 
 
@@ -44,17 +47,20 @@ class AnalyticsFrequencyItem(BaseModel):
     label: str
     subscription_count: int
     monthly_equivalent: Decimal
+    currency: str
 
 
 class AnalyticsTrendCategoryItem(BaseModel):
     category_name: str
     total_spend: Decimal
+    currency: str
 
 
 class AnalyticsTrendPoint(BaseModel):
     period_start: date
     label: str
     total_spend: Decimal
+    currency: str
     category_totals: list[AnalyticsTrendCategoryItem]
 
 

--- a/backend/src/schemas/auth.py
+++ b/backend/src/schemas/auth.py
@@ -50,11 +50,37 @@ class UserResponse(BaseModel):
     id: int
     email: str
     full_name: str
+    preferred_currency: str
     is_active: bool
     created_at: datetime
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class UserUpdateRequest(BaseModel):
+    full_name: str | None = None
+    preferred_currency: str | None = None
+
+    @field_validator("full_name")
+    @classmethod
+    def validate_full_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if len(normalized) < 2:
+            raise ValueError("Full name must be at least 2 characters.")
+        return normalized
+
+    @field_validator("preferred_currency")
+    @classmethod
+    def validate_preferred_currency(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().upper()
+        if len(normalized) != 3 or not normalized.isalpha():
+            raise ValueError("Use a 3-letter currency code.")
+        return normalized
 
 
 class TokenResponse(BaseModel):

--- a/backend/src/schemas/currency.py
+++ b/backend/src/schemas/currency.py
@@ -1,0 +1,22 @@
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class SupportedCurrency(BaseModel):
+    code: str
+    name: str
+
+
+class SupportedCurrencyListResponse(BaseModel):
+    items: list[SupportedCurrency]
+
+
+class ExchangeRateResponse(BaseModel):
+    base_currency: str
+    quote_currency: str
+    rate: Decimal
+    effective_date: date
+    source: str
+    is_fallback: bool = False

--- a/backend/src/schemas/dashboard.py
+++ b/backend/src/schemas/dashboard.py
@@ -24,6 +24,7 @@ DashboardColumn = Literal["primary", "secondary"]
 
 class DashboardSummaryStats(BaseModel):
     total_monthly_spend: Decimal
+    currency: str
     active_subscriptions: int
     upcoming_renewals: int
     cancelled_subscriptions: int
@@ -33,6 +34,7 @@ class DashboardMonthlySpendPoint(BaseModel):
     month: str
     label: str
     total: Decimal
+    currency: str
 
 
 class DashboardActiveSubscriptionItem(BaseModel):
@@ -51,6 +53,7 @@ class DashboardCategoryBreakdownItem(BaseModel):
     category_name: str
     subscriptions: int
     total_monthly_spend: Decimal
+    currency: str
 
 
 class DashboardUpcomingRenewalItem(BaseModel):

--- a/backend/src/services/analytics.py
+++ b/backend/src/services/analytics.py
@@ -24,6 +24,7 @@ from src.schemas.analytics import (
     AnalyticsTrendPoint,
     AnalyticsWindow,
 )
+from src.services.currency import convert
 
 logger = get_logger(__name__)
 
@@ -46,9 +47,23 @@ def _quantize_money(value: Decimal) -> Decimal:
     return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
-def _monthly_equivalent(subscription: Subscription) -> Decimal:
+def _get_user_currency(user: User) -> str:
+    return (user.preferred_currency or "USD").strip().upper()
+
+
+async def _monthly_equivalent(
+    session: AsyncSession,
+    subscription: Subscription,
+    *,
+    target_currency: str,
+) -> Decimal:
     cadence = subscription.cadence.lower()
-    amount = Decimal(subscription.amount)
+    amount = await convert(
+        session,
+        Decimal(subscription.amount),
+        from_currency=subscription.currency,
+        to_currency=target_currency,
+    )
 
     if cadence == "weekly":
         return _quantize_money((amount * Decimal(52)) / Decimal(12))
@@ -106,6 +121,7 @@ async def get_expense_analytics(
 ) -> AnalyticsResponse:
     config = WINDOW_CONFIG[range_key]
     today = date.today()
+    target_currency = _get_user_currency(user)
     window_days = int(config["days"])
     projection_months = Decimal(str(config["projection_months"]))
     window_start = today - timedelta(days=window_days - 1)
@@ -193,7 +209,18 @@ async def get_expense_analytics(
     total_spend = Decimal("0.00")
 
     for payment, subscription in payment_rows:
-        amount = _quantize_money(abs(Decimal(payment.amount)))
+        paid_at = payment.paid_at.astimezone(UTC) if payment.paid_at.tzinfo else payment.paid_at
+        amount = _quantize_money(
+            abs(
+                await convert(
+                    session,
+                    Decimal(payment.amount),
+                    from_currency=payment.currency,
+                    to_currency=target_currency,
+                    effective_date=paid_at.date(),
+                )
+            )
+        )
         total_spend += amount
 
         category_name = _category_name(subscription, category_map)
@@ -206,7 +233,6 @@ async def get_expense_analytics(
         )
         method_spend_totals[payment_method_key] += amount
 
-        paid_at = payment.paid_at.astimezone(UTC) if payment.paid_at.tzinfo else payment.paid_at
         month_key = _month_start(paid_at.date())
         trend_totals[month_key] += amount
         trend_category_totals[(month_key, category_name)] += amount
@@ -228,7 +254,11 @@ async def get_expense_analytics(
     )
 
     for subscription in active_subscriptions:
-        monthly_equivalent = _monthly_equivalent(subscription)
+        monthly_equivalent = await _monthly_equivalent(
+            session,
+            subscription,
+            target_currency=target_currency,
+        )
         category_key = (
             subscription.category_id,
             _category_name(subscription, category_map),
@@ -271,6 +301,7 @@ async def get_expense_analytics(
             category_id=category_id,
             category_name=category_name,
             total_spend=_quantize_money(category_spend_totals[(category_id, category_name)]),
+            currency=target_currency,
             active_subscriptions=int(
                 category_projection[(category_id, category_name)]["active_subscriptions"]
             ),
@@ -305,6 +336,7 @@ async def get_expense_analytics(
             total_spend=_quantize_money(
                 method_spend_totals[(payment_method_id, payment_method_label, provider)]
             ),
+            currency=target_currency,
             active_subscriptions=int(
                 payment_method_projection[
                     (payment_method_id, payment_method_label, provider)
@@ -328,6 +360,7 @@ async def get_expense_analytics(
             label=CADENCE_LABELS.get(cadence, cadence.capitalize()),
             subscription_count=int(values["subscription_count"]),
             monthly_equivalent=_quantize_money(Decimal(values["monthly_equivalent"])),
+            currency=target_currency,
         )
         for cadence, values in sorted(
             frequency_totals.items(),
@@ -361,12 +394,14 @@ async def get_expense_analytics(
                 period_start=cursor,
                 label=cursor.strftime("%b %y" if show_year else "%b"),
                 total_spend=_quantize_money(trend_totals[cursor]),
+                currency=target_currency,
                 category_totals=[
                     AnalyticsTrendCategoryItem(
                         category_name=category_name,
                         total_spend=_quantize_money(
                             trend_category_totals[(cursor, category_name)]
                         ),
+                        currency=target_currency,
                     )
                     for category_name in trend_categories
                 ],
@@ -386,6 +421,7 @@ async def get_expense_analytics(
             average_monthly_spend=_quantize_money(
                 total_spend / projection_months if projection_months else Decimal("0.00")
             ),
+            currency=target_currency,
             active_subscriptions=len(active_subscriptions),
             projected_monthly_savings=projected_monthly_savings,
             projected_range_savings=projected_range_savings,

--- a/backend/src/services/auth.py
+++ b/backend/src/services/auth.py
@@ -17,7 +17,13 @@ from src.models.raw_transaction import RawTransaction
 from src.models.subscription import Subscription
 from src.models.subscription_event import SubscriptionEvent
 from src.models.user import User
-from src.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
+from src.schemas.auth import (
+    LoginRequest,
+    RegisterRequest,
+    TokenResponse,
+    UserResponse,
+    UserUpdateRequest,
+)
 
 logger = get_logger(__name__)
 
@@ -109,6 +115,27 @@ async def refresh_user_tokens(session: AsyncSession, refresh_token: str) -> Toke
 
     logger.info("auth.refreshed", user_id=user.id, email=user.email)
     return _build_token_response(user)
+
+
+async def update_user_profile(
+    session: AsyncSession,
+    *,
+    user: User,
+    payload: UserUpdateRequest,
+) -> User:
+    if payload.full_name is not None:
+        user.full_name = payload.full_name
+    if payload.preferred_currency is not None:
+        user.preferred_currency = payload.preferred_currency
+
+    await session.commit()
+    await session.refresh(user)
+    logger.info(
+        "auth.profile_updated",
+        user_id=user.id,
+        preferred_currency=user.preferred_currency,
+    )
+    return user
 
 
 async def delete_user_workspace_data(session: AsyncSession, user: User) -> None:

--- a/backend/src/services/currency.py
+++ b/backend/src/services/currency.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterable
+from datetime import UTC, date, datetime
+from decimal import ROUND_HALF_UP, Decimal
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.logging import get_logger
+from src.models.exchange_rate import ExchangeRate
+from src.schemas.currency import ExchangeRateResponse, SupportedCurrency
+
+logger = get_logger(__name__)
+
+SUPPORTED_CURRENCIES: tuple[SupportedCurrency, ...] = (
+    SupportedCurrency(code="USD", name="US Dollar"),
+    SupportedCurrency(code="EUR", name="Euro"),
+    SupportedCurrency(code="GBP", name="British Pound"),
+    SupportedCurrency(code="CAD", name="Canadian Dollar"),
+    SupportedCurrency(code="AUD", name="Australian Dollar"),
+    SupportedCurrency(code="JPY", name="Japanese Yen"),
+    SupportedCurrency(code="INR", name="Indian Rupee"),
+)
+SUPPORTED_CURRENCY_CODES = frozenset(currency.code for currency in SUPPORTED_CURRENCIES)
+DEFAULT_BASE_CURRENCY = "USD"
+FRANKFURTER_URL = "https://api.frankfurter.app/latest"
+
+
+def _normalize_currency(value: str) -> str:
+    normalized = value.strip().upper()
+    if len(normalized) != 3 or not normalized.isalpha():
+        raise ValueError("Currency must be a 3-letter code.")
+    return normalized
+
+
+def _quantize_money(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _quantize_rate(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
+
+
+async def get_rate(
+    session: AsyncSession,
+    *,
+    base_currency: str,
+    quote_currency: str,
+    effective_date: date | None = None,
+) -> Decimal | None:
+    base = _normalize_currency(base_currency)
+    quote = _normalize_currency(quote_currency)
+    if base == quote:
+        return Decimal("1")
+
+    as_of = effective_date or date.today()
+    direct = await session.scalar(
+        select(ExchangeRate)
+        .where(
+            ExchangeRate.base_currency == base,
+            ExchangeRate.quote_currency == quote,
+            ExchangeRate.effective_date <= as_of,
+        )
+        .order_by(ExchangeRate.effective_date.desc())
+    )
+    if direct is not None:
+        return Decimal(direct.rate)
+
+    inverse = await session.scalar(
+        select(ExchangeRate)
+        .where(
+            ExchangeRate.base_currency == quote,
+            ExchangeRate.quote_currency == base,
+            ExchangeRate.effective_date <= as_of,
+        )
+        .order_by(ExchangeRate.effective_date.desc())
+    )
+    if inverse is not None and Decimal(inverse.rate) != 0:
+        return _quantize_rate(Decimal("1") / Decimal(inverse.rate))
+
+    return None
+
+
+async def convert(
+    session: AsyncSession,
+    amount: Decimal,
+    *,
+    from_currency: str,
+    to_currency: str,
+    effective_date: date | None = None,
+) -> Decimal:
+    source = _normalize_currency(from_currency)
+    target = _normalize_currency(to_currency)
+    if source == target:
+        return _quantize_money(amount)
+
+    rate = await get_rate(
+        session,
+        base_currency=source,
+        quote_currency=target,
+        effective_date=effective_date,
+    )
+    if rate is None:
+        logger.warning(
+            "currency.rate_missing_fallback",
+            source_currency=source,
+            target_currency=target,
+            effective_date=(effective_date or date.today()).isoformat(),
+        )
+        return _quantize_money(amount)
+
+    return _quantize_money(amount * rate)
+
+
+async def get_exchange_rate_response(
+    session: AsyncSession,
+    *,
+    base_currency: str,
+    quote_currency: str,
+    effective_date: date | None = None,
+) -> ExchangeRateResponse:
+    base = _normalize_currency(base_currency)
+    quote = _normalize_currency(quote_currency)
+    as_of = effective_date or date.today()
+    rate = await get_rate(
+        session,
+        base_currency=base,
+        quote_currency=quote,
+        effective_date=as_of,
+    )
+    if rate is None:
+        return ExchangeRateResponse(
+            base_currency=base,
+            quote_currency=quote,
+            rate=Decimal("1.000000"),
+            effective_date=as_of,
+            source="fallback",
+            is_fallback=True,
+        )
+
+    return ExchangeRateResponse(
+        base_currency=base,
+        quote_currency=quote,
+        rate=_quantize_rate(rate),
+        effective_date=as_of,
+        source="exchange_rates",
+    )
+
+
+def _fetch_frankfurter_rates(
+    base_currency: str,
+    quote_currencies: Iterable[str],
+) -> dict[str, object]:
+    query = urlencode({"from": base_currency, "to": ",".join(sorted(quote_currencies))})
+    with urlopen(f"{FRANKFURTER_URL}?{query}", timeout=10) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+async def refresh_exchange_rates(
+    session: AsyncSession,
+    *,
+    base_currency: str = DEFAULT_BASE_CURRENCY,
+    quote_currencies: Iterable[str] | None = None,
+) -> int:
+    base = _normalize_currency(base_currency)
+    quotes = {
+        _normalize_currency(currency)
+        for currency in (quote_currencies or SUPPORTED_CURRENCY_CODES)
+        if _normalize_currency(currency) != base
+    }
+    if not quotes:
+        return 0
+
+    payload = await asyncio.to_thread(_fetch_frankfurter_rates, base, quotes)
+    rates = payload.get("rates")
+    if not isinstance(rates, dict):
+        raise ValueError("Frankfurter response did not include a rates object.")
+
+    effective_date_raw = payload.get("date")
+    effective_date = (
+        datetime.strptime(str(effective_date_raw), "%Y-%m-%d").date()
+        if effective_date_raw
+        else datetime.now(UTC).date()
+    )
+
+    saved = 0
+    for quote, raw_rate in rates.items():
+        quote_currency = _normalize_currency(str(quote))
+        rate = _quantize_rate(Decimal(str(raw_rate)))
+        existing = await session.scalar(
+            select(ExchangeRate).where(
+                ExchangeRate.base_currency == base,
+                ExchangeRate.quote_currency == quote_currency,
+                ExchangeRate.effective_date == effective_date,
+            )
+        )
+        if existing is None:
+            session.add(
+                ExchangeRate(
+                    base_currency=base,
+                    quote_currency=quote_currency,
+                    rate=rate,
+                    effective_date=effective_date,
+                    source="frankfurter.app",
+                )
+            )
+        else:
+            existing.rate = rate
+            existing.source = "frankfurter.app"
+        saved += 1
+
+    await session.commit()
+    logger.info(
+        "currency.rates_refreshed",
+        base_currency=base,
+        quote_count=saved,
+        effective_date=effective_date.isoformat(),
+    )
+    return saved

--- a/backend/src/services/dashboard.py
+++ b/backend/src/services/dashboard.py
@@ -22,6 +22,7 @@ from src.schemas.dashboard import (
     DashboardSummaryStats,
     DashboardUpcomingRenewalItem,
 )
+from src.services.currency import convert
 
 logger = get_logger(__name__)
 
@@ -44,9 +45,23 @@ def _quantize_money(value: Decimal) -> Decimal:
     return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
-def _monthly_equivalent(subscription: Subscription) -> Decimal:
+def _get_user_currency(user: User) -> str:
+    return (user.preferred_currency or "USD").strip().upper()
+
+
+async def _monthly_equivalent(
+    session: AsyncSession,
+    subscription: Subscription,
+    *,
+    target_currency: str,
+) -> Decimal:
     cadence = subscription.cadence.lower()
-    amount = Decimal(subscription.amount)
+    amount = await convert(
+        session,
+        Decimal(subscription.amount),
+        from_currency=subscription.currency,
+        to_currency=target_currency,
+    )
 
     if cadence == "weekly":
         return _quantize_money((amount * Decimal(52)) / Decimal(12))
@@ -74,6 +89,7 @@ async def get_dashboard_summary(
     user: User,
 ) -> DashboardSummaryResponse:
     today = date.today()
+    target_currency = _get_user_currency(user)
     upcoming_cutoff = today + timedelta(days=UPCOMING_WINDOW_DAYS)
     recent_cutoff = today - timedelta(days=RECENTLY_ENDED_WINDOW_DAYS)
 
@@ -125,11 +141,16 @@ async def get_dashboard_summary(
         reverse=True,
     )
 
-    total_monthly_spend = _quantize_money(
-        sum(
-            (_monthly_equivalent(subscription) for subscription in active_subscriptions),
-            Decimal("0.00"),
+    monthly_equivalents: dict[int, Decimal] = {}
+    for subscription in active_subscriptions:
+        monthly_equivalents[subscription.id] = await _monthly_equivalent(
+            session,
+            subscription,
+            target_currency=target_currency,
         )
+
+    total_monthly_spend = _quantize_money(
+        sum(monthly_equivalents.values(), Decimal("0.00"))
     )
 
     category_totals: dict[tuple[int | None, str], dict[str, Decimal | int]] = {}
@@ -148,8 +169,8 @@ async def get_dashboard_summary(
             {"subscriptions": 0, "total_monthly_spend": Decimal("0.00")},
         )
         entry["subscriptions"] = int(entry["subscriptions"]) + 1
-        entry["total_monthly_spend"] = Decimal(entry["total_monthly_spend"]) + _monthly_equivalent(
-            subscription
+        entry["total_monthly_spend"] = (
+            Decimal(entry["total_monthly_spend"]) + monthly_equivalents[subscription.id]
         )
 
     month_totals: dict[str, Decimal] = {}
@@ -166,6 +187,7 @@ async def get_dashboard_summary(
                 month=key,
                 label=cursor.strftime("%b"),
                 total=Decimal("0.00"),
+                currency=target_currency,
             )
         )
         cursor = _shift_months(cursor, 1)
@@ -199,13 +221,20 @@ async def get_dashboard_summary(
         paid_at = payment.paid_at.astimezone(UTC) if payment.paid_at.tzinfo else payment.paid_at
         key = paid_at.strftime("%Y-%m")
         if key in month_totals:
-            month_totals[key] += Decimal(payment.amount)
+            month_totals[key] += await convert(
+                session,
+                Decimal(payment.amount),
+                from_currency=payment.currency,
+                to_currency=target_currency,
+                effective_date=paid_at.date(),
+            )
 
     monthly_spend = [
         DashboardMonthlySpendPoint(
             month=point.month,
             label=point.label,
             total=_quantize_money(month_totals[point.month]),
+            currency=target_currency,
         )
         for point in month_points
     ]
@@ -213,6 +242,7 @@ async def get_dashboard_summary(
     response = DashboardSummaryResponse(
         summary=DashboardSummaryStats(
             total_monthly_spend=total_monthly_spend,
+            currency=target_currency,
             active_subscriptions=len(active_subscriptions),
             upcoming_renewals=len(upcoming_renewals),
             cancelled_subscriptions=len(cancelled_subscriptions),
@@ -250,6 +280,7 @@ async def get_dashboard_summary(
                 category_name=category_name,
                 subscriptions=int(values["subscriptions"]),
                 total_monthly_spend=_quantize_money(Decimal(values["total_monthly_spend"])),
+                currency=target_currency,
             )
             for (category_id, category_name), values in sorted(
                 category_totals.items(),

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -1,11 +1,23 @@
+from typing import cast
+
+from arq import cron
 from arq.connections import RedisSettings
+from arq.typing import WorkerCoroutine
 
 from src.config import get_settings
-from src.jobs import process_csv_upload_job, process_pdf_upload_job
+from src.jobs import process_csv_upload_job, process_pdf_upload_job, refresh_exchange_rates_job
 
 settings = get_settings()
 
 
 class WorkerSettings:
-    functions = [process_csv_upload_job, process_pdf_upload_job]
+    functions = [process_csv_upload_job, process_pdf_upload_job, refresh_exchange_rates_job]
+    cron_jobs = [
+        cron(
+            cast(WorkerCoroutine, refresh_exchange_rates_job),
+            hour=6,
+            minute=0,
+            name="daily_exchange_rate_refresh",
+        )
+    ]
     redis_settings = RedisSettings.from_dsn(settings.redis_url)

--- a/backend/tests/api/test_analytics.py
+++ b/backend/tests/api/test_analytics.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 from src.core import database as database_module
+from src.models.exchange_rate import ExchangeRate
 from src.models.payment_history import PaymentHistory
 from src.models.subscription import Subscription
 
@@ -62,6 +63,7 @@ def _create_subscription(
     category_id: int,
     payment_method_id: int,
     start_date: str,
+    currency: str = "USD",
 ) -> int:
     response = client.post(
         "/api/v1/subscriptions",
@@ -70,7 +72,7 @@ def _create_subscription(
             "name": name,
             "vendor": name,
             "amount": amount,
-            "currency": "USD",
+            "currency": currency,
             "cadence": cadence,
             "status": "active",
             "start_date": start_date,
@@ -82,7 +84,13 @@ def _create_subscription(
     return response.json()["id"]
 
 
-def _seed_payment_history(subscription_id: int, paid_at: datetime, amount: Decimal) -> None:
+def _seed_payment_history(
+    subscription_id: int,
+    paid_at: datetime,
+    amount: Decimal,
+    *,
+    currency: str = "USD",
+) -> None:
     async def _write() -> None:
         async with database_module.SessionLocal() as session:
             subscription = await session.get(Subscription, subscription_id)
@@ -93,9 +101,26 @@ def _seed_payment_history(subscription_id: int, paid_at: datetime, amount: Decim
                     payment_method_id=subscription.payment_method_id,
                     paid_at=paid_at,
                     amount=amount,
-                    currency="USD",
+                    currency=currency,
                     payment_status="settled",
                     reference=f"{subscription_id}-{paid_at.date().isoformat()}",
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_write())
+
+
+def _seed_exchange_rate(base: str, quote: str, rate: str, effective_date: date) -> None:
+    async def _write() -> None:
+        async with database_module.SessionLocal() as session:
+            session.add(
+                ExchangeRate(
+                    base_currency=base,
+                    quote_currency=quote,
+                    rate=Decimal(rate),
+                    effective_date=effective_date,
+                    source="test",
                 )
             )
             await session.commit()
@@ -210,6 +235,7 @@ def test_expense_analytics_returns_category_method_frequency_and_trend_data(clie
     assert payload["summary"] == {
         "total_spend": "250.00",
         "average_monthly_spend": "41.67",
+        "currency": "USD",
         "active_subscriptions": 4,
         "projected_monthly_savings": "65.00",
         "projected_range_savings": "390.00",
@@ -218,6 +244,7 @@ def test_expense_analytics_returns_category_method_frequency_and_trend_data(clie
         "category_id": utilities_id,
         "category_name": "Utilities",
         "total_spend": "90.00",
+        "currency": "USD",
         "active_subscriptions": 1,
         "projected_monthly_savings": "30.00",
         "projected_range_savings": "180.00",
@@ -237,18 +264,21 @@ def test_expense_analytics_returns_category_method_frequency_and_trend_data(clie
             "label": "Monthly cadence",
             "subscription_count": 2,
             "monthly_equivalent": "25.00",
+            "currency": "USD",
         },
         {
             "cadence": "quarterly",
             "label": "Quarterly cadence",
             "subscription_count": 1,
             "monthly_equivalent": "30.00",
+            "currency": "USD",
         },
         {
             "cadence": "yearly",
             "label": "Yearly cadence",
             "subscription_count": 1,
             "monthly_equivalent": "10.00",
+            "currency": "USD",
         },
     ]
 
@@ -266,3 +296,51 @@ def test_expense_analytics_returns_category_method_frequency_and_trend_data(clie
     assert other_response.status_code == 200
     assert other_response.json()["summary"]["total_spend"] == "0.00"
     assert other_response.json()["categories"] == []
+
+
+def test_expense_analytics_converts_observed_and_projected_totals(client) -> None:
+    today = date.today()
+    current_month_start = today.replace(day=1)
+    headers = _auth_headers(client, "analytics-currency@example.com")
+    category_id = _create_category(client, headers, "Infrastructure")
+    method_id = _create_payment_method(
+        client,
+        headers,
+        label="Primary card",
+        provider="Visa",
+        last4="4242",
+    )
+    _seed_exchange_rate("USD", "EUR", "0.900000", current_month_start)
+
+    update_response = client.patch(
+        "/api/v1/auth/me",
+        headers=headers,
+        json={"preferred_currency": "EUR"},
+    )
+    assert update_response.status_code == 200
+
+    subscription_id = _create_subscription(
+        client,
+        headers,
+        name="Cloud Storage",
+        amount="10.00",
+        cadence="monthly",
+        category_id=category_id,
+        payment_method_id=method_id,
+        start_date=str(today - timedelta(days=120)),
+    )
+    _seed_payment_history(
+        subscription_id,
+        datetime.combine(current_month_start + timedelta(days=2), datetime.min.time(), tzinfo=UTC),
+        Decimal("20.00"),
+    )
+
+    response = client.get("/api/v1/expense-reports/analytics?range=90d", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["currency"] == "EUR"
+    assert payload["summary"]["total_spend"] == "18.00"
+    assert payload["summary"]["projected_monthly_savings"] == "9.00"
+    assert payload["categories"][0]["currency"] == "EUR"
+    assert payload["categories"][0]["total_spend"] == "18.00"

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -40,6 +40,15 @@ def test_register_login_refresh_and_me(client) -> None:
     )
     assert me_response.status_code == 200
     assert me_response.json()["full_name"] == "Owner One"
+    assert me_response.json()["preferred_currency"] == "USD"
+
+    update_response = client.patch(
+        "/api/v1/auth/me",
+        headers={"Authorization": f"Bearer {login_payload['access_token']}"},
+        json={"preferred_currency": "eur"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["preferred_currency"] == "EUR"
 
     refresh_response = client.post(
         "/api/v1/auth/refresh",

--- a/backend/tests/api/test_currencies.py
+++ b/backend/tests/api/test_currencies.py
@@ -1,0 +1,50 @@
+from datetime import date
+
+
+def _auth_headers(client) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "currency@example.com",
+            "full_name": "Currency Owner",
+            "password": "super-secret",
+        },
+    )
+    assert response.status_code == 201
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def test_currencies_api_lists_supported_codes_and_missing_rate_fallback(client) -> None:
+    headers = _auth_headers(client)
+
+    list_response = client.get("/api/v1/currencies", headers=headers)
+    assert list_response.status_code == 200
+    assert [item["code"] for item in list_response.json()["items"]] == [
+        "USD",
+        "EUR",
+        "GBP",
+        "CAD",
+        "AUD",
+        "JPY",
+        "INR",
+    ]
+
+    rate_response = client.get(
+        "/api/v1/currencies/rate",
+        headers=headers,
+        params={
+            "base_currency": "CAD",
+            "quote_currency": "INR",
+            "effective_date": date(2026, 4, 21).isoformat(),
+        },
+    )
+
+    assert rate_response.status_code == 200
+    assert rate_response.json() == {
+        "base_currency": "CAD",
+        "quote_currency": "INR",
+        "effective_date": "2026-04-21",
+        "is_fallback": True,
+        "rate": "1.000000",
+        "source": "fallback",
+    }

--- a/backend/tests/api/test_dashboard.py
+++ b/backend/tests/api/test_dashboard.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 from src.core import database as database_module
+from src.models.exchange_rate import ExchangeRate
 from src.models.payment_history import PaymentHistory
 from src.models.subscription import Subscription
 
@@ -54,6 +55,7 @@ def _create_subscription(
     next_charge_date: str | None = None,
     end_date: str | None = None,
     payment_method_id: int | None = None,
+    currency: str = "USD",
 ) -> int:
     response = client.post(
         "/api/v1/subscriptions",
@@ -62,7 +64,7 @@ def _create_subscription(
             "name": name,
             "vendor": name,
             "amount": amount,
-            "currency": "USD",
+            "currency": currency,
             "cadence": cadence,
             "status": status,
             "start_date": start_date,
@@ -76,7 +78,13 @@ def _create_subscription(
     return response.json()["id"]
 
 
-def _seed_payment_history(subscription_id: int, paid_at: datetime, amount: Decimal) -> None:
+def _seed_payment_history(
+    subscription_id: int,
+    paid_at: datetime,
+    amount: Decimal,
+    *,
+    currency: str = "USD",
+) -> None:
     async def _write() -> None:
         async with database_module.SessionLocal() as session:
             subscription = await session.get(Subscription, subscription_id)
@@ -87,9 +95,26 @@ def _seed_payment_history(subscription_id: int, paid_at: datetime, amount: Decim
                     payment_method_id=subscription.payment_method_id,
                     paid_at=paid_at,
                     amount=amount,
-                    currency="USD",
+                    currency=currency,
                     payment_status="settled",
                     reference=f"{subscription_id}-{paid_at.date().isoformat()}",
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_write())
+
+
+def _seed_exchange_rate(base: str, quote: str, rate: str, effective_date: date) -> None:
+    async def _write() -> None:
+        async with database_module.SessionLocal() as session:
+            session.add(
+                ExchangeRate(
+                    base_currency=base,
+                    quote_currency=quote,
+                    rate=Decimal(rate),
+                    effective_date=effective_date,
+                    source="test",
                 )
             )
             await session.commit()
@@ -187,6 +212,7 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
     payload = summary_response.json()
     assert payload["summary"] == {
         "total_monthly_spend": "25.00",
+        "currency": "USD",
         "active_subscriptions": 2,
         "upcoming_renewals": 2,
         "cancelled_subscriptions": 1,
@@ -196,6 +222,7 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
     assert payload["active_subscriptions"][1]["name"] == "Dropbox"
     assert payload["category_breakdown"][0]["category_name"] == "Entertainment"
     assert payload["category_breakdown"][0]["total_monthly_spend"] == "15.00"
+    assert payload["category_breakdown"][0]["currency"] == "USD"
     assert payload["category_breakdown"][1]["category_name"] == "Productivity"
     assert payload["upcoming_renewals"][0]["name"] == "Netflix"
     assert payload["upcoming_renewals"][0]["days_until_charge"] == 4
@@ -263,3 +290,45 @@ def test_dashboard_layout_requires_each_widget_exactly_once(client) -> None:
     )
 
     assert response.status_code == 422
+
+
+def test_dashboard_summary_converts_workspace_totals_to_preferred_currency(client) -> None:
+    today = date.today()
+    current_month_start = today.replace(day=1)
+    headers = _auth_headers(client, "currency-dashboard@example.com")
+    _seed_exchange_rate("USD", "EUR", "0.900000", current_month_start)
+    update_response = client.patch(
+        "/api/v1/auth/me",
+        headers=headers,
+        json={"preferred_currency": "EUR"},
+    )
+    assert update_response.status_code == 200
+
+    subscription_id = _create_subscription(
+        client,
+        headers,
+        name="Cloud Storage",
+        amount="10.00",
+        cadence="monthly",
+        status="active",
+        start_date=str(today - timedelta(days=30)),
+    )
+    _seed_payment_history(
+        subscription_id,
+        datetime.combine(current_month_start + timedelta(days=3), datetime.min.time(), tzinfo=UTC),
+        Decimal("20.00"),
+    )
+
+    response = client.get("/api/v1/dashboard/summary", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["currency"] == "EUR"
+    assert payload["summary"]["total_monthly_spend"] == "9.00"
+    month_map = {item["month"]: item for item in payload["monthly_spend"]}
+    assert month_map[current_month_start.strftime("%Y-%m")] == {
+        "month": current_month_start.strftime("%Y-%m"),
+        "label": current_month_start.strftime("%b"),
+        "total": "18.00",
+        "currency": "EUR",
+    }

--- a/backend/tests/services/test_currency.py
+++ b/backend/tests/services/test_currency.py
@@ -1,0 +1,72 @@
+import asyncio
+from datetime import date
+from decimal import Decimal
+
+from src.core import database as database_module
+from src.models.exchange_rate import ExchangeRate
+from src.services.currency import convert, get_rate
+
+
+def _seed_rate(base: str, quote: str, rate: str, effective_date: date) -> None:
+    async def _write() -> None:
+        async with database_module.SessionLocal() as session:
+            session.add(
+                ExchangeRate(
+                    base_currency=base,
+                    quote_currency=quote,
+                    rate=Decimal(rate),
+                    effective_date=effective_date,
+                    source="test",
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_write())
+
+
+def test_currency_service_converts_direct_and_inverse_rates(app) -> None:
+    _seed_rate("USD", "EUR", "0.900000", date(2026, 4, 20))
+
+    async def _read() -> tuple[Decimal | None, Decimal, Decimal]:
+        async with database_module.SessionLocal() as session:
+            direct = await get_rate(
+                session,
+                base_currency="USD",
+                quote_currency="EUR",
+                effective_date=date(2026, 4, 21),
+            )
+            eur_amount = await convert(
+                session,
+                Decimal("10.00"),
+                from_currency="USD",
+                to_currency="EUR",
+                effective_date=date(2026, 4, 21),
+            )
+            usd_amount = await convert(
+                session,
+                Decimal("9.00"),
+                from_currency="EUR",
+                to_currency="USD",
+                effective_date=date(2026, 4, 21),
+            )
+            return direct, eur_amount, usd_amount
+
+    direct_rate, converted_to_eur, converted_to_usd = asyncio.run(_read())
+
+    assert direct_rate == Decimal("0.900000")
+    assert converted_to_eur == Decimal("9.00")
+    assert converted_to_usd == Decimal("10.00")
+
+
+def test_currency_service_falls_back_to_original_amount_when_rate_missing(app) -> None:
+    async def _read() -> Decimal:
+        async with database_module.SessionLocal() as session:
+            return await convert(
+                session,
+                Decimal("12.34"),
+                from_currency="CAD",
+                to_currency="INR",
+                effective_date=date(2026, 4, 21),
+            )
+
+    assert asyncio.run(_read()) == Decimal("12.34")

--- a/frontend/src/app/(app)/settings/page.tsx
+++ b/frontend/src/app/(app)/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CreditCard, FolderTree, PencilLine, ShieldAlert, Trash2, UserRound } from "lucide-react";
 
 import { useAuth } from "@/hooks/use-auth";
@@ -25,6 +25,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { getCurrencyName, supportedCurrencies } from "@/lib/currency";
 
 type CategoryDraft = {
   description: string;
@@ -107,9 +108,12 @@ function SectionShell({
 }
 
 export default function SettingsPage() {
-  const { user } = useAuth();
-  const { preferredCurrency } = useOnboarding();
+  const { updateProfile, user } = useAuth();
+  const { preferredCurrency, setPreferredCurrency } = useOnboarding();
   const [categoryDraft, setCategoryDraft] = useState<CategoryDraft>(emptyCategoryDraft);
+  const [currencyDraft, setCurrencyDraft] = useState(user?.preferred_currency ?? preferredCurrency);
+  const [currencyError, setCurrencyError] = useState<string | null>(null);
+  const [isSavingCurrency, setIsSavingCurrency] = useState(false);
   const [paymentMethodDraft, setPaymentMethodDraft] = useState<PaymentMethodDraft>(emptyPaymentMethodDraft);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [editingCategoryDraft, setEditingCategoryDraft] = useState<CategoryDraft>(emptyCategoryDraft);
@@ -130,16 +134,34 @@ export default function SettingsPage() {
 
   const categories = categoriesQuery.data?.items ?? [];
   const paymentMethods = paymentMethodsQuery.data?.items ?? [];
+  const effectivePreferredCurrency = user?.preferred_currency ?? preferredCurrency;
   const currencySummary = useMemo(
     () =>
       getCurrencySummary(
         (subscriptionsQuery.data?.items ?? []).map((subscription) => subscription.currency),
-        preferredCurrency,
+        effectivePreferredCurrency,
       ),
-    [preferredCurrency, subscriptionsQuery.data?.items],
+    [effectivePreferredCurrency, subscriptionsQuery.data?.items],
   );
 
   const isCatalogLoading = categoriesQuery.isLoading || paymentMethodsQuery.isLoading;
+
+  useEffect(() => {
+    setCurrencyDraft(effectivePreferredCurrency);
+  }, [effectivePreferredCurrency]);
+
+  async function handleCurrencySave() {
+    setCurrencyError(null);
+    setIsSavingCurrency(true);
+    try {
+      const nextUser = await updateProfile({ preferred_currency: currencyDraft });
+      setPreferredCurrency(nextUser.preferred_currency);
+    } catch (error) {
+      setCurrencyError(getErrorMessage(error));
+    } finally {
+      setIsSavingCurrency(false);
+    }
+  }
 
   const openCategoryEditor = (category: Category) => {
     setEditingCategory(category);
@@ -605,6 +627,37 @@ export default function SettingsPage() {
               <p className="text-xs uppercase tracking-[0.28em] text-black/42">Workspace currency</p>
               <p className="mt-2 text-2xl font-semibold text-ink">{currencySummary.label}</p>
               <p className="mt-2 text-sm leading-6 text-black/58">{currencySummary.detail}</p>
+              <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+                <label className="sr-only" htmlFor="preferred-currency">
+                  Preferred currency
+                </label>
+                <select
+                  className="h-11 w-full rounded-full border border-black/10 bg-stone/70 px-4 text-sm font-semibold text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
+                  id="preferred-currency"
+                  onChange={(event) => setCurrencyDraft(event.target.value)}
+                  value={currencyDraft}
+                >
+                  {supportedCurrencies.map((option) => (
+                    <option key={option.code} value={option.code}>
+                      {option.code} - {option.name}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  className="rounded-full px-5"
+                  disabled={isSavingCurrency || currencyDraft === effectivePreferredCurrency}
+                  onClick={() => {
+                    void handleCurrencySave();
+                  }}
+                  type="button"
+                >
+                  {isSavingCurrency ? "Saving..." : "Save"}
+                </Button>
+              </div>
+              <p className="mt-2 text-xs leading-5 text-black/50">
+                Dashboard and report aggregates convert into {getCurrencyName(effectivePreferredCurrency)}.
+              </p>
+              {currencyError ? <p className="mt-2 text-sm text-ember">{currencyError}</p> : null}
             </div>
 
             {categories.length === 0 && paymentMethods.length === 0 ? (

--- a/frontend/src/app/(app)/subscriptions/page.tsx
+++ b/frontend/src/app/(app)/subscriptions/page.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useAuth } from "@/hooks/use-auth";
 import { useFilters } from "@/hooks/use-filters";
 import { useOnboarding } from "@/hooks/use-onboarding";
 import { useCreateSubscription, useSubscriptionCatalog, useSubscriptionList } from "@/hooks/use-subscriptions";
@@ -39,7 +40,9 @@ export default function SubscriptionsPage() {
     limit: 100,
     ...queryFilters,
   });
+  const { user } = useAuth();
   const { preferredCurrency } = useOnboarding();
+  const workspaceCurrency = user?.preferred_currency ?? preferredCurrency;
 
   const categories = categoriesQuery.data?.items ?? [];
   const paymentMethods = paymentMethodsQuery.data?.items ?? [];
@@ -258,7 +261,7 @@ export default function SubscriptionsPage() {
               description={
                 hasActiveFilters
                   ? "No plans match the current search or filter. Clear the active constraints to widen the view again."
-                  : `No subscriptions are saved yet. Use the form on the right to add the first plan with ${preferredCurrency} as the default billing code.`
+                  : `No subscriptions are saved yet. Use the form on the right to add the first plan with ${workspaceCurrency} as the default billing code.`
               }
               eyebrow={hasActiveFilters ? "Filtered view" : "First subscription"}
               icon={<Sparkles className="size-5" />}
@@ -296,7 +299,7 @@ export default function SubscriptionsPage() {
             await createSubscription.mutateAsync(payload);
           }}
           paymentMethods={paymentMethods}
-          preferredCurrency={preferredCurrency}
+          preferredCurrency={workspaceCurrency}
           submitLabel="Save subscription"
           testId="subscription-create-form"
           title="Add a subscription"

--- a/frontend/src/components/dashboard/snapshot-bar.tsx
+++ b/frontend/src/components/dashboard/snapshot-bar.tsx
@@ -51,6 +51,7 @@ function renderMetricValue(metricKey: (typeof metricMeta)[number]["key"], summar
     return (
       <CurrencyDisplay
         className="text-3xl font-semibold tracking-tight sm:text-4xl"
+        currency={summary.currency}
         value={Number.parseFloat(summary.total_monthly_spend)}
       />
     );
@@ -103,6 +104,11 @@ export function SnapshotBar({ isLoading = false, summary }: SnapshotBarProps) {
               ) : (
                 <div className="space-y-3">
                   {renderMetricValue(key, summary)}
+                  {key === "total_monthly_spend" ? (
+                    <p className={cn("text-xs uppercase tracking-[0.24em]", index === 0 ? "text-white/45" : "text-black/42")}>
+                      Approx. converted to {summary.currency}
+                    </p>
+                  ) : null}
                   <p className={cn("text-sm leading-6", index === 0 ? "text-white/68" : "text-black/62")}>
                     {detail(summary)}
                   </p>

--- a/frontend/src/components/dashboard/widget-library.tsx
+++ b/frontend/src/components/dashboard/widget-library.tsx
@@ -125,7 +125,7 @@ function ChartTooltip({
 }: {
   active?: boolean;
   label?: string;
-  payload?: Array<{ payload?: { total?: number } }>;
+  payload?: Array<{ payload?: { currency?: string; total?: number } }>;
 }) {
   if (!active || !payload?.length) {
     return null;
@@ -135,7 +135,10 @@ function ChartTooltip({
     <div className="rounded-[1.2rem] border border-black/10 bg-white/94 px-4 py-3 shadow-line">
       <p className="text-xs uppercase tracking-[0.28em] text-black/42">{label}</p>
       <p className="mt-2 text-sm font-semibold text-ink">
-        {formatCurrency({ value: payload[0]?.payload?.total ?? 0 })}
+        {formatCurrency({
+          currency: payload[0]?.payload?.currency ?? "USD",
+          value: payload[0]?.payload?.total ?? 0,
+        })}
       </p>
     </div>
   );
@@ -162,9 +165,10 @@ function ActiveSubscriptionsWidget({ summary }: { summary: DashboardSummary }) {
         <p className="mt-4 text-5xl font-semibold tracking-tight">{summary.summary.active_subscriptions}</p>
         <p className="mt-3 text-sm leading-6 text-white/65">
           {formatCurrency({
+            currency: summary.summary.currency,
             value: Number.parseFloat(summary.summary.total_monthly_spend),
           })}{" "}
-          in monthly-equivalent spend is currently active.
+          in monthly-equivalent spend is currently active after conversion.
         </p>
       </div>
 
@@ -202,6 +206,7 @@ function MonthlySpendWidget({ summary }: { summary: DashboardSummary }) {
   const chartData = summary.monthly_spend.map((point) => ({
     label: point.label,
     month: point.month,
+    currency: point.currency,
     total: Number.parseFloat(point.total),
   }));
   const hasData = chartData.some((point) => point.total > 0);
@@ -223,7 +228,13 @@ function MonthlySpendWidget({ summary }: { summary: DashboardSummary }) {
         <div>
           <p className="text-xs uppercase tracking-[0.28em] text-black/45">Latest recorded month</p>
           <p className="mt-2 text-3xl font-semibold tracking-tight text-ink">
-            {formatCurrency({ value: chartData.at(-1)?.total ?? 0 })}
+            {formatCurrency({
+              currency: summary.summary.currency,
+              value: chartData.at(-1)?.total ?? 0,
+            })}
+          </p>
+          <p className="mt-1 text-xs uppercase tracking-[0.24em] text-black/42">
+            Approx. converted to {summary.summary.currency}
           </p>
         </div>
         <p className="max-w-xs text-sm leading-6 text-black/58">
@@ -252,6 +263,7 @@ function MonthlySpendWidget({ summary }: { summary: DashboardSummary }) {
 
 function CategoryBreakdownWidget({ summary }: { summary: DashboardSummary }) {
   const chartData = summary.category_breakdown.slice(0, 5).map((item) => ({
+    currency: item.currency,
     label: item.category_name,
     subscriptions: item.subscriptions,
     total: Number.parseFloat(item.total_monthly_spend),
@@ -309,7 +321,9 @@ function CategoryBreakdownWidget({ summary }: { summary: DashboardSummary }) {
               </div>
             </div>
 
-            <p className="text-sm font-semibold text-ink">{formatCompactCurrency(String(item.total))}</p>
+            <p className="text-sm font-semibold text-ink">
+              {formatCompactCurrency(String(item.total), item.currency)}
+            </p>
           </div>
         ))}
       </div>
@@ -459,7 +473,10 @@ export function DashboardBoardFootnote({ summary }: { summary: DashboardSummary 
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-white/45">Live spend signal</p>
             <p className="mt-2 text-2xl font-semibold tracking-tight">
-              {formatCurrency({ value: Number.parseFloat(summary.summary.total_monthly_spend) })}
+              {formatCurrency({
+                currency: summary.summary.currency,
+                value: Number.parseFloat(summary.summary.total_monthly_spend),
+              })}
             </p>
           </div>
           <ArrowUpRight className="size-5 text-white/55" />

--- a/frontend/src/components/providers/auth-provider.tsx
+++ b/frontend/src/components/providers/auth-provider.tsx
@@ -5,7 +5,7 @@ import { createContext, useEffect, useState } from "react";
 
 import { AUTH_STORAGE_KEY } from "@/lib/constants";
 import { apiClient } from "@/lib/api-client";
-import type { AuthResponse, LoginInput, RegisterInput, User } from "@/types";
+import type { AuthResponse, LoginInput, RegisterInput, User, UserUpdateInput } from "@/types";
 
 type AuthContextValue = {
   accessToken: string | null;
@@ -16,6 +16,7 @@ type AuthContextValue = {
   logout: () => void;
   refreshSession: () => Promise<void>;
   register: (input: RegisterInput) => Promise<void>;
+  updateProfile: (input: UserUpdateInput) => Promise<User>;
   user: User | null;
 };
 
@@ -158,6 +159,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     register: async (input: RegisterInput) => {
       const nextSession = await apiClient.register(input);
       applySession(nextSession);
+    },
+    updateProfile: async (input: UserUpdateInput) => {
+      if (!session?.access_token) {
+        throw new Error("You must be signed in to update your profile.");
+      }
+      const user = await apiClient.updateMe(session.access_token, input);
+      setSession((current) => (current ? { ...current, user } : current));
+      return user;
     },
     user: session?.user ?? null,
   };

--- a/frontend/src/components/reports/report-analytics.tsx
+++ b/frontend/src/components/reports/report-analytics.tsx
@@ -32,6 +32,7 @@ const METHOD_COLORS = ["#111418", "#dc5d30", "#d9895d", "#95a6ba", "#cdb28f"];
 
 type ValueTooltipProps = {
   active?: boolean;
+  currency?: string;
   label?: string;
   payload?: Array<{
     color?: string;
@@ -47,7 +48,7 @@ type ReportAnalyticsProps = {
   onRangeChange: (range: AnalyticsRangeKey) => void;
 };
 
-function ValueTooltip({ active, label, payload }: ValueTooltipProps) {
+function ValueTooltip({ active, currency = "USD", label, payload }: ValueTooltipProps) {
   if (!active || !payload?.length) {
     return null;
   }
@@ -66,7 +67,7 @@ function ValueTooltip({ active, label, payload }: ValueTooltipProps) {
               {item.name}
             </span>
             <span className="font-semibold text-ink">
-              {formatCurrency({ value: Number(item.value ?? 0) })}
+              {formatCurrency({ currency, value: Number(item.value ?? 0) })}
             </span>
           </div>
         ))}
@@ -137,6 +138,7 @@ export function ReportAnalytics({
   );
 
   const summary = analytics?.summary;
+  const displayCurrency = summary?.currency ?? "USD";
   const hasObservedSpend = Number(summary?.total_spend ?? 0) > 0;
   const hasProjectedSavings = savingsChartData.length > 0;
   const hasPaymentMix = paymentMethodData.length > 0;
@@ -175,17 +177,19 @@ export function ReportAnalytics({
           <p className="text-xs uppercase tracking-[0.28em] text-white/42">Observed spend</p>
           <CurrencyDisplay
             className="mt-3 block text-3xl font-semibold tracking-tight"
-            currency="USD"
+            currency={displayCurrency}
             value={Number(summary?.total_spend ?? 0)}
           />
-          <p className="mt-3 text-sm text-white/62">{analytics ? analytics.window.label : "Selected window"}</p>
+          <p className="mt-3 text-sm text-white/62">
+            {analytics ? analytics.window.label : "Selected window"} · approx. {displayCurrency}
+          </p>
         </div>
 
         <div className="rounded-[1.5rem] border border-black/10 bg-stone/70 p-5">
           <p className="text-xs uppercase tracking-[0.28em] text-black/42">Average month</p>
           <CurrencyDisplay
             className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
-            currency="USD"
+            currency={displayCurrency}
             value={Number(summary?.average_monthly_spend ?? 0)}
           />
           <p className="mt-3 text-sm text-black/58">Actual spend normalized to the selected window.</p>
@@ -205,7 +209,7 @@ export function ReportAnalytics({
           <p className="text-xs uppercase tracking-[0.28em] text-black/42">Potential savings</p>
           <CurrencyDisplay
             className="mt-3 block text-3xl font-semibold tracking-tight text-ink"
-            currency="USD"
+            currency={displayCurrency}
             value={Number(summary?.projected_range_savings ?? 0)}
           />
           <p className="mt-3 text-sm text-black/58">
@@ -241,7 +245,10 @@ export function ReportAnalytics({
                     tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
                     tickLine={false}
                   />
-                  <Tooltip content={<ValueTooltip />} cursor={{ fill: "rgba(220, 93, 48, 0.08)" }} />
+                  <Tooltip
+                    content={<ValueTooltip currency={displayCurrency} />}
+                    cursor={{ fill: "rgba(220, 93, 48, 0.08)" }}
+                  />
                   {analytics?.trend_categories.map((categoryName, index) => (
                     <Bar
                       dataKey={categoryName}
@@ -291,11 +298,11 @@ export function ReportAnalytics({
                   <YAxis
                     axisLine={false}
                     tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
-                    tickFormatter={(value) => `$${value}`}
+                    tickFormatter={(value) => `${displayCurrency} ${value}`}
                     tickLine={false}
                     width={48}
                   />
-                  <Tooltip content={<ValueTooltip />} />
+                  <Tooltip content={<ValueTooltip currency={displayCurrency} />} />
                   <Line
                     dataKey="total_spend"
                     dot={{ fill: "#dc5d30", r: 4 }}
@@ -341,7 +348,7 @@ export function ReportAnalytics({
                         <Cell fill={entry.color} key={entry.label} />
                       ))}
                     </Pie>
-                    <Tooltip content={<ValueTooltip />} />
+                    <Tooltip content={<ValueTooltip currency={displayCurrency} />} />
                   </PieChart>
                 </ResponsiveContainer>
               ) : (
@@ -365,7 +372,7 @@ export function ReportAnalytics({
                   </div>
                   <CurrencyDisplay
                     className="mt-4 block text-2xl font-semibold tracking-tight text-ink"
-                    currency="USD"
+                    currency={displayCurrency}
                     value={method.total_spend}
                   />
                 </div>
@@ -397,7 +404,7 @@ export function ReportAnalytics({
                   <XAxis
                     axisLine={false}
                     tick={{ fill: "rgba(17,20,24,0.45)", fontSize: 12 }}
-                    tickFormatter={(value) => `$${value}`}
+                    tickFormatter={(value) => `${displayCurrency} ${value}`}
                     tickLine={false}
                     type="number"
                   />
@@ -409,7 +416,10 @@ export function ReportAnalytics({
                     type="category"
                     width={110}
                   />
-                  <Tooltip content={<ValueTooltip />} cursor={{ fill: "rgba(220, 93, 48, 0.08)" }} />
+                  <Tooltip
+                    content={<ValueTooltip currency={displayCurrency} />}
+                    cursor={{ fill: "rgba(220, 93, 48, 0.08)" }}
+                  />
                   <Bar
                     dataKey="projected_range_savings"
                     fill="#111418"
@@ -438,11 +448,14 @@ export function ReportAnalytics({
                   <div className="text-right">
                     <CurrencyDisplay
                       className="block text-xl font-semibold tracking-tight text-ink"
-                      currency="USD"
+                      currency={displayCurrency}
                       value={category.projected_range_savings}
                     />
                     <p className="mt-1 text-xs text-black/52">
-                      {formatCurrency({ value: category.projected_monthly_savings })} per month
+                      {formatCurrency({
+                        currency: displayCurrency,
+                        value: category.projected_monthly_savings,
+                      })} per month
                     </p>
                   </div>
                 </div>
@@ -475,7 +488,10 @@ export function ReportAnalytics({
               <p className="text-xs uppercase tracking-[0.24em] text-white/42">{item.label}</p>
               <p className="mt-3 text-3xl font-semibold tracking-tight">{item.subscription_count}</p>
               <p className="mt-2 text-sm text-white/64">
-                {formatCurrency({ value: Number(item.monthly_equivalent) })} in monthly-equivalent spend
+                {formatCurrency({
+                  currency: displayCurrency,
+                  value: Number(item.monthly_equivalent),
+                })} in monthly-equivalent spend
               </p>
             </div>
           ))}

--- a/frontend/src/components/subscriptions/subscription-card.tsx
+++ b/frontend/src/components/subscriptions/subscription-card.tsx
@@ -89,7 +89,12 @@ export function SubscriptionCard({
               currency={subscription.currency}
               value={Number.isFinite(amount) ? amount : 0}
             />
-            <p className="mt-1 text-sm capitalize text-black/48">{subscription.cadence} billing</p>
+            <div className="mt-2 flex flex-wrap items-center gap-2 md:justify-end">
+              <span className="inline-flex h-7 items-center rounded-full border border-black/10 bg-stone/70 px-2.5 text-xs font-semibold uppercase tracking-[0.2em] text-black/52">
+                {subscription.currency}
+              </span>
+              <span className="text-sm capitalize text-black/48">{subscription.cadence} billing</span>
+            </div>
           </div>
         </div>
 

--- a/frontend/src/components/subscriptions/subscription-form.tsx
+++ b/frontend/src/components/subscriptions/subscription-form.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
+import { supportedCurrencies } from "@/lib/currency";
 import {
   buildSubscriptionFormValues,
   subscriptionCadenceOptions,
@@ -133,13 +134,17 @@ export function SubscriptionForm({
               <label className="text-sm font-medium text-ink" htmlFor="subscription-currency">
                 Currency
               </label>
-              <input
+              <select
                 id="subscription-currency"
                 className="h-12 w-full rounded-[1rem] border border-black/10 bg-white/82 px-4 text-sm uppercase text-ink outline-none transition focus:border-black/20 focus:ring-2 focus:ring-ember/15"
-                maxLength={3}
-                placeholder="USD"
                 {...register("currency")}
-              />
+              >
+                {supportedCurrencies.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.code}
+                  </option>
+                ))}
+              </select>
               {!initialSubscription ? (
                 <p className="text-xs uppercase tracking-[0.24em] text-black/42">
                   Workspace default: {preferredCurrency}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -18,6 +18,7 @@ import type {
   PaymentMethodInput,
   PaymentMethodListResponse,
   RegisterInput,
+  SupportedCurrencyListResponse,
   Subscription,
   SubscriptionFilters,
   SubscriptionListResponse,
@@ -26,6 +27,7 @@ import type {
   Upload,
   UploadListResponse,
   User,
+  UserUpdateInput,
 } from "@/types";
 
 type RequestOptions = {
@@ -164,6 +166,15 @@ export const apiClient = {
   },
   getMe(token: string) {
     return request<User>("/auth/me", undefined, { token });
+  },
+  updateMe(token: string, payload: UserUpdateInput) {
+    return request<User>("/auth/me", {
+      body: JSON.stringify(payload),
+      method: "PATCH",
+    }, { token });
+  },
+  getCurrencies(token: string) {
+    return request<SupportedCurrencyListResponse>("/currencies", undefined, { token });
   },
   login(payload: LoginInput) {
     return request<AuthResponse>("/auth/login", {

--- a/frontend/src/lib/currency.ts
+++ b/frontend/src/lib/currency.ts
@@ -1,0 +1,14 @@
+export const supportedCurrencies = [
+  { code: "USD", name: "US Dollar" },
+  { code: "EUR", name: "Euro" },
+  { code: "GBP", name: "British Pound" },
+  { code: "CAD", name: "Canadian Dollar" },
+  { code: "AUD", name: "Australian Dollar" },
+  { code: "JPY", name: "Japanese Yen" },
+  { code: "INR", name: "Indian Rupee" },
+] as const;
+
+export function getCurrencyName(currency: string) {
+  const normalized = currency.trim().toUpperCase();
+  return supportedCurrencies.find((option) => option.code === normalized)?.name ?? normalized;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,9 +7,15 @@ export type User = {
   id: number;
   email: string;
   full_name: string;
+  preferred_currency: string;
   is_active: boolean;
   created_at: string;
   updated_at: string;
+};
+
+export type UserUpdateInput = {
+  full_name?: string;
+  preferred_currency?: string;
 };
 
 export type LoginInput = {
@@ -74,6 +80,7 @@ export type PaymentMethodInput = {
 
 export type DashboardSummaryStats = {
   total_monthly_spend: string;
+  currency: string;
   active_subscriptions: number;
   upcoming_renewals: number;
   cancelled_subscriptions: number;
@@ -83,6 +90,7 @@ export type DashboardMonthlySpendPoint = {
   month: string;
   label: string;
   total: string;
+  currency: string;
 };
 
 export type DashboardActiveSubscriptionItem = {
@@ -101,6 +109,7 @@ export type DashboardCategoryBreakdownItem = {
   category_name: string;
   subscriptions: number;
   total_monthly_spend: string;
+  currency: string;
 };
 
 export type DashboardUpcomingRenewalItem = {
@@ -216,6 +225,7 @@ export type AnalyticsWindow = {
 export type AnalyticsSummary = {
   total_spend: string;
   average_monthly_spend: string;
+  currency: string;
   active_subscriptions: number;
   projected_monthly_savings: string;
   projected_range_savings: string;
@@ -225,6 +235,7 @@ export type AnalyticsCategoryItem = {
   category_id: number | null;
   category_name: string;
   total_spend: string;
+  currency: string;
   active_subscriptions: number;
   projected_monthly_savings: string;
   projected_range_savings: string;
@@ -235,6 +246,7 @@ export type AnalyticsPaymentMethodItem = {
   payment_method_label: string;
   provider: string | null;
   total_spend: string;
+  currency: string;
   active_subscriptions: number;
 };
 
@@ -243,18 +255,30 @@ export type AnalyticsFrequencyItem = {
   label: string;
   subscription_count: number;
   monthly_equivalent: string;
+  currency: string;
 };
 
 export type AnalyticsTrendCategoryItem = {
   category_name: string;
   total_spend: string;
+  currency: string;
 };
 
 export type AnalyticsTrendPoint = {
   period_start: string;
   label: string;
   total_spend: string;
+  currency: string;
   category_totals: AnalyticsTrendCategoryItem[];
+};
+
+export type SupportedCurrency = {
+  code: string;
+  name: string;
+};
+
+export type SupportedCurrencyListResponse = {
+  items: SupportedCurrency[];
 };
 
 export type ExpenseAnalytics = {

--- a/frontend/tests/e2e/subscriptions.spec.ts
+++ b/frontend/tests/e2e/subscriptions.spec.ts
@@ -24,7 +24,7 @@ test("adds, edits, and deletes a subscription", async ({ page, request }) => {
   await createForm.getByLabel("Subscription name").fill(subscriptionName);
   await createForm.getByLabel("Vendor").fill("Netflix");
   await createForm.getByLabel("Amount", { exact: true }).fill("15.49");
-  await createForm.getByLabel("Currency").fill("USD");
+  await createForm.getByLabel("Currency").selectOption("USD");
   await createForm.getByLabel("Billing day").fill("1");
   await createForm.getByLabel("Start date").fill("2026-01-01");
   await createForm.getByLabel("Next charge date").fill("2026-02-01");

--- a/frontend/tests/unit/components/dashboard-widgets.test.tsx
+++ b/frontend/tests/unit/components/dashboard-widgets.test.tsx
@@ -31,21 +31,23 @@ const fullSummary: DashboardSummary = {
     {
       category_id: 10,
       category_name: "Entertainment",
+      currency: "USD",
       subscriptions: 2,
       total_monthly_spend: "25.98",
     },
     {
       category_id: 11,
       category_name: "Productivity",
+      currency: "USD",
       subscriptions: 1,
       total_monthly_spend: "9.99",
     },
   ],
   monthly_spend: [
-    { label: "Jan", month: "2026-01", total: "0.00" },
-    { label: "Feb", month: "2026-02", total: "0.00" },
-    { label: "Mar", month: "2026-03", total: "59.98" },
-    { label: "Apr", month: "2026-04", total: "86.50" },
+    { currency: "USD", label: "Jan", month: "2026-01", total: "0.00" },
+    { currency: "USD", label: "Feb", month: "2026-02", total: "0.00" },
+    { currency: "USD", label: "Mar", month: "2026-03", total: "59.98" },
+    { currency: "USD", label: "Apr", month: "2026-04", total: "86.50" },
   ],
   recently_ended: [
     {
@@ -60,6 +62,7 @@ const fullSummary: DashboardSummary = {
   summary: {
     active_subscriptions: 2,
     cancelled_subscriptions: 1,
+    currency: "USD",
     total_monthly_spend: "35.97",
     upcoming_renewals: 2,
   },
@@ -89,13 +92,14 @@ const emptySummary: DashboardSummary = {
   active_subscriptions: [],
   category_breakdown: [],
   monthly_spend: [
-    { label: "Jan", month: "2026-01", total: "0.00" },
-    { label: "Feb", month: "2026-02", total: "0.00" },
+    { currency: "USD", label: "Jan", month: "2026-01", total: "0.00" },
+    { currency: "USD", label: "Feb", month: "2026-02", total: "0.00" },
   ],
   recently_ended: [],
   summary: {
     active_subscriptions: 0,
     cancelled_subscriptions: 0,
+    currency: "USD",
     total_monthly_spend: "0.00",
     upcoming_renewals: 0,
   },

--- a/frontend/tests/unit/components/report-analytics.test.tsx
+++ b/frontend/tests/unit/components/report-analytics.test.tsx
@@ -10,6 +10,7 @@ const analytics: ExpenseAnalytics = {
       active_subscriptions: 1,
       category_id: 1,
       category_name: "Utilities",
+      currency: "USD",
       projected_monthly_savings: "30.00",
       projected_range_savings: "180.00",
       total_spend: "90.00",
@@ -18,6 +19,7 @@ const analytics: ExpenseAnalytics = {
       active_subscriptions: 2,
       category_id: 2,
       category_name: "Entertainment",
+      currency: "USD",
       projected_monthly_savings: "25.00",
       projected_range_savings: "150.00",
       total_spend: "40.00",
@@ -26,12 +28,14 @@ const analytics: ExpenseAnalytics = {
   frequency_distribution: [
     {
       cadence: "monthly",
+      currency: "USD",
       label: "Monthly cadence",
       monthly_equivalent: "25.00",
       subscription_count: 2,
     },
     {
       cadence: "quarterly",
+      currency: "USD",
       label: "Quarterly cadence",
       monthly_equivalent: "30.00",
       subscription_count: 1,
@@ -43,6 +47,7 @@ const analytics: ExpenseAnalytics = {
       payment_method_id: 11,
       payment_method_label: "Visa Primary card ending 4242",
       provider: "Visa",
+      currency: "USD",
       total_spend: "150.00",
     },
     {
@@ -50,12 +55,14 @@ const analytics: ExpenseAnalytics = {
       payment_method_id: 12,
       payment_method_label: "Amex Backup card ending 3005",
       provider: "Amex",
+      currency: "USD",
       total_spend: "100.00",
     },
   ],
   summary: {
     active_subscriptions: 4,
     average_monthly_spend: "41.67",
+    currency: "USD",
     projected_monthly_savings: "65.00",
     projected_range_savings: "390.00",
     total_spend: "250.00",
@@ -64,18 +71,20 @@ const analytics: ExpenseAnalytics = {
   trends: [
     {
       category_totals: [
-        { category_name: "Utilities", total_spend: "90.00" },
-        { category_name: "Entertainment", total_spend: "15.00" },
+        { category_name: "Utilities", currency: "USD", total_spend: "90.00" },
+        { category_name: "Entertainment", currency: "USD", total_spend: "15.00" },
       ],
+      currency: "USD",
       label: "Mar",
       period_start: "2026-03-01",
       total_spend: "105.00",
     },
     {
       category_totals: [
-        { category_name: "Utilities", total_spend: "0.00" },
-        { category_name: "Entertainment", total_spend: "25.00" },
+        { category_name: "Utilities", currency: "USD", total_spend: "0.00" },
+        { category_name: "Entertainment", currency: "USD", total_spend: "25.00" },
       ],
+      currency: "USD",
       label: "Apr",
       period_start: "2026-04-01",
       total_spend: "25.00",

--- a/frontend/tests/unit/components/snapshot-bar.test.tsx
+++ b/frontend/tests/unit/components/snapshot-bar.test.tsx
@@ -10,6 +10,7 @@ describe("SnapshotBar", () => {
         summary={{
           active_subscriptions: 12,
           cancelled_subscriptions: 3,
+          currency: "USD",
           total_monthly_spend: "245.99",
           upcoming_renewals: 7,
         }}

--- a/frontend/tests/unit/hooks/use-auth.test.ts
+++ b/frontend/tests/unit/hooks/use-auth.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/lib/api-client", () => ({
     login: vi.fn(),
     refresh: vi.fn(),
     register: vi.fn(),
+    updateMe: vi.fn(),
   },
 }));
 
@@ -26,6 +27,7 @@ const buildSession = (overrides: Partial<AuthResponse> = {}) => ({
     id: 1,
     email: "owner@example.com",
     full_name: "Owner One",
+    preferred_currency: "USD",
     is_active: true,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),

--- a/frontend/tests/unit/lib/api-client.test.ts
+++ b/frontend/tests/unit/lib/api-client.test.ts
@@ -43,6 +43,7 @@ describe("apiClient", () => {
             id: 1,
             email: "owner@example.com",
             full_name: "Owner One",
+            preferred_currency: "USD",
             is_active: true,
             created_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),


### PR DESCRIPTION
# Day 20 Complete

Implemented and pushed `day-20/multi-currency-support` through `938a3ea` with 37 per-file commits. GitHub issues `#75`, `#76`, and umbrella `#74` are commented and closed, and milestone 20 is closed with `open_issues = 0`.

## Verification

Verification passed:

- Lockfile guard
- Backend pytest / ruff / mypy
- Frontend unit tests / lint / build / typecheck

No blockers remain; next scheduled target is **Day 21** — `day-21/notification-system`.

---

## CI Fix — Automation Worktree

Fixed the CI failure in the automation worktree on `day-20/multi-currency-support`.

Changed [`[subscriptions.spec.ts](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/tests/e2e/subscriptions.spec.ts#L27)`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/tests/e2e/subscriptions.spec.ts#L27) so the `Currency` `<select>` uses Playwright's `selectOption("USD")` instead of `.fill("USD")`.

### Verification

- `npm run test:e2e -- subscriptions.spec.ts` passed: **4/4**
- `npm run test:e2e` passed: **40/40**

Existing untracked `backend/.venv` and `frontend/node_modules` were left untouched.# Day 20 Complete

Implemented and pushed `day-20/multi-currency-support` through `938a3ea` with 37 per-file commits. GitHub issues `#75`, `#76`, and umbrella `#74` are commented and closed, and milestone 20 is closed with `open_issues = 0`.

## Verification

Verification passed:

- Lockfile guard
- Backend pytest / ruff / mypy
- Frontend unit tests / lint / build / typecheck

No blockers remain; next scheduled target is **Day 21** — `day-21/notification-system`.

---

## CI Fix — Automation Worktree

Fixed the CI failure in the automation worktree on `day-20/multi-currency-support`.

Changed [`[subscriptions.spec.ts](https://claude.ai/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/tests/e2e/subscriptions.spec.ts#L27)`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/tests/e2e/subscriptions.spec.ts#L27) so the `Currency` `<select>` uses Playwright's `selectOption("USD")` instead of `.fill("USD")`.

### Verification

- `npm run test:e2e -- subscriptions.spec.ts` passed: **4/4**
- `npm run test:e2e` passed: **40/40**

Existing untracked `backend/.venv` and `frontend/node_modules` were left untouched.