### PR TITLE
Day 22/subscription score duplicates

### DIFF
--- a/backend/src/api/routes/dashboard.py
+++ b/backend/src/api/routes/dashboard.py
@@ -11,11 +11,13 @@ from src.schemas.dashboard import (
     DashboardLayoutUpdate,
     DashboardSummaryResponse,
 )
+from src.schemas.score import SubscriptionScoreResponse
 from src.services.dashboard import (
     get_dashboard_layout,
     get_dashboard_summary,
     update_dashboard_layout,
 )
+from src.services.score import get_subscription_score
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 DbSession = Annotated[AsyncSession, Depends(get_db)]
@@ -33,6 +35,19 @@ async def get_dashboard_summary_route(
     current_user: CurrentUser,
 ) -> DashboardSummaryResponse:
     return await get_dashboard_summary(session, user=current_user)
+
+
+@router.get(
+    "/score",
+    response_model=SubscriptionScoreResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the subscription score and duplicate candidates",
+)
+async def get_dashboard_score_route(
+    session: DbSession,
+    current_user: CurrentUser,
+) -> SubscriptionScoreResponse:
+    return await get_subscription_score(session, user=current_user)
 
 
 @router.get(

--- a/backend/src/schemas/dashboard.py
+++ b/backend/src/schemas/dashboard.py
@@ -5,21 +5,27 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 DASHBOARD_WIDGET_IDS = (
+    "subscription-score",
     "active-subscriptions",
     "monthly-spend",
     "category-breakdown",
     "upcoming-renewals",
     "recently-ended",
+    "duplicate-alerts",
 )
 
 DashboardWidgetId = Literal[
+    "subscription-score",
     "active-subscriptions",
     "monthly-spend",
     "category-breakdown",
     "upcoming-renewals",
     "recently-ended",
+    "duplicate-alerts",
 ]
 DashboardColumn = Literal["primary", "secondary"]
+DashboardScoreBand = Literal["excellent", "steady", "attention", "at-risk"]
+DuplicateConfidence = Literal["high", "medium"]
 
 
 class DashboardSummaryStats(BaseModel):
@@ -75,6 +81,29 @@ class DashboardRecentlyEndedItem(BaseModel):
     end_date: date
 
 
+class DashboardScoreOverview(BaseModel):
+    score: int
+    grade: str
+    band: DashboardScoreBand
+    recommendation_count: int
+    duplicate_candidates: int
+    potential_monthly_savings: Decimal
+    currency: str
+
+
+class DashboardDuplicateAlertItem(BaseModel):
+    left_subscription_id: int
+    left_name: str
+    left_vendor: str
+    right_subscription_id: int
+    right_name: str
+    right_vendor: str
+    shared_signal: str
+    confidence: DuplicateConfidence
+    potential_monthly_savings: Decimal
+    currency: str
+
+
 class DashboardSummaryResponse(BaseModel):
     summary: DashboardSummaryStats
     active_subscriptions: list[DashboardActiveSubscriptionItem]
@@ -82,6 +111,8 @@ class DashboardSummaryResponse(BaseModel):
     category_breakdown: list[DashboardCategoryBreakdownItem]
     upcoming_renewals: list[DashboardUpcomingRenewalItem]
     recently_ended: list[DashboardRecentlyEndedItem]
+    score_overview: DashboardScoreOverview | None = None
+    duplicate_alerts: list[DashboardDuplicateAlertItem] = []
 
 
 class DashboardLayoutWidget(BaseModel):

--- a/backend/src/schemas/score.py
+++ b/backend/src/schemas/score.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel
+
+ScoreBand = Literal["excellent", "steady", "attention", "at-risk"]
+RecommendationPriority = Literal["high", "medium", "low"]
+DuplicateConfidence = Literal["high", "medium"]
+
+
+class SubscriptionScoreBreakdownItem(BaseModel):
+    id: Literal["coverage", "renewal", "context", "waste"]
+    label: str
+    detail: str
+    score: int
+    max_score: int
+
+
+class SubscriptionScoreRecommendation(BaseModel):
+    title: str
+    description: str
+    priority: RecommendationPriority
+    action_label: str | None = None
+    action_href: str | None = None
+    subscriptions_affected: int | None = None
+    potential_monthly_savings: Decimal | None = None
+    currency: str | None = None
+
+
+class SubscriptionDuplicateCandidate(BaseModel):
+    left_subscription_id: int
+    left_name: str
+    left_vendor: str
+    right_subscription_id: int
+    right_name: str
+    right_vendor: str
+    shared_signal: str
+    confidence: DuplicateConfidence
+    potential_monthly_savings: Decimal
+    currency: str
+
+
+class SubscriptionScoreResponse(BaseModel):
+    score: int
+    grade: str
+    band: ScoreBand
+    active_subscription_count: int
+    potential_monthly_savings: Decimal
+    currency: str
+    breakdown: list[SubscriptionScoreBreakdownItem]
+    recommendations: list[SubscriptionScoreRecommendation]
+    duplicate_candidates: list[SubscriptionDuplicateCandidate]

--- a/backend/src/services/dashboard.py
+++ b/backend/src/services/dashboard.py
@@ -1,5 +1,6 @@
 from datetime import UTC, date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
+from typing import Literal, cast
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,16 +14,23 @@ from src.models.user import User
 from src.schemas.dashboard import (
     DashboardActiveSubscriptionItem,
     DashboardCategoryBreakdownItem,
+    DashboardDuplicateAlertItem,
     DashboardLayoutResponse,
     DashboardLayoutUpdate,
     DashboardLayoutWidget,
     DashboardMonthlySpendPoint,
     DashboardRecentlyEndedItem,
+    DashboardScoreOverview,
     DashboardSummaryResponse,
     DashboardSummaryStats,
     DashboardUpcomingRenewalItem,
 )
 from src.services.currency import convert
+from src.services.score import (
+    build_score_overview,
+    get_subscription_score,
+    summarize_duplicate_alerts,
+)
 
 logger = get_logger(__name__)
 
@@ -32,13 +40,17 @@ MONTHLY_SPEND_MONTHS = 6
 
 DEFAULT_DASHBOARD_LAYOUT = DashboardLayoutUpdate(
     widgets=[
+        DashboardLayoutWidget(id="subscription-score", column="primary"),
         DashboardLayoutWidget(id="active-subscriptions", column="primary"),
         DashboardLayoutWidget(id="monthly-spend", column="primary"),
-        DashboardLayoutWidget(id="recently-ended", column="primary"),
+        DashboardLayoutWidget(id="duplicate-alerts", column="secondary"),
         DashboardLayoutWidget(id="category-breakdown", column="secondary"),
         DashboardLayoutWidget(id="upcoming-renewals", column="secondary"),
+        DashboardLayoutWidget(id="recently-ended", column="primary"),
     ]
 )
+
+DEFAULT_WIDGET_BY_ID = {widget.id: widget for widget in DEFAULT_DASHBOARD_LAYOUT.widgets}
 
 
 def _quantize_money(value: Decimal) -> Decimal:
@@ -81,6 +93,41 @@ def _shift_months(value: date, offset: int) -> date:
     year = month_index // 12
     month = month_index % 12 + 1
     return date(year, month, 1)
+
+
+def _normalize_layout_widgets(raw_layout: object) -> list[DashboardLayoutWidget]:
+    widgets_payload = raw_layout.get("widgets", []) if isinstance(raw_layout, dict) else []
+    normalized: list[DashboardLayoutWidget] = []
+    seen_ids: set[str] = set()
+
+    for widget in widgets_payload:
+        if not isinstance(widget, dict):
+            continue
+
+        widget_id = widget.get("id")
+        column = widget.get("column")
+        if (
+            not isinstance(widget_id, str)
+            or not isinstance(column, str)
+            or widget_id in seen_ids
+            or widget_id not in DEFAULT_WIDGET_BY_ID
+            or column not in {"primary", "secondary"}
+        ):
+            continue
+
+        normalized.append(
+            DashboardLayoutWidget(
+                id=widget_id,
+                column=cast(Literal["primary", "secondary"], column),
+            )
+        )
+        seen_ids.add(widget_id)
+
+    for default_widget in DEFAULT_DASHBOARD_LAYOUT.widgets:
+        if default_widget.id not in seen_ids:
+            normalized.append(default_widget)
+
+    return normalized
 
 
 async def get_dashboard_summary(
@@ -149,9 +196,7 @@ async def get_dashboard_summary(
             target_currency=target_currency,
         )
 
-    total_monthly_spend = _quantize_money(
-        sum(monthly_equivalents.values(), Decimal("0.00"))
-    )
+    total_monthly_spend = _quantize_money(sum(monthly_equivalents.values(), Decimal("0.00")))
 
     category_totals: dict[tuple[int | None, str], dict[str, Decimal | int]] = {}
     for subscription in active_subscriptions:
@@ -238,6 +283,12 @@ async def get_dashboard_summary(
         )
         for point in month_points
     ]
+    score_payload = await get_subscription_score(session, user=user)
+    score_overview = DashboardScoreOverview.model_validate(build_score_overview(score_payload))
+    duplicate_alerts = [
+        DashboardDuplicateAlertItem.model_validate(candidate.model_dump())
+        for candidate in summarize_duplicate_alerts(score_payload.duplicate_candidates, limit=3)
+    ]
 
     response = DashboardSummaryResponse(
         summary=DashboardSummaryStats(
@@ -316,6 +367,8 @@ async def get_dashboard_summary(
             for subscription in recently_ended[:6]
             if subscription.end_date is not None
         ],
+        score_overview=score_overview,
+        duplicate_alerts=duplicate_alerts,
     )
     logger.info(
         "dashboard.summary.loaded",
@@ -339,8 +392,9 @@ async def get_dashboard_layout(
             updated_at=None,
         )
 
+    widgets = _normalize_layout_widgets(layout.layout)
     return DashboardLayoutResponse(
-        widgets=DashboardLayoutUpdate.model_validate(layout.layout).widgets,
+        widgets=widgets,
         version=layout.version,
         updated_at=layout.updated_at,
     )

--- a/backend/src/services/score.py
+++ b/backend/src/services/score.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import re
+from decimal import ROUND_HALF_UP, Decimal
+from itertools import combinations
+from typing import Any
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.subscription import Subscription
+from src.models.user import User
+from src.schemas.score import (
+    ScoreBand,
+    SubscriptionDuplicateCandidate,
+    SubscriptionScoreBreakdownItem,
+    SubscriptionScoreRecommendation,
+    SubscriptionScoreResponse,
+)
+from src.services.currency import convert
+
+STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "app",
+    "basic",
+    "co",
+    "company",
+    "for",
+    "inc",
+    "ltd",
+    "plan",
+    "premium",
+    "pro",
+    "service",
+    "services",
+    "subscription",
+    "suite",
+    "the",
+}
+MONTHLY_SCORE_WEIGHT = 25
+
+
+def _quantize_money(value: Decimal) -> Decimal:
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _round_score(value: float) -> int:
+    return max(0, min(MONTHLY_SCORE_WEIGHT, int(round(value))))
+
+
+def _get_user_currency(user: User) -> str:
+    return (user.preferred_currency or "USD").strip().upper()
+
+
+def _normalize_tokens(*parts: str | None) -> set[str]:
+    tokens = re.findall(r"[a-z0-9]+", " ".join(part or "" for part in parts).lower())
+    return {token for token in tokens if len(token) > 1 and token not in STOP_WORDS}
+
+
+def _normalize_vendor(value: str | None) -> str:
+    return " ".join(sorted(_normalize_tokens(value)))
+
+
+def _normalize_host(value: str | None) -> str | None:
+    if not value:
+        return None
+
+    host = urlparse(value).netloc.lower().removeprefix("www.").strip()
+    return host or None
+
+
+def _token_similarity(left: set[str], right: set[str]) -> float:
+    if not left or not right:
+        return 0.0
+
+    union = left | right
+    if not union:
+        return 0.0
+
+    return len(left & right) / len(union)
+
+
+async def _monthly_equivalent(
+    session: AsyncSession,
+    subscription: Subscription,
+    *,
+    target_currency: str,
+) -> Decimal:
+    cadence = subscription.cadence.lower()
+    amount = await convert(
+        session,
+        Decimal(subscription.amount),
+        from_currency=subscription.currency,
+        to_currency=target_currency,
+    )
+
+    if cadence == "weekly":
+        return _quantize_money((amount * Decimal(52)) / Decimal(12))
+    if cadence == "quarterly":
+        return _quantize_money(amount / Decimal(3))
+    if cadence == "yearly":
+        return _quantize_money(amount / Decimal(12))
+    return _quantize_money(amount)
+
+
+def _grade(score: int) -> tuple[str, ScoreBand]:
+    if score >= 90:
+        return ("A", "excellent")
+    if score >= 80:
+        return ("B", "steady")
+    if score >= 65:
+        return ("C", "attention")
+    if score >= 50:
+        return ("D", "attention")
+    return ("F", "at-risk")
+
+
+async def _build_duplicate_candidates(
+    session: AsyncSession,
+    subscriptions: list[Subscription],
+    *,
+    target_currency: str,
+) -> list[SubscriptionDuplicateCandidate]:
+    if len(subscriptions) < 2:
+        return []
+
+    monthly_equivalents = {
+        subscription.id: await _monthly_equivalent(
+            session,
+            subscription,
+            target_currency=target_currency,
+        )
+        for subscription in subscriptions
+    }
+
+    candidates: list[tuple[float, SubscriptionDuplicateCandidate]] = []
+
+    for left, right in combinations(subscriptions, 2):
+        left_tokens = _normalize_tokens(left.vendor, left.name)
+        right_tokens = _normalize_tokens(right.vendor, right.name)
+        token_similarity = _token_similarity(left_tokens, right_tokens)
+        left_vendor = _normalize_vendor(left.vendor)
+        right_vendor = _normalize_vendor(right.vendor)
+        left_host = _normalize_host(left.website_url)
+        right_host = _normalize_host(right.website_url)
+        vendor_match = left_vendor == right_vendor and bool(left_vendor)
+        host_match = left_host == right_host and bool(left_host)
+        same_category = left.category_id is not None and left.category_id == right.category_id
+
+        confidence = 0.0
+        reasons: list[str] = []
+        if vendor_match:
+            confidence += 0.5
+            reasons.append("matching vendor")
+        if host_match:
+            confidence += 0.3
+            reasons.append("shared website")
+        if same_category:
+            confidence += 0.2
+            reasons.append("same category")
+        if token_similarity >= 0.75:
+            confidence += 0.2
+            reasons.append("nearly identical naming")
+        elif token_similarity >= 0.6:
+            confidence += 0.1
+            reasons.append("overlapping naming")
+
+        if confidence < 0.6:
+            continue
+
+        signal = reasons[0] if reasons else "similar billing profile"
+        savings = _quantize_money(min(monthly_equivalents[left.id], monthly_equivalents[right.id]))
+        candidates.append(
+            (
+                confidence,
+                SubscriptionDuplicateCandidate(
+                    left_subscription_id=left.id,
+                    left_name=left.name,
+                    left_vendor=left.vendor,
+                    right_subscription_id=right.id,
+                    right_name=right.name,
+                    right_vendor=right.vendor,
+                    shared_signal=signal,
+                    confidence="high" if confidence >= 0.8 else "medium",
+                    potential_monthly_savings=savings,
+                    currency=target_currency,
+                ),
+            )
+        )
+
+    candidates.sort(
+        key=lambda item: (
+            item[0],
+            item[1].potential_monthly_savings,
+            -item[1].left_subscription_id,
+            -item[1].right_subscription_id,
+        ),
+        reverse=True,
+    )
+    return [candidate for _, candidate in candidates]
+
+
+def _non_overlapping_duplicate_savings(
+    candidates: list[SubscriptionDuplicateCandidate],
+) -> Decimal:
+    total = Decimal("0.00")
+    seen_subscription_ids: set[int] = set()
+
+    for candidate in candidates:
+        pair = {candidate.left_subscription_id, candidate.right_subscription_id}
+        if pair & seen_subscription_ids:
+            continue
+
+        total += Decimal(candidate.potential_monthly_savings)
+        seen_subscription_ids.update(pair)
+
+    return _quantize_money(total)
+
+
+def _build_breakdown(
+    subscriptions: list[Subscription],
+    duplicate_candidates: list[SubscriptionDuplicateCandidate],
+    *,
+    total_monthly_spend: Decimal,
+) -> list[SubscriptionScoreBreakdownItem]:
+    total = len(subscriptions)
+    if total == 0:
+        return [
+            SubscriptionScoreBreakdownItem(
+                id="coverage",
+                label="Coverage",
+                detail="No active subscriptions are available to score yet.",
+                score=0,
+                max_score=MONTHLY_SCORE_WEIGHT,
+            ),
+            SubscriptionScoreBreakdownItem(
+                id="renewal",
+                label="Renewal readiness",
+                detail="Add an active subscription to start tracking charge cadence.",
+                score=0,
+                max_score=MONTHLY_SCORE_WEIGHT,
+            ),
+            SubscriptionScoreBreakdownItem(
+                id="context",
+                label="Context",
+                detail="Profile links and notes unlock better recommendations once plans exist.",
+                score=0,
+                max_score=MONTHLY_SCORE_WEIGHT,
+            ),
+            SubscriptionScoreBreakdownItem(
+                id="waste",
+                label="Waste control",
+                detail="Duplicate detection activates once at least two active plans are present.",
+                score=0,
+                max_score=MONTHLY_SCORE_WEIGHT,
+            ),
+        ]
+
+    categorized = sum(1 for subscription in subscriptions if subscription.category_id is not None)
+    billed = sum(1 for subscription in subscriptions if subscription.payment_method_id is not None)
+    renewal_dates = sum(
+        1 for subscription in subscriptions if subscription.next_charge_date is not None
+    )
+    monthly_with_anchor = sum(
+        1
+        for subscription in subscriptions
+        if subscription.cadence != "monthly"
+        or subscription.day_of_month is not None
+        or subscription.next_charge_date is not None
+    )
+    linked = sum(1 for subscription in subscriptions if subscription.website_url)
+    documented = sum(
+        1 for subscription in subscriptions if subscription.description or subscription.notes
+    )
+
+    coverage_score = _round_score(
+        (((categorized / total) + (billed / total)) / 2) * MONTHLY_SCORE_WEIGHT
+    )
+    renewal_score = _round_score(
+        (((renewal_dates / total) + (monthly_with_anchor / total)) / 2) * MONTHLY_SCORE_WEIGHT
+    )
+    context_score = _round_score(
+        (((linked / total) + (documented / total)) / 2) * MONTHLY_SCORE_WEIGHT
+    )
+
+    duplicate_penalty_ratio = 0.0
+    duplicate_savings = _non_overlapping_duplicate_savings(duplicate_candidates)
+    if total_monthly_spend > 0:
+        duplicate_penalty_ratio = min(
+            0.85,
+            (len(duplicate_candidates) / max(1, total - 1)) * 0.55
+            + float((duplicate_savings / total_monthly_spend) * Decimal("0.45")),
+        )
+    elif duplicate_candidates:
+        duplicate_penalty_ratio = min(0.85, len(duplicate_candidates) * 0.3)
+    waste_score = _round_score((1 - duplicate_penalty_ratio) * MONTHLY_SCORE_WEIGHT)
+
+    return [
+        SubscriptionScoreBreakdownItem(
+            id="coverage",
+            label="Coverage",
+            detail=(
+                f"{categorized}/{total} categorized and "
+                f"{billed}/{total} mapped to a payment method."
+            ),
+            score=coverage_score,
+            max_score=MONTHLY_SCORE_WEIGHT,
+        ),
+        SubscriptionScoreBreakdownItem(
+            id="renewal",
+            label="Renewal readiness",
+            detail=(
+                f"{renewal_dates}/{total} with renewal dates and "
+                f"{monthly_with_anchor}/{total} with a monthly anchor."
+            ),
+            score=renewal_score,
+            max_score=MONTHLY_SCORE_WEIGHT,
+        ),
+        SubscriptionScoreBreakdownItem(
+            id="context",
+            label="Context",
+            detail=(
+                f"{linked}/{total} linked back to a service URL and "
+                f"{documented}/{total} carrying notes or descriptions."
+            ),
+            score=context_score,
+            max_score=MONTHLY_SCORE_WEIGHT,
+        ),
+        SubscriptionScoreBreakdownItem(
+            id="waste",
+            label="Waste control",
+            detail=(
+                "No strong overlap pairs are active right now."
+                if not duplicate_candidates
+                else (
+                    f"{len(duplicate_candidates)} overlap pair(s) could free about "
+                    f"{duplicate_savings} {duplicate_candidates[0].currency}/mo."
+                )
+            ),
+            score=waste_score,
+            max_score=MONTHLY_SCORE_WEIGHT,
+        ),
+    ]
+
+
+def _build_recommendations(
+    subscriptions: list[Subscription],
+    duplicate_candidates: list[SubscriptionDuplicateCandidate],
+    *,
+    currency: str,
+) -> list[SubscriptionScoreRecommendation]:
+    total = len(subscriptions)
+    if total == 0:
+        return [
+            SubscriptionScoreRecommendation(
+                title="Add an active subscription",
+                description=(
+                    "The score starts once at least one live subscription exists in the "
+                    "workspace."
+                ),
+                priority="high",
+                action_label="Open subscriptions",
+                action_href="/subscriptions",
+            )
+        ]
+
+    missing_category = sum(1 for subscription in subscriptions if subscription.category_id is None)
+    missing_payment_method = sum(
+        1 for subscription in subscriptions if subscription.payment_method_id is None
+    )
+    missing_renewal_date = sum(
+        1 for subscription in subscriptions if subscription.next_charge_date is None
+    )
+    missing_context = sum(
+        1
+        for subscription in subscriptions
+        if not subscription.website_url and not subscription.description and not subscription.notes
+    )
+
+    recommendations: list[tuple[int, SubscriptionScoreRecommendation]] = []
+
+    if duplicate_candidates:
+        recommendations.append(
+            (
+                0,
+                SubscriptionScoreRecommendation(
+                    title="Resolve duplicate candidates",
+                    description=(
+                        f"{len(duplicate_candidates)} overlap pair(s) are active and could "
+                        "be merged or downgraded."
+                    ),
+                    priority="high",
+                    action_label="Open score page",
+                    action_href="/score",
+                    subscriptions_affected=len(
+                        {candidate.left_subscription_id for candidate in duplicate_candidates}
+                        | {candidate.right_subscription_id for candidate in duplicate_candidates}
+                    ),
+                    potential_monthly_savings=_non_overlapping_duplicate_savings(
+                        duplicate_candidates
+                    ),
+                    currency=currency,
+                ),
+            )
+        )
+
+    if missing_payment_method:
+        recommendations.append(
+            (
+                1,
+                SubscriptionScoreRecommendation(
+                    title="Attach payment rails",
+                    description=(
+                        f"{missing_payment_method} active subscription(s) are missing a "
+                        "payment method, which weakens renewal visibility."
+                    ),
+                    priority="high",
+                    action_label="Open subscriptions",
+                    action_href="/subscriptions",
+                    subscriptions_affected=missing_payment_method,
+                ),
+            )
+        )
+
+    if missing_renewal_date:
+        recommendations.append(
+            (
+                2,
+                SubscriptionScoreRecommendation(
+                    title="Fill in renewal dates",
+                    description=(
+                        f"{missing_renewal_date} active subscription(s) still lack a next "
+                        "charge date or anchor."
+                    ),
+                    priority="high",
+                    action_label="Review subscriptions",
+                    action_href="/subscriptions",
+                    subscriptions_affected=missing_renewal_date,
+                ),
+            )
+        )
+
+    if missing_category:
+        recommendations.append(
+            (
+                3,
+                SubscriptionScoreRecommendation(
+                    title="Categorize uncoded plans",
+                    description=(
+                        f"{missing_category} active subscription(s) are still uncategorized, "
+                        "which reduces dashboard and duplicate clarity."
+                    ),
+                    priority="medium",
+                    action_label="Open settings",
+                    action_href="/settings",
+                    subscriptions_affected=missing_category,
+                ),
+            )
+        )
+
+    if missing_context:
+        recommendations.append(
+            (
+                4,
+                SubscriptionScoreRecommendation(
+                    title="Add service context",
+                    description=(
+                        f"{missing_context} active subscription(s) are missing URLs, notes, "
+                        "and descriptions that help future cleanup."
+                    ),
+                    priority="medium",
+                    action_label="Review subscriptions",
+                    action_href="/subscriptions",
+                    subscriptions_affected=missing_context,
+                ),
+            )
+        )
+
+    if not recommendations:
+        recommendations.append(
+            (
+                5,
+                SubscriptionScoreRecommendation(
+                    title="Keep the score steady",
+                    description=(
+                        "The active portfolio is well linked, scheduled, and free of strong "
+                        "duplicate signals."
+                    ),
+                    priority="low",
+                    action_label="Open dashboard",
+                    action_href="/dashboard",
+                ),
+            )
+        )
+
+    recommendations.sort(key=lambda item: item[0])
+    return [recommendation for _, recommendation in recommendations[:4]]
+
+
+async def get_subscription_score(
+    session: AsyncSession,
+    *,
+    user: User,
+) -> SubscriptionScoreResponse:
+    target_currency = _get_user_currency(user)
+    subscriptions = list(
+        (
+            await session.scalars(
+                select(Subscription)
+                .where(Subscription.user_id == user.id, Subscription.status == "active")
+                .order_by(Subscription.id.asc())
+            )
+        ).all()
+    )
+
+    monthly_equivalents = [
+        await _monthly_equivalent(session, subscription, target_currency=target_currency)
+        for subscription in subscriptions
+    ]
+    total_monthly_spend = _quantize_money(sum(monthly_equivalents, Decimal("0.00")))
+    duplicate_candidates = await _build_duplicate_candidates(
+        session,
+        subscriptions,
+        target_currency=target_currency,
+    )
+    breakdown = _build_breakdown(
+        subscriptions,
+        duplicate_candidates,
+        total_monthly_spend=total_monthly_spend,
+    )
+    score = sum(item.score for item in breakdown)
+    grade, band = _grade(score)
+    recommendations = _build_recommendations(
+        subscriptions,
+        duplicate_candidates,
+        currency=target_currency,
+    )
+
+    return SubscriptionScoreResponse(
+        score=score,
+        grade=grade,
+        band=band,
+        active_subscription_count=len(subscriptions),
+        potential_monthly_savings=_non_overlapping_duplicate_savings(duplicate_candidates),
+        currency=target_currency,
+        breakdown=breakdown,
+        recommendations=recommendations,
+        duplicate_candidates=duplicate_candidates[:6],
+    )
+
+
+def summarize_duplicate_alerts(
+    candidates: list[SubscriptionDuplicateCandidate],
+    *,
+    limit: int,
+) -> list[SubscriptionDuplicateCandidate]:
+    return candidates[:limit]
+
+
+def build_score_overview(score_payload: SubscriptionScoreResponse) -> dict[str, Any]:
+    return {
+        "score": score_payload.score,
+        "grade": score_payload.grade,
+        "band": score_payload.band,
+        "recommendation_count": len(score_payload.recommendations),
+        "duplicate_candidates": len(score_payload.duplicate_candidates),
+        "potential_monthly_savings": score_payload.potential_monthly_savings,
+        "currency": score_payload.currency,
+    }

--- a/backend/tests/api/test_dashboard.py
+++ b/backend/tests/api/test_dashboard.py
@@ -56,13 +56,17 @@ def _create_subscription(
     end_date: str | None = None,
     payment_method_id: int | None = None,
     currency: str = "USD",
+    vendor: str | None = None,
+    website_url: str | None = None,
+    description: str | None = None,
+    notes: str | None = None,
 ) -> int:
     response = client.post(
         "/api/v1/subscriptions",
         headers=headers,
         json={
             "name": name,
-            "vendor": name,
+            "vendor": vendor or name,
             "amount": amount,
             "currency": currency,
             "cadence": cadence,
@@ -72,6 +76,9 @@ def _create_subscription(
             "next_charge_date": next_charge_date,
             "end_date": end_date,
             "payment_method_id": payment_method_id,
+            "website_url": website_url,
+            "description": description,
+            "notes": notes,
         },
     )
     assert response.status_code == 201
@@ -232,15 +239,27 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
     month_map = {item["month"]: item["total"] for item in payload["monthly_spend"]}
     assert month_map[current_month_start.strftime("%Y-%m")] == "135.00"
     assert month_map[previous_month.strftime("%Y-%m")] == "15.00"
+    assert payload["score_overview"] == {
+        "score": 75,
+        "grade": "C",
+        "band": "attention",
+        "recommendation_count": 1,
+        "duplicate_candidates": 0,
+        "potential_monthly_savings": "0.00",
+        "currency": "USD",
+    }
+    assert payload["duplicate_alerts"] == []
 
     layout_response = client.get("/api/v1/dashboard/layout", headers=owner_headers)
     assert layout_response.status_code == 200
     assert layout_response.json()["widgets"] == [
+        {"id": "subscription-score", "column": "primary"},
         {"id": "active-subscriptions", "column": "primary"},
         {"id": "monthly-spend", "column": "primary"},
-        {"id": "recently-ended", "column": "primary"},
+        {"id": "duplicate-alerts", "column": "secondary"},
         {"id": "category-breakdown", "column": "secondary"},
         {"id": "upcoming-renewals", "column": "secondary"},
+        {"id": "recently-ended", "column": "primary"},
     ]
 
     update_response = client.put(
@@ -248,9 +267,11 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
         headers=owner_headers,
         json={
             "widgets": [
+                {"id": "subscription-score", "column": "primary"},
                 {"id": "active-subscriptions", "column": "primary"},
                 {"id": "upcoming-renewals", "column": "primary"},
                 {"id": "monthly-spend", "column": "primary"},
+                {"id": "duplicate-alerts", "column": "secondary"},
                 {"id": "category-breakdown", "column": "secondary"},
                 {"id": "recently-ended", "column": "secondary"},
             ]
@@ -258,18 +279,18 @@ def test_dashboard_summary_and_layout_persistence(client) -> None:
     )
     assert update_response.status_code == 200
     assert update_response.json()["version"] == 1
-    assert update_response.json()["widgets"][1]["id"] == "upcoming-renewals"
+    assert update_response.json()["widgets"][2]["id"] == "upcoming-renewals"
 
     persisted_layout_response = client.get("/api/v1/dashboard/layout", headers=owner_headers)
     assert persisted_layout_response.status_code == 200
-    assert persisted_layout_response.json()["widgets"][1] == {
+    assert persisted_layout_response.json()["widgets"][2] == {
         "id": "upcoming-renewals",
         "column": "primary",
     }
 
     other_layout_response = client.get("/api/v1/dashboard/layout", headers=other_headers)
     assert other_layout_response.status_code == 200
-    assert other_layout_response.json()["widgets"][0]["id"] == "active-subscriptions"
+    assert other_layout_response.json()["widgets"][0]["id"] == "subscription-score"
 
 
 def test_dashboard_layout_requires_each_widget_exactly_once(client) -> None:
@@ -280,9 +301,11 @@ def test_dashboard_layout_requires_each_widget_exactly_once(client) -> None:
         headers=headers,
         json={
             "widgets": [
+                {"id": "subscription-score", "column": "primary"},
                 {"id": "active-subscriptions", "column": "primary"},
                 {"id": "monthly-spend", "column": "primary"},
                 {"id": "monthly-spend", "column": "secondary"},
+                {"id": "duplicate-alerts", "column": "secondary"},
                 {"id": "upcoming-renewals", "column": "secondary"},
                 {"id": "recently-ended", "column": "primary"},
             ]
@@ -332,3 +355,76 @@ def test_dashboard_summary_converts_workspace_totals_to_preferred_currency(clien
         "total": "18.00",
         "currency": "EUR",
     }
+
+
+def test_dashboard_score_route_surfaces_duplicates_and_recommendations(client) -> None:
+    today = date.today()
+    headers = _auth_headers(client, "score-dashboard@example.com")
+    entertainment_id = _create_category(client, headers, "Entertainment")
+    payment_method_id = _create_payment_method(client, headers)
+
+    _create_subscription(
+        client,
+        headers,
+        name="Netflix Standard",
+        vendor="Netflix",
+        amount="15.00",
+        cadence="monthly",
+        status="active",
+        start_date=str(today - timedelta(days=120)),
+        category_id=entertainment_id,
+        next_charge_date=str(today + timedelta(days=5)),
+        payment_method_id=payment_method_id,
+        website_url="https://www.netflix.com",
+        description="Primary streaming plan",
+    )
+    _create_subscription(
+        client,
+        headers,
+        name="Netflix Mobile",
+        vendor="Netflix",
+        amount="8.00",
+        cadence="monthly",
+        status="active",
+        start_date=str(today - timedelta(days=60)),
+        website_url="https://www.netflix.com/mobile",
+    )
+    _create_subscription(
+        client,
+        headers,
+        name="Notion",
+        vendor="Notion",
+        amount="12.00",
+        cadence="monthly",
+        status="active",
+        start_date=str(today - timedelta(days=40)),
+        next_charge_date=str(today + timedelta(days=12)),
+        notes="Used for docs",
+    )
+
+    response = client.get("/api/v1/dashboard/score", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["score"] == 58
+    assert payload["grade"] == "D"
+    assert payload["band"] == "attention"
+    assert payload["active_subscription_count"] == 3
+    assert payload["potential_monthly_savings"] == "8.00"
+    assert payload["currency"] == "USD"
+    assert [item["id"] for item in payload["breakdown"]] == [
+        "coverage",
+        "renewal",
+        "context",
+        "waste",
+    ]
+    assert payload["duplicate_candidates"][0]["left_vendor"] == "Netflix"
+    assert payload["duplicate_candidates"][0]["right_vendor"] == "Netflix"
+    assert payload["duplicate_candidates"][0]["shared_signal"] == "matching vendor"
+    assert payload["duplicate_candidates"][0]["potential_monthly_savings"] == "8.00"
+    assert [item["title"] for item in payload["recommendations"]] == [
+        "Resolve duplicate candidates",
+        "Attach payment rails",
+        "Fill in renewal dates",
+        "Categorize uncoded plans",
+    ]

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { startTransition, useMemo } from "react";
-import { ArrowRight, Activity, LayoutTemplate } from "lucide-react";
+import { ArrowRight, Activity, Gauge, LayoutTemplate } from "lucide-react";
 
 import { WorkspaceOnboarding } from "@/components/onboarding/workspace-onboarding";
 import { SnapshotBar } from "@/components/dashboard/snapshot-bar";
@@ -53,14 +53,14 @@ export default function DashboardPage() {
         action={
           showOnboarding ? undefined : (
             <Button asChild className="rounded-full px-5" variant="outline">
-              <Link href="/subscriptions">
-                Open subscriptions
+              <Link href="/score">
+                Open score
                 <ArrowRight className="ml-2 size-4" />
               </Link>
             </Button>
           )
         }
-        description="Operate from a live dashboard where five persistent widgets keep spend, renewals, category mix, and subscription churn in one working surface."
+        description="Operate from a live dashboard where score, duplicate risk, renewals, category mix, and spend all stay visible in one working surface."
         eyebrow="Dashboard workspace"
         title="Smart dashboard workspace"
       />
@@ -97,7 +97,7 @@ export default function DashboardPage() {
               <div className="rounded-[1.35rem] border border-white/10 bg-white/6 p-4">
                 <p className="text-xs uppercase tracking-[0.24em] text-white/42">Data freshness</p>
                 <p className="mt-2 text-sm leading-6 text-white/68">
-                  Upload history feeds the spend curve, while subscription records keep category, renewal, and churn widgets grounded.
+                  Upload history feeds the spend curve, while subscription records keep score, duplicate alerts, renewal, and churn widgets grounded.
                 </p>
               </div>
             </div>
@@ -113,6 +113,12 @@ export default function DashboardPage() {
             </p>
 
             <div className="mt-5 space-y-3">
+              <Button asChild className="w-full rounded-full" variant="outline">
+                <Link href="/score">
+                  Open subscription score
+                  <Gauge className="ml-2 size-4" />
+                </Link>
+              </Button>
               <Button asChild className="w-full rounded-full" variant="outline">
                 <Link href="/uploads">
                   Open uploads

--- a/frontend/src/app/(app)/score/page.tsx
+++ b/frontend/src/app/(app)/score/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, Gauge, LoaderCircle, ShieldAlert, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { CurrencyDisplay } from "@/components/ui/currency-display";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/ui/page-header";
+import { useDashboardScore } from "@/hooks/use-dashboard";
+import { cn } from "@/lib/utils";
+import type { DashboardScoreBand } from "@/types";
+
+function formatBandLabel(value: DashboardScoreBand) {
+  if (value === "excellent") {
+    return "Excellent";
+  }
+  if (value === "steady") {
+    return "Steady";
+  }
+  if (value === "attention") {
+    return "Needs attention";
+  }
+  return "At risk";
+}
+
+function GaugeRing({ score }: { score: number }) {
+  const circumference = 2 * Math.PI * 82;
+  const progress = Math.max(0, Math.min(100, score));
+  const strokeDashoffset = circumference - (progress / 100) * circumference;
+
+  return (
+    <div className="relative flex size-56 items-center justify-center">
+      <svg className="-rotate-90" height="224" viewBox="0 0 224 224" width="224">
+        <circle
+          cx="112"
+          cy="112"
+          fill="none"
+          r="82"
+          stroke="rgba(255,255,255,0.12)"
+          strokeWidth="18"
+        />
+        <circle
+          cx="112"
+          cy="112"
+          fill="none"
+          r="82"
+          stroke="#dc5d30"
+          strokeDasharray={circumference}
+          strokeDashoffset={strokeDashoffset}
+          strokeLinecap="round"
+          strokeWidth="18"
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <p className="text-6xl font-semibold tracking-tight text-white">{score}</p>
+        <p className="mt-2 text-sm uppercase tracking-[0.32em] text-white/48">Current score</p>
+      </div>
+    </div>
+  );
+}
+
+export default function ScorePage() {
+  const scoreQuery = useDashboardScore();
+  const score = scoreQuery.data;
+
+  if (scoreQuery.isLoading && !score) {
+    return (
+      <div className="space-y-8 animate-page-enter">
+        <PageHeader
+          description="Loading the latest score, duplicate watchlist, and recommended cleanup moves."
+          eyebrow="Subscription score"
+          title="Portfolio health"
+        />
+        <div className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-8">
+          <div className="flex items-center gap-3 text-sm text-black/58">
+            <LoaderCircle className="size-4 animate-spin" />
+            Loading subscription score...
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!score || score.active_subscription_count === 0) {
+    return (
+      <div className="space-y-8 animate-page-enter">
+        <PageHeader
+          action={
+            <Button asChild className="rounded-full px-5" variant="outline">
+              <Link href="/subscriptions">
+                Open subscriptions
+                <ArrowRight className="ml-2 size-4" />
+              </Link>
+            </Button>
+          }
+          description="The score activates after the workspace has at least one live subscription to inspect."
+          eyebrow="Subscription score"
+          title="Portfolio health"
+        />
+        <EmptyState
+          action={
+            <Button asChild className="rounded-full px-5" variant="outline">
+              <Link href="/subscriptions">Add the first subscription</Link>
+            </Button>
+          }
+          description="Once active plans exist, this page will grade coverage, renewal readiness, context, and duplicate risk."
+          icon={<Gauge className="size-5" />}
+          title="No active subscriptions to score yet"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8 animate-page-enter">
+      <PageHeader
+        action={
+          <Button asChild className="rounded-full px-5" variant="outline">
+            <Link href="/subscriptions">
+              Review subscriptions
+              <ArrowRight className="ml-2 size-4" />
+            </Link>
+          </Button>
+        }
+        description="Grade the live subscription portfolio, surface the sharpest duplicate overlaps, and keep the next cleanup action explicit."
+        eyebrow="Subscription score"
+        title="Portfolio health"
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.18fr)_360px]">
+        <section className="space-y-6">
+          <section className="rounded-[2rem] border border-white/10 bg-[#101922] p-6 text-white shadow-[0_24px_80px_rgba(17,20,24,0.22)] sm:p-8">
+            <div className="grid gap-6 lg:grid-cols-[minmax(240px,0.82fr)_minmax(0,1.18fr)] lg:items-center">
+              <div className="flex justify-center lg:justify-start">
+                <GaugeRing score={score.score} />
+              </div>
+
+              <div className="space-y-5">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.32em] text-white/45">Overall grade</p>
+                  <h2 className="mt-3 text-4xl font-semibold tracking-tight">
+                    {score.grade} · {formatBandLabel(score.band)}
+                  </h2>
+                  <p className="mt-3 max-w-xl text-sm leading-6 text-white/68">
+                    The score blends portfolio coverage, renewal readiness, service context, and duplicate pressure across the current active subscriptions.
+                  </p>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-[1.35rem] border border-white/10 bg-white/6 px-4 py-4">
+                    <p className="text-xs uppercase tracking-[0.24em] text-white/42">Active plans</p>
+                    <p className="mt-3 text-2xl font-semibold tracking-tight">{score.active_subscription_count}</p>
+                  </div>
+                  <div className="rounded-[1.35rem] border border-white/10 bg-white/6 px-4 py-4">
+                    <p className="text-xs uppercase tracking-[0.24em] text-white/42">Potential savings</p>
+                    <CurrencyDisplay
+                      className="mt-3 block text-2xl font-semibold tracking-tight"
+                      currency={score.currency}
+                      value={Number.parseFloat(score.potential_monthly_savings)}
+                    />
+                  </div>
+                  <div className="rounded-[1.35rem] border border-white/10 bg-white/6 px-4 py-4">
+                    <p className="text-xs uppercase tracking-[0.24em] text-white/42">Duplicate candidates</p>
+                    <p className="mt-3 text-2xl font-semibold tracking-tight">{score.duplicate_candidates.length}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+            <div className="flex flex-col gap-3 border-b border-black/10 pb-5 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.32em] text-black/45">Breakdown</p>
+                <h3 className="mt-2 text-2xl font-semibold tracking-tight text-ink">Where the score is moving</h3>
+              </div>
+              <p className="max-w-xl text-sm leading-6 text-black/58">
+                Each lane contributes up to 25 points so cleanup effort stays comparable instead of vague.
+              </p>
+            </div>
+
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              {score.breakdown.map((item) => {
+                const progress = `${(item.score / item.max_score) * 100}%`;
+
+                return (
+                  <div className="rounded-[1.45rem] border border-black/10 bg-white/80 p-5" key={item.id}>
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.28em] text-black/42">{item.label}</p>
+                        <p className="mt-3 text-sm leading-6 text-black/58">{item.detail}</p>
+                      </div>
+                      <div className="rounded-full border border-black/10 bg-stone/70 px-3 py-2 text-sm font-semibold text-ink">
+                        {item.score}/{item.max_score}
+                      </div>
+                    </div>
+                    <div className="mt-4 h-2 overflow-hidden rounded-full bg-black/8">
+                      <div className="h-full rounded-full bg-[#dc5d30]" style={{ width: progress }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+            <div className="flex items-center gap-3">
+              <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+                <Sparkles className="size-5" />
+              </span>
+              <div>
+                <p className="text-xs uppercase tracking-[0.28em] text-black/42">Recommendations</p>
+                <h3 className="mt-1 text-2xl font-semibold tracking-tight text-ink">Next actions</h3>
+              </div>
+            </div>
+
+            <div className="mt-5 space-y-3">
+              {score.recommendations.map((item) => (
+                <div className="rounded-[1.45rem] border border-black/10 bg-white/84 p-5" key={item.title}>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-lg font-semibold text-ink">{item.title}</p>
+                        <span
+                          className={cn(
+                            "rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em]",
+                            item.priority === "high"
+                              ? "bg-[#101922] text-white"
+                              : item.priority === "medium"
+                                ? "bg-stone text-ink"
+                                : "bg-black/6 text-black/58",
+                          )}
+                        >
+                          {item.priority}
+                        </span>
+                      </div>
+                      <p className="mt-3 max-w-2xl text-sm leading-6 text-black/58">{item.description}</p>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                      {item.potential_monthly_savings ? (
+                        <div className="rounded-full border border-black/10 bg-stone/70 px-4 py-2 text-sm text-ink">
+                          <CurrencyDisplay
+                            className="font-semibold"
+                            currency={item.currency ?? score.currency}
+                            value={Number.parseFloat(item.potential_monthly_savings)}
+                          />
+                        </div>
+                      ) : null}
+                      {item.action_href && item.action_label ? (
+                        <Button asChild className="rounded-full px-4" size="sm" variant="outline">
+                          <Link href={item.action_href}>{item.action_label}</Link>
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </section>
+
+        <aside className="space-y-5">
+          <section className="rounded-[2rem] border border-black/10 bg-white/76 p-6 shadow-line backdrop-blur sm:p-7">
+            <div className="flex items-center gap-3">
+              <span className="inline-flex size-11 items-center justify-center rounded-[1rem] border border-black/10 bg-stone text-ink">
+                <ShieldAlert className="size-5" />
+              </span>
+              <div>
+                <p className="text-xs uppercase tracking-[0.28em] text-black/42">Duplicate watchlist</p>
+                <h3 className="mt-1 text-2xl font-semibold tracking-tight text-ink">Possible overlap pairs</h3>
+              </div>
+            </div>
+
+            <div className="mt-5 space-y-3">
+              {score.duplicate_candidates.length === 0 ? (
+                <div className="rounded-[1.45rem] border border-dashed border-black/12 bg-white/70 p-5 text-sm leading-6 text-black/58">
+                  No strong overlap pairs are active right now. The waste-control lane will stay high until duplicate pressure returns.
+                </div>
+              ) : (
+                score.duplicate_candidates.map((item) => (
+                  <div
+                    className="rounded-[1.45rem] border border-black/10 bg-white/84 p-5"
+                    key={`${item.left_subscription_id}-${item.right_subscription_id}`}
+                  >
+                    <p className="text-base font-semibold text-ink">
+                      {item.left_name} + {item.right_name}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-black/58">
+                      {item.left_vendor} · {item.shared_signal} · {item.confidence} confidence
+                    </p>
+                    <CurrencyDisplay
+                      className="mt-4 block text-xl font-semibold tracking-tight text-ink"
+                      currency={item.currency}
+                      value={Number.parseFloat(item.potential_monthly_savings)}
+                    />
+                    <p className="mt-1 text-xs uppercase tracking-[0.24em] text-black/42">
+                      Potential monthly savings
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-[2rem] border border-white/10 bg-[#101922] p-6 text-white shadow-[0_24px_80px_rgba(17,20,24,0.22)] sm:p-7">
+            <p className="text-xs uppercase tracking-[0.3em] text-white/42">How to read it</p>
+            <p className="mt-4 text-sm leading-6 text-white/68">
+              Coverage and renewal lanes reward clean billing metadata. Context rewards service URLs and notes. Waste control stays high when duplicate overlap is low.
+            </p>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/app-shell/app-shell.tsx
+++ b/frontend/src/components/app-shell/app-shell.tsx
@@ -106,6 +106,11 @@ const routeMeta: Record<string, { description: string; searchPlaceholder: string
     searchPlaceholder: "Search reports, upload names, merchants, categories",
     title: "Reports",
   },
+  "/score": {
+    description: "Subscription score, duplicate overlap candidates, and the next cleanup actions.",
+    searchPlaceholder: "Search score recommendations, duplicate candidates, renewal gaps",
+    title: "Subscription score",
+  },
   "/payments": {
     description: "Billing rails, cards, and fallback payment methods live here.",
     searchPlaceholder: "Search cards, billing fallback, payment health",
@@ -154,7 +159,7 @@ export function AppShell({ children }: AppShellProps) {
   const meta =
     Object.entries(routeMeta).find(([href]) => isActivePath(pathname, href))?.[1] ??
     routeMeta["/dashboard"];
-  const currentNavItem = navItems.find((item) => isActivePath(pathname, item.href)) ?? navItems[0];
+  const currentNavItem = navItems.find((item) => isActivePath(pathname, item.href));
   const displayName = user?.full_name || user?.email?.split("@")[0] || "Workspace operator";
 
   const handleSignOut = () => {
@@ -272,7 +277,7 @@ export function AppShell({ children }: AppShellProps) {
             <div className="flex h-20 items-center gap-4 px-4 sm:px-6 lg:px-8">
               <div className="min-w-0 flex-1">
                 <p className="text-xs uppercase tracking-[0.32em] text-black/45">
-                  {currentNavItem.label}
+                  {currentNavItem?.label ?? meta.title}
                 </p>
                 <h1
                   className="mt-1 truncate text-2xl font-semibold text-ink sm:text-3xl"

--- a/frontend/src/components/dashboard/widget-board.tsx
+++ b/frontend/src/components/dashboard/widget-board.tsx
@@ -153,7 +153,7 @@ export function DashboardWidgetBoard({
           <p className="text-xs uppercase tracking-[0.32em] text-black/45">Widget workspace</p>
           <h2 className="text-2xl font-semibold tracking-tight text-ink">Drag the dashboard into focus</h2>
           <p className="max-w-2xl text-sm leading-6 text-black/62">
-            The board holds five live widgets, each tuned for a specific operating question instead of a generic dashboard card.
+            The board holds seven live widgets, each tuned for a specific operating question instead of a generic dashboard card.
           </p>
         </div>
 

--- a/frontend/src/components/dashboard/widget-library.tsx
+++ b/frontend/src/components/dashboard/widget-library.tsx
@@ -8,14 +8,16 @@ import {
   CalendarClock,
   Donut,
   FolderClock,
+  Gauge,
   Layers3,
+  ShieldAlert,
 } from "lucide-react";
 import { Bar, BarChart, CartesianGrid, Cell, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis } from "recharts";
 
 import { Button } from "@/components/ui/button";
 import { CurrencyDisplay, formatCurrency } from "@/components/ui/currency-display";
 import { cn } from "@/lib/utils";
-import type { DashboardSummary, DashboardWidgetId } from "@/types";
+import type { DashboardScoreBand, DashboardSummary, DashboardWidgetId } from "@/types";
 
 import { WidgetContainer } from "./widget-container";
 
@@ -30,6 +32,13 @@ type WidgetMeta = {
 const CATEGORY_COLORS = ["#111418", "#dc5d30", "#d9895d", "#95a6ba", "#cdb28f"];
 
 export const dashboardWidgetMeta: Record<DashboardWidgetId, WidgetMeta> = {
+  "subscription-score": {
+    description: "A portfolio score that blends coverage, renewal readiness, context, and duplicate risk.",
+    desktopHeight: 4,
+    emptyText: "Add active subscriptions to start tracking the score and cleanup queue.",
+    eyebrow: "Score pulse",
+    title: "Subscription score",
+  },
   "active-subscriptions": {
     description: "Live roster of the subscriptions currently shaping monthly spend.",
     desktopHeight: 4,
@@ -57,6 +66,13 @@ export const dashboardWidgetMeta: Record<DashboardWidgetId, WidgetMeta> = {
     emptyText: "Cancelled subscriptions with end dates will show up here.",
     eyebrow: "Closed recently",
     title: "Recently ended",
+  },
+  "duplicate-alerts": {
+    description: "Possible overlap pairs ranked by confidence so duplicate spend can be cleaned up fast.",
+    desktopHeight: 4,
+    emptyText: "Duplicate alerts appear when two active plans look like overlapping services.",
+    eyebrow: "Overlap watch",
+    title: "Duplicate alerts",
   },
   "upcoming-renewals": {
     description: "Charges due soon, ordered by urgency so the next move is obvious.",
@@ -140,6 +156,190 @@ function ChartTooltip({
           value: payload[0]?.payload?.total ?? 0,
         })}
       </p>
+    </div>
+  );
+}
+
+function formatBandLabel(value: DashboardScoreBand) {
+  if (value === "excellent") {
+    return "Excellent";
+  }
+  if (value === "steady") {
+    return "Steady";
+  }
+  if (value === "attention") {
+    return "Needs attention";
+  }
+  return "At risk";
+}
+
+function ScoreWidget({ summary }: { summary: DashboardSummary }) {
+  const score = summary.score_overview;
+
+  if (!score || summary.summary.active_subscriptions === 0) {
+    return (
+      <WidgetEmptyState
+        ctaHref="/subscriptions"
+        ctaLabel="Add subscriptions"
+        icon={<Gauge className="size-5" />}
+        text={dashboardWidgetMeta["subscription-score"].emptyText}
+      />
+    );
+  }
+
+  const circumference = 2 * Math.PI * 52;
+  const progress = Math.max(0, Math.min(100, score.score));
+  const strokeDashoffset = circumference - (progress / 100) * circumference;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(210px,0.78fr)_minmax(0,1.22fr)]">
+      <div className="rounded-[1.5rem] bg-[#101922] p-5 text-white shadow-[0_18px_60px_rgba(17,20,24,0.22)]">
+        <p className="text-xs uppercase tracking-[0.28em] text-white/45">Current score</p>
+        <div className="mt-5 flex items-center justify-center">
+          <div className="relative flex size-36 items-center justify-center">
+            <svg className="-rotate-90" height="136" viewBox="0 0 136 136" width="136">
+              <circle
+                cx="68"
+                cy="68"
+                fill="none"
+                r="52"
+                stroke="rgba(255,255,255,0.12)"
+                strokeWidth="12"
+              />
+              <circle
+                cx="68"
+                cy="68"
+                fill="none"
+                r="52"
+                stroke="#dc5d30"
+                strokeDasharray={circumference}
+                strokeDashoffset={strokeDashoffset}
+                strokeLinecap="round"
+                strokeWidth="12"
+              />
+            </svg>
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <p className="text-4xl font-semibold tracking-tight">{score.score}</p>
+              <p className="mt-1 text-sm uppercase tracking-[0.28em] text-white/48">{score.grade} grade</p>
+            </div>
+          </div>
+        </div>
+        <p className="mt-4 text-sm leading-6 text-white/68">
+          {formatBandLabel(score.band)} with {score.recommendation_count} recommended cleanup move
+          {score.recommendation_count === 1 ? "" : "s"} queued.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-[1.35rem] border border-black/10 bg-white/68 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-black/42">Duplicate savings</p>
+            <CurrencyDisplay
+              className="mt-3 block text-2xl font-semibold tracking-tight text-ink"
+              currency={score.currency}
+              value={Number.parseFloat(score.potential_monthly_savings)}
+            />
+            <p className="mt-1 text-sm text-black/58">
+              {score.duplicate_candidates} overlap candidate{score.duplicate_candidates === 1 ? "" : "s"}
+            </p>
+          </div>
+          <div className="rounded-[1.35rem] border border-black/10 bg-white/68 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-black/42">Action queue</p>
+            <p className="mt-3 text-2xl font-semibold tracking-tight text-ink">{score.recommendation_count}</p>
+            <p className="mt-1 text-sm text-black/58">Recommendations are ready on the full score page.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {summary.summary.active_subscriptions > 0 ? (
+            <>
+              <div className="rounded-[1.35rem] border border-black/10 bg-stone/70 px-4 py-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-black/42">Score band</p>
+                <p className="mt-3 text-lg font-semibold text-ink">{formatBandLabel(score.band)}</p>
+                <p className="mt-1 text-sm text-black/58">Coverage, context, renewals, and waste control.</p>
+              </div>
+              <div className="rounded-[1.35rem] border border-black/10 bg-stone/70 px-4 py-4">
+                <p className="text-xs uppercase tracking-[0.24em] text-black/42">Next move</p>
+                <p className="mt-3 text-lg font-semibold text-ink">
+                  {score.recommendation_count > 0 ? "Open score page" : "Score is stable"}
+                </p>
+                <p className="mt-1 text-sm text-black/58">Review the full breakdown and recommendation stack.</p>
+              </div>
+            </>
+          ) : null}
+        </div>
+
+        <Button asChild className="rounded-full px-4" size="sm" variant="outline">
+          <Link href="/score">Open score page</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function DuplicateAlertsWidget({ summary }: { summary: DashboardSummary }) {
+  const items = summary.duplicate_alerts.slice(0, 3);
+  const score = summary.score_overview;
+
+  if (items.length === 0) {
+    return (
+      <WidgetEmptyState
+        ctaHref="/score"
+        ctaLabel="Review score"
+        icon={<ShieldAlert className="size-5" />}
+        text={dashboardWidgetMeta["duplicate-alerts"].emptyText}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-[1.5rem] bg-[#101922] p-5 text-white shadow-[0_18px_60px_rgba(17,20,24,0.22)]">
+        <p className="text-xs uppercase tracking-[0.28em] text-white/45">Potential monthly savings</p>
+        <CurrencyDisplay
+          className="mt-3 block text-3xl font-semibold tracking-tight"
+          currency={score?.currency ?? items[0].currency}
+          value={Number.parseFloat(score?.potential_monthly_savings ?? items[0].potential_monthly_savings)}
+        />
+        <p className="mt-2 text-sm leading-6 text-white/68">
+          {score?.duplicate_candidates ?? items.length} duplicate candidate
+          {(score?.duplicate_candidates ?? items.length) === 1 ? "" : "s"} are active right now.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {items.map((item) => (
+          <div
+            className="rounded-[1.35rem] border border-black/10 bg-white/68 px-4 py-4"
+            key={`${item.left_subscription_id}-${item.right_subscription_id}`}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="truncate text-base font-semibold text-ink">
+                  {item.left_name} + {item.right_name}
+                </p>
+                <p className="mt-1 text-sm text-black/58">
+                  {item.left_vendor} · {item.shared_signal}
+                </p>
+              </div>
+              <div className="text-right">
+                <CurrencyDisplay
+                  className="text-base font-semibold text-ink"
+                  currency={item.currency}
+                  value={Number.parseFloat(item.potential_monthly_savings)}
+                />
+                <p className="mt-1 text-xs uppercase tracking-[0.24em] text-black/42">
+                  {item.confidence} confidence
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Button asChild className="rounded-full px-4" size="sm" variant="outline">
+        <Link href="/score">Review duplicates</Link>
+      </Button>
     </div>
   );
 }
@@ -429,6 +629,8 @@ function RecentlyEndedWidget({ summary }: { summary: DashboardSummary }) {
 
 function renderWidgetBody(widgetId: DashboardWidgetId, summary: DashboardSummary) {
   switch (widgetId) {
+    case "subscription-score":
+      return <ScoreWidget summary={summary} />;
     case "active-subscriptions":
       return <ActiveSubscriptionsWidget summary={summary} />;
     case "monthly-spend":
@@ -439,6 +641,8 @@ function renderWidgetBody(widgetId: DashboardWidgetId, summary: DashboardSummary
       return <UpcomingRenewalsWidget summary={summary} />;
     case "recently-ended":
       return <RecentlyEndedWidget summary={summary} />;
+    case "duplicate-alerts":
+      return <DuplicateAlertsWidget summary={summary} />;
     default:
       return null;
   }

--- a/frontend/src/hooks/use-dashboard.ts
+++ b/frontend/src/hooks/use-dashboard.ts
@@ -9,6 +9,7 @@ import type { DashboardLayoutPayload, DashboardLayoutWidget } from "@/types";
 
 const dashboardKeys = {
   layout: ["dashboard", "layout"] as const,
+  score: ["dashboard", "score"] as const,
   summary: ["dashboard", "summary"] as const,
 };
 
@@ -36,6 +37,18 @@ export function useDashboardSummary() {
     queryFn: () => apiClient.getDashboardSummary(accessToken!),
     placeholderData: (previousData) => previousData,
     queryKey: dashboardKeys.summary,
+    staleTime: 30_000,
+  });
+}
+
+export function useDashboardScore() {
+  const { accessToken } = useAuth();
+
+  return useQuery({
+    enabled: Boolean(accessToken),
+    queryFn: () => apiClient.getDashboardScore(accessToken!),
+    placeholderData: (previousData) => previousData,
+    queryKey: dashboardKeys.score,
     staleTime: 30_000,
   });
 }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -26,6 +26,7 @@ import type {
   SubscriptionFilters,
   SubscriptionListResponse,
   SubscriptionPaymentHistory,
+  SubscriptionScore,
   SubscriptionUpsertInput,
   TelegramLinkTokenResponse,
   Upload,
@@ -240,6 +241,9 @@ export const apiClient = {
   },
   getDashboardSummary(token: string) {
     return request<DashboardSummary>("/dashboard/summary", undefined, { token });
+  },
+  getDashboardScore(token: string) {
+    return request<SubscriptionScore>("/dashboard/score", undefined, { token });
   },
   getDashboardLayout(token: string) {
     return request<DashboardLayout>("/dashboard/layout", undefined, { token });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -131,6 +131,32 @@ export type DashboardRecentlyEndedItem = {
   end_date: string;
 };
 
+export type DashboardScoreBand = "excellent" | "steady" | "attention" | "at-risk";
+export type DuplicateConfidence = "high" | "medium";
+
+export type DashboardScoreOverview = {
+  score: number;
+  grade: string;
+  band: DashboardScoreBand;
+  recommendation_count: number;
+  duplicate_candidates: number;
+  potential_monthly_savings: string;
+  currency: string;
+};
+
+export type DashboardDuplicateAlertItem = {
+  left_subscription_id: number;
+  left_name: string;
+  left_vendor: string;
+  right_subscription_id: number;
+  right_name: string;
+  right_vendor: string;
+  shared_signal: string;
+  confidence: DuplicateConfidence;
+  potential_monthly_savings: string;
+  currency: string;
+};
+
 export type DashboardSummary = {
   summary: DashboardSummaryStats;
   active_subscriptions: DashboardActiveSubscriptionItem[];
@@ -138,14 +164,18 @@ export type DashboardSummary = {
   category_breakdown: DashboardCategoryBreakdownItem[];
   upcoming_renewals: DashboardUpcomingRenewalItem[];
   recently_ended: DashboardRecentlyEndedItem[];
+  score_overview: DashboardScoreOverview | null;
+  duplicate_alerts: DashboardDuplicateAlertItem[];
 };
 
 export type DashboardWidgetId =
+  | "subscription-score"
   | "active-subscriptions"
   | "monthly-spend"
   | "category-breakdown"
   | "upcoming-renewals"
-  | "recently-ended";
+  | "recently-ended"
+  | "duplicate-alerts";
 export type DashboardLayoutColumn = "primary" | "secondary";
 
 export type DashboardLayoutWidget = {
@@ -160,6 +190,50 @@ export type DashboardLayoutPayload = {
 export type DashboardLayout = DashboardLayoutPayload & {
   version: number;
   updated_at: string | null;
+};
+
+export type SubscriptionScoreBreakdownItem = {
+  id: "coverage" | "renewal" | "context" | "waste";
+  label: string;
+  detail: string;
+  score: number;
+  max_score: number;
+};
+
+export type SubscriptionScoreRecommendation = {
+  title: string;
+  description: string;
+  priority: "high" | "medium" | "low";
+  action_label: string | null;
+  action_href: string | null;
+  subscriptions_affected: number | null;
+  potential_monthly_savings: string | null;
+  currency: string | null;
+};
+
+export type SubscriptionDuplicateCandidate = {
+  left_subscription_id: number;
+  left_name: string;
+  left_vendor: string;
+  right_subscription_id: number;
+  right_name: string;
+  right_vendor: string;
+  shared_signal: string;
+  confidence: DuplicateConfidence;
+  potential_monthly_savings: string;
+  currency: string;
+};
+
+export type SubscriptionScore = {
+  score: number;
+  grade: string;
+  band: DashboardScoreBand;
+  active_subscription_count: number;
+  potential_monthly_savings: string;
+  currency: string;
+  breakdown: SubscriptionScoreBreakdownItem[];
+  recommendations: SubscriptionScoreRecommendation[];
+  duplicate_candidates: SubscriptionDuplicateCandidate[];
 };
 
 export type ExpenseReportCategoryBreakdownItem = {

--- a/frontend/tests/unit/components/dashboard-widgets.test.tsx
+++ b/frontend/tests/unit/components/dashboard-widgets.test.tsx
@@ -49,6 +49,20 @@ const fullSummary: DashboardSummary = {
     { currency: "USD", label: "Mar", month: "2026-03", total: "59.98" },
     { currency: "USD", label: "Apr", month: "2026-04", total: "86.50" },
   ],
+  duplicate_alerts: [
+    {
+      confidence: "high",
+      currency: "USD",
+      left_name: "Netflix Standard",
+      left_subscription_id: 10,
+      left_vendor: "Netflix",
+      potential_monthly_savings: "8.99",
+      right_name: "Netflix Mobile",
+      right_subscription_id: 11,
+      right_vendor: "Netflix",
+      shared_signal: "matching vendor",
+    },
+  ],
   recently_ended: [
     {
       amount: "12.99",
@@ -65,6 +79,15 @@ const fullSummary: DashboardSummary = {
     currency: "USD",
     total_monthly_spend: "35.97",
     upcoming_renewals: 2,
+  },
+  score_overview: {
+    band: "attention",
+    currency: "USD",
+    duplicate_candidates: 1,
+    grade: "C",
+    potential_monthly_savings: "8.99",
+    recommendation_count: 2,
+    score: 74,
   },
   upcoming_renewals: [
     {
@@ -91,11 +114,13 @@ const fullSummary: DashboardSummary = {
 const emptySummary: DashboardSummary = {
   active_subscriptions: [],
   category_breakdown: [],
+  duplicate_alerts: [],
   monthly_spend: [
     { currency: "USD", label: "Jan", month: "2026-01", total: "0.00" },
     { currency: "USD", label: "Feb", month: "2026-02", total: "0.00" },
   ],
   recently_ended: [],
+  score_overview: null,
   summary: {
     active_subscriptions: 0,
     cancelled_subscriptions: 0,
@@ -110,11 +135,13 @@ describe("DashboardWidgetCard", () => {
   it.each<
     [DashboardWidgetId, string, DashboardSummary, string]
   >([
+    ["subscription-score", "Subscription score", fullSummary, "Current score"],
     ["active-subscriptions", "Active subscriptions", fullSummary, "Netflix"],
     ["monthly-spend", "Monthly spend", fullSummary, "Latest recorded month"],
     ["category-breakdown", "Category breakdown", fullSummary, "Entertainment"],
     ["upcoming-renewals", "Upcoming renewals", fullSummary, "3 days"],
     ["recently-ended", "Recently ended", fullSummary, "Headspace"],
+    ["duplicate-alerts", "Duplicate alerts", fullSummary, "Netflix Standard + Netflix Mobile"],
   ])("renders %s with live data", (widgetId, title, summary, detailText) => {
     render(
       <div style={{ width: 720 }}>
@@ -129,11 +156,13 @@ describe("DashboardWidgetCard", () => {
   it.each<
     [DashboardWidgetId, string]
   >([
+    ["subscription-score", "Add active subscriptions to start tracking the score and cleanup queue."],
     ["active-subscriptions", "Add subscriptions or import statement data to populate the active roster."],
     ["monthly-spend", "Upload statement history to start plotting monthly spend."],
     ["category-breakdown", "Categorize active subscriptions to unlock the category breakdown."],
     ["upcoming-renewals", "Upcoming renewal dates will appear once active plans have charge schedules."],
     ["recently-ended", "Cancelled subscriptions with end dates will show up here."],
+    ["duplicate-alerts", "Duplicate alerts appear when two active plans look like overlapping services."],
   ])("shows the empty state for %s", (widgetId, emptyText) => {
     render(
       <div style={{ width: 720 }}>


### PR DESCRIPTION
Day 22 is complete on `day-22/subscription-score-duplicates` and pushed to origin at `ebb3261`. Backend now exposes the score/duplicate API in [`/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/services/score.py`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/services/score.py), the dashboard summary carries score overview plus duplicate alerts with legacy layout normalization in [`/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/services/dashboard.py`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/src/services/dashboard.py), and frontend adds the new score workspace at [`/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/app/(app)/score/page.tsx`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/app/(app)/score/page.tsx) plus the two new dashboard widgets in [`/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/components/dashboard/widget-library.tsx`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/src/components/dashboard/widget-library.tsx).

Verification passed with `lockfile-guard.sh`, `backend/.venv/bin/pytest backend/tests`, `backend/.venv/bin/ruff check backend/src backend/tests`, `backend/.venv/bin/mypy backend/src`, `npm test`, `npm run lint`, `npm run build`, and the follow-up `npm run typecheck`. GitHub write-back succeeded: issues `#81`, `#82`, and `#80` are commented and closed, milestone 22 is closed, and there are no blockers. The next scheduled run should advance to Day 23 on `day-23/family-sharing-view`.

::inbox-item{title="Day 22 score shipped" summary="Milestone 22 closed; next run should start Day 23"}