### PR TITLE
Day 29/documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,150 @@
 
 ## Unreleased
 
-- Mark the Day 15 MVP milestone complete with a polished landing page, global error handling, and final security/logging hardening.
-- Ship the MVP surface across subscriptions, uploads, dashboard widgets, onboarding, settings, and authentication flows.
-- Bootstrap backend FastAPI structure, logging, database layer, storage and email abstractions.
-- Bootstrap frontend Next.js app shell, providers, and test harness.
-- Add Docker Compose, Makefile, and GitHub Actions workflows for Day 1.
+- Day 30 final QA remains the next scheduled verification milestone.
+
+## Day 29 - Documentation
+
+- Added complete root, backend, frontend, API, OpenAPI, privacy, and milestone-history documentation.
+
+## Day 28 - Performance Optimization
+
+- Added gzip, private cache headers, slow SQL logging, selected-column dashboard loads,
+  performance indexes, dynamic dashboard/report chunks, route prefetching, and bundle analysis.
+- Verified the production landing page with a Lighthouse Performance score above 90.
+
+## Day 27 - Security Hardening
+
+- Added encrypted Telegram fields with blind indexes, rate limiting, request size limits,
+  security headers, authenticated CSRF checks, and safer session storage.
+- Removed Telegram chat IDs from logs and added security coverage.
+
+## Day 26 - UI Polish and Design Consistency
+
+- Polished global tokens, focus visibility, reduced-motion handling, shared buttons,
+  page headers, dialogs, app-shell landmarks, dark mode, and mobile navigation.
+
+## Day 25 - Integration Testing Phase 2 and 3
+
+- Added backend performance indexes and E2E coverage for analytics, calendar, exports,
+  uploads, and responsive workspace behavior.
+
+## Day 24 - Data Export
+
+- Added authenticated CSV, JSON, and iCalendar exports with active-only, payment-history,
+  and calendar-horizon options plus a frontend export workspace.
+
+## Day 23 - Family Sharing View
+
+- Added household creation, invite joining, leave flow, member privacy controls, shared
+  dashboard metrics, and shared-plan recommendations.
+
+## Day 22 - Subscription Score and Duplicates
+
+- Added the subscription health score, duplicate candidate detection, score endpoint,
+  dashboard widgets, and a dedicated score workspace.
+
+## Day 21 - Notification Polish
+
+- Added notification preference management, reminder controls, Telegram linking, and
+  authenticated notification list/read flows.
+
+## Day 20 - Calendar and Renewal Reminders
+
+- Added monthly renewal calendar data, frontend calendar workspace, and reminder-oriented
+  renewal visibility.
+
+## Day 19 - Reports and Analytics
+
+- Added expense report listing/detail, analytics aggregates, chart-backed report views,
+  and report navigation from uploaded statement data.
+
+## Day 18 - Multi-Currency Support
+
+- Added supported currencies, exchange-rate lookup, preferred currency handling, and
+  currency-aware display in subscription and dashboard surfaces.
+
+## Day 17 - Expense Report Generation
+
+- Added generated expense reports from parsed raw transactions and linked reports into
+  the authenticated workspace.
+
+## Day 16 - User Data Scoping
+
+- Scoped categories, payment methods, subscriptions, uploads, reports, and settings data
+  to the authenticated user.
+
+## Day 15 - MVP Completion
+
+- Completed the MVP pass across public landing, authentication, uploads, subscriptions,
+  dashboard, onboarding, settings, and app-level error handling.
+
+## Day 14 - Onboarding and Empty States
+
+- Added workspace onboarding, empty states, loading states, and route-level guidance for
+  first-run users.
+
+## Day 13 - Integration Testing E2E
+
+- Added Playwright global setup, shared session helpers, E2E specs for core flows, CI
+  browser installation, and backend integration-flow tests.
+
+## Day 12 - Search, Filters, and Settings
+
+- Added URL-synced subscription filters, debounce helpers, settings CRUD for categories
+  and payment methods, profile currency controls, and workspace data deletion.
+
+## Day 11 - Dashboard Widgets
+
+- Added persisted dashboard widget layout, active subscription rows, monthly spend,
+  category breakdown, upcoming renewals, recently ended plans, and charting dependencies.
+
+## Day 10 - Dashboard API Snapshot
+
+- Added dashboard summary aggregation, persistent layout endpoints, live frontend snapshot
+  widgets, and dashboard contract tests.
+
+## Day 9 - Upload UI and Processing Status
+
+- Added drag-and-drop upload intake, XHR progress, processing status rail, upload history,
+  delete actions, service logos, and upload API client hooks.
+
+## Day 8 - Subscription Detection Engine
+
+- Added recurring merchant grouping, cadence analysis, confidence scoring, category
+  auto-creation, subscription sync, and payment-history linking from uploads.
+
+## Day 7 - Parsing Templates and Normalizer
+
+- Added institution parsing templates, merchant normalization, known-service aliases,
+  ARQ worker wiring, and explicit CSV/PDF processing jobs.
+
+## Day 6 - PDF and CSV Upload Parsing
+
+- Added upload metadata, upload endpoints, CSV/PDF extraction services, Chase/generic
+  parsing support, and raw transaction storage.
+
+## Day 5 - Manual Entry Subscription Management
+
+- Added subscription CRUD with website URLs, manual-entry UI, detail views, and React
+  Query hooks for subscription management.
+
+## Day 4 - Authentication
+
+- Added registration, login, refresh, current-user profile, protected frontend routes,
+  and authenticated app providers.
+
+## Day 3 - Core Data Models
+
+- Added subscription, category, payment method, payment history, upload, raw transaction,
+  notification, and dashboard persistence models.
+
+## Day 2 - Frontend Foundations
+
+- Added the Next.js app shell, Tailwind setup, shared UI primitives, providers, and
+  initial test harness.
+
+## Day 1 - Project Bootstrap
+
+- Added the FastAPI skeleton, database layer, logging, storage and email abstractions,
+  Docker Compose, Makefile, and backend/frontend CI workflows.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,139 @@
-
 # MySubscription Tracker
 
-MySubscription Tracker is a full-stack subscription management app built across daily milestones. Day 1 establishes the backend API skeleton, frontend app shell, local development infrastructure, and CI workflows.
+MySubscription Tracker is a full-stack workspace for managing recurring spend. It combines
+manual subscription management, statement upload parsing, renewal visibility, household
+sharing, analytics, exports, notification preferences, and security hardening into one
+operator-focused app.
 
 ## Stack
 
-- Backend: FastAPI, SQLAlchemy async, Alembic, Structlog, UV
-- Frontend: Next.js App Router, Tailwind CSS, React Query, React Hook Form, next-themes
-- Tooling: Vitest, Playwright, Ruff, MyPy, Docker Compose, GitHub Actions
+- Backend: FastAPI, SQLAlchemy async, Alembic, PostgreSQL, Redis, ARQ, Structlog, UV
+- Frontend: Next.js App Router, React 19, Tailwind CSS, React Query, React Hook Form, Vitest, Playwright
+- Data ingestion: CSV and PDF parsing, institution templates, recurring merchant detection, raw transaction storage
+- Tooling: Ruff, MyPy, GitHub Actions, Docker Compose, Lighthouse, bundle analyzer
 
 ## Repository Layout
 
-- `backend/` FastAPI app, models, migrations, seed script, and backend tests
-- `frontend/` Next.js app shell, providers, test harness, and UI foundations
-- `.github/workflows/` backend and frontend CI pipelines
-
-## Day 1 Commands
-
-```bash
-make dev-infra
-make dev-backend
-make dev-frontend
-make test
-make lint
-make migrate
-make seed
+```text
+backend/                  FastAPI API, models, migrations, services, workers, tests
+backend/docs/             API reference and exported OpenAPI schema
+frontend/                 Next.js app, shared UI, hooks, tests, Playwright specs
+.github/workflows/        Backend and frontend CI pipelines
+docker-compose.yml        Local PostgreSQL and Redis services
+Makefile                  Common development commands
+CHANGELOG.md              30-day milestone history
 ```
 
-## Environment Notes
+## Quick Start
 
-- Backend settings load from `backend/.env.development`.
-- Frontend expects `NEXT_PUBLIC_API_BASE_URL` to point at the backend API, defaulting to `http://localhost:8000/api/v1`.
-- Docker is required for local Postgres and Redis services.
+1. Start infrastructure:
 
-## Verification Status
+   ```bash
+   make dev-infra
+   ```
 
-This run created the Day 1 bootstrap tree. Package installation through `uv` and `npm` still depends on DNS resolution inside those package managers in the current environment, so CI-oriented config is in place but local dependency install may require a less restricted shell.
+2. Install backend dependencies and run migrations:
+
+   ```bash
+   cd backend
+   UV_CACHE_DIR=/tmp/uv-cache uv sync --group dev
+   UV_CACHE_DIR=/tmp/uv-cache uv run alembic upgrade head
+   ```
+
+3. Install frontend dependencies:
+
+   ```bash
+   cd frontend
+   npm ci
+   ```
+
+4. Run the backend and frontend in separate terminals:
+
+   ```bash
+   make dev-backend
+   make dev-frontend
+   ```
+
+The frontend runs on `http://localhost:3000`. The API defaults to
+`http://localhost:8000/api/v1`, with interactive OpenAPI docs at
+`http://localhost:8000/docs`.
+
+## Environment
+
+Backend settings load from `backend/.env.development` by default. Important variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `DATABASE_URL` | `postgresql+asyncpg://postgres:postgres@localhost:5432/mysubscription_tracker` | Primary database |
+| `REDIS_URL` | `redis://localhost:6379/0` | Background job queue |
+| `JWT_SECRET_KEY` | `dev-secret-change-me` | Access and refresh token signing |
+| `FIELD_ENCRYPTION_KEY` | unset | Required outside development/test for encrypted fields |
+| `BACKEND_CORS_ORIGINS` | `["http://localhost:3000"]` | Allowed browser origins |
+| `UPLOAD_JOB_BACKEND` | `inline` | `inline` or Redis-backed worker processing |
+| `SENTRY_DSN` | unset | Optional production error reporting |
+| `GLOBAL_RATE_LIMIT` | `600` | Requests per window per client |
+| `MAX_REQUEST_BODY_BYTES` | `11534336` | Upload/request body cap |
+
+Frontend settings:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | `http://localhost:8000/api/v1` | API origin used by the browser client |
+
+## Common Commands
+
+```bash
+make dev-infra       # PostgreSQL and Redis
+make dev-backend     # FastAPI reload server
+make dev-frontend    # Next.js dev server
+make migrate         # Alembic upgrade head
+make seed            # Seed default categories
+make test            # Backend and frontend unit tests
+make lint            # Backend Ruff/MyPy and frontend lint/typecheck
+```
+
+Direct checks used by CI:
+
+```bash
+cd backend
+uv run ruff check .
+uv run mypy src
+uv run pytest
+
+cd frontend
+npm run lint
+npm run typecheck
+npm run test
+npm run build
+npm run test:e2e
+```
+
+## Product Surface
+
+- Public pages: landing page, login, registration, privacy policy
+- Authenticated pages: dashboard, uploads, subscriptions, subscription detail, reports, exports,
+  score, family, calendar, payments, settings
+- Backend domains: authentication, user profile, categories, payment methods, subscriptions,
+  uploads, dashboard layout/summary, analytics reports, exports, calendar renewals, family
+  sharing, notifications, currency conversion, subscription score
+
+## API Documentation
+
+- Human-readable API guide: `backend/docs/api.md`
+- Exported OpenAPI schema: `backend/docs/openapi.json`
+- Runtime docs: `http://localhost:8000/docs` and `http://localhost:8000/redoc`
+
+Regenerate the exported schema after API changes:
+
+```bash
+cd backend
+uv run python - <<'PY'
+import json
+from pathlib import Path
+from src.main import create_app
+
+Path("docs/openapi.json").write_text(
+    json.dumps(create_app().openapi(), indent=2, sort_keys=True) + "\n"
+)
+PY
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,12 +1,116 @@
-## Backend
+# MySubscription Tracker Backend
 
-FastAPI application skeleton for MySubscription Tracker.
+FastAPI backend for subscription tracking, statement ingestion, dashboard summaries, analytics,
+exports, family sharing, notifications, and security controls.
 
-### Commands
+## Requirements
+
+- Python 3.12
+- UV
+- PostgreSQL 16
+- Redis 7
+
+Start PostgreSQL and Redis from the repository root:
 
 ```bash
+make dev-infra
+```
+
+## Setup
+
+```bash
+cd backend
 UV_CACHE_DIR=/tmp/uv-cache uv sync --group dev
+UV_CACHE_DIR=/tmp/uv-cache uv run alembic upgrade head
+UV_CACHE_DIR=/tmp/uv-cache uv run uvicorn src.main:app --reload
+```
+
+The API listens on `http://localhost:8000` and serves versioned routes under `/api/v1`.
+Interactive docs are available at `/docs` and `/redoc`.
+
+## Configuration
+
+Settings are defined in `src/config.py` and load from `backend/.env.development` by default.
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `APP_NAME` | `MySubscription Tracker API` | OpenAPI display name |
+| `ENVIRONMENT` | `development` | Enables stricter production validation outside development/test |
+| `API_V1_PREFIX` | `/api/v1` | Versioned API prefix |
+| `DATABASE_URL` | local PostgreSQL URL | Async SQLAlchemy database URL |
+| `JWT_SECRET_KEY` | `dev-secret-change-me` | Must be changed outside development/test |
+| `JWT_ALGORITHM` | `HS256` | Token signing algorithm |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | Access token lifetime |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token lifetime |
+| `BACKEND_CORS_ORIGINS` | `["http://localhost:3000"]` | Browser origins allowed for credentialed API calls |
+| `LOG_LEVEL` | `INFO` | Structlog level |
+| `JSON_LOGS` | `false` | JSON log output switch |
+| `SENTRY_DSN` | unset | Optional FastAPI Sentry integration |
+| `STORAGE_BACKEND` | `local` | Upload storage backend |
+| `LOCAL_STORAGE_PATH` | `./storage` | Local upload storage path |
+| `EMAIL_BACKEND` | `console` | Notification email backend |
+| `APP_BASE_URL` | `http://localhost:8000` | Base URL for generated links |
+| `TELEGRAM_WEBHOOK_SECRET` | unset | Telegram webhook validation |
+| `DISABLE_RATE_LIMITING` | `false` | Test/development escape hatch |
+| `GLOBAL_RATE_LIMIT` | `600` | Requests per client per window |
+| `GLOBAL_RATE_WINDOW_SECONDS` | `60` | Rate limit window size |
+| `MAX_REQUEST_BODY_BYTES` | `11534336` | Request body cap |
+| `FIELD_ENCRYPTION_KEY` | unset | Required outside development/test |
+| `SECURITY_HSTS_ENABLED` | `false` | Enables HSTS header when deployed behind HTTPS |
+| `UPLOAD_JOB_BACKEND` | `inline` | Inline processing or Redis-backed worker dispatch |
+| `REDIS_URL` | `redis://localhost:6379/0` | ARQ worker connection |
+| `SLOW_QUERY_THRESHOLD_MS` | `500` | Slow SQL logging threshold |
+
+## Commands
+
+```bash
 UV_CACHE_DIR=/tmp/uv-cache uv run uvicorn src.main:app --reload
 UV_CACHE_DIR=/tmp/uv-cache uv run alembic upgrade head
+UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/seed_categories.py
 UV_CACHE_DIR=/tmp/uv-cache uv run pytest
+UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .
+UV_CACHE_DIR=/tmp/uv-cache uv run mypy src
 ```
+
+## Background Jobs
+
+Uploads default to inline processing for local development. To process through Redis/ARQ,
+set `UPLOAD_JOB_BACKEND=arq`, keep Redis running, and start the worker:
+
+```bash
+cd backend
+UV_CACHE_DIR=/tmp/uv-cache uv run arq src.worker.WorkerSettings
+```
+
+The worker handles CSV/PDF statement parsing, normalized raw transaction storage, recurring
+subscription detection, exchange-rate refresh jobs, and notification dispatch jobs.
+
+## API Documentation
+
+- `docs/api.md` gives endpoint groups, authentication expectations, and request examples.
+- `docs/openapi.json` is the exported OpenAPI schema generated from the FastAPI app.
+- Runtime OpenAPI docs are available at `/docs` and `/redoc`.
+
+Regenerate the exported schema after endpoint or schema changes:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python - <<'PY'
+import json
+from pathlib import Path
+from src.main import create_app
+
+Path("docs/openapi.json").write_text(
+    json.dumps(create_app().openapi(), indent=2, sort_keys=True) + "\n"
+)
+PY
+```
+
+## Test Data Flow
+
+1. Register or log in through `/api/v1/auth`.
+2. Create categories and payment methods.
+3. Add subscriptions manually or upload CSV/PDF statements.
+4. Review detected subscriptions, dashboard widgets, analytics, exports, notifications, and family sharing.
+
+Most authenticated endpoints require `Authorization: Bearer <access_token>`.
+State-changing browser requests also send a CSRF header from the frontend API client.

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -1,0 +1,178 @@
+# MySubscription Tracker API
+
+Base URL: `http://localhost:8000/api/v1`
+
+Runtime documentation:
+
+- Swagger UI: `http://localhost:8000/docs`
+- ReDoc: `http://localhost:8000/redoc`
+- Exported schema: `backend/docs/openapi.json`
+
+## Authentication
+
+Register or log in to receive an access token and refresh token. Send the access token on
+authenticated requests:
+
+```bash
+curl -H "Authorization: Bearer $ACCESS_TOKEN" \
+  http://localhost:8000/api/v1/subscriptions
+```
+
+Browser-origin state-changing requests are protected by origin and CSRF checks. The frontend
+API client attaches the required CSRF header automatically.
+
+## Core Examples
+
+Register:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"owner@example.com","full_name":"Jordan Lee","password":"change-me-123"}'
+```
+
+Create a subscription:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/subscriptions \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Netflix",
+    "amount": "22.99",
+    "currency": "USD",
+    "billing_cycle": "monthly",
+    "next_billing_date": "2026-05-15",
+    "status": "active"
+  }'
+```
+
+Upload a statement:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/uploads \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -F "file=@statement.csv"
+```
+
+Export active subscriptions as iCalendar:
+
+```bash
+curl -L "http://localhost:8000/api/v1/exports?format=ical&active_only=true" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -o subscriptions.ics
+```
+
+## Endpoint Groups
+
+### Health
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/health` | Service readiness and uptime check. |
+
+### Auth and Profile
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/auth/register` | Create an account and return tokens. |
+| `POST` | `/auth/login` | Authenticate with email and password. |
+| `POST` | `/auth/refresh` | Refresh an authenticated session. |
+| `GET` | `/auth/me` | Return the current user profile. |
+| `PATCH` | `/auth/me` | Update profile fields such as name and preferred currency. |
+| `DELETE` | `/auth/me/data` | Delete workspace-owned user data while preserving the account. |
+
+### Subscriptions
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/subscriptions` | List subscriptions with search, status, cadence, category, payment method, and amount filters. |
+| `POST` | `/subscriptions` | Create a manual subscription. |
+| `GET` | `/subscriptions/{subscription_id}` | Fetch one subscription. |
+| `PATCH` | `/subscriptions/{subscription_id}` | Update lifecycle, pricing, renewal, category, and payment details. |
+| `DELETE` | `/subscriptions/{subscription_id}` | Remove one subscription. |
+| `GET` | `/subscriptions/{subscription_id}/payment-history` | List payment history linked to one subscription. |
+
+### Uploads and Parsing
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/uploads` | Upload CSV or PDF statement files for parsing and recurring charge detection. |
+| `GET` | `/uploads` | List upload history and processing state. |
+| `GET` | `/uploads/{upload_id}/status` | Poll queue, processing, completed, or failed status. |
+| `DELETE` | `/uploads/{upload_id}` | Delete upload metadata and stored file references owned by the user. |
+
+### Dashboard, Reports, and Score
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/dashboard/summary` | Spend totals, active subscriptions, upcoming renewals, category mix, uploads, and score summary. |
+| `GET` | `/dashboard/layout` | Fetch saved widget layout. |
+| `PUT` | `/dashboard/layout` | Replace saved widget layout. |
+| `GET` | `/dashboard/score` | Subscription health score and duplicate candidates. |
+| `GET` | `/expense-reports` | List generated expense reports. |
+| `GET` | `/expense-reports/{report_id}` | Fetch one report. |
+| `GET` | `/expense-reports/analytics` | Return chart-ready spend analytics by range. |
+
+### Settings Data
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/categories` | List user categories. |
+| `POST` | `/categories` | Create a category. |
+| `GET` | `/categories/{category_id}` | Fetch one category. |
+| `PATCH` | `/categories/{category_id}` | Update category metadata. |
+| `DELETE` | `/categories/{category_id}` | Delete an unused category. |
+| `GET` | `/payment-methods` | List user payment methods. |
+| `POST` | `/payment-methods` | Create a payment method. |
+| `GET` | `/payment-methods/{payment_method_id}` | Fetch one payment method. |
+| `PATCH` | `/payment-methods/{payment_method_id}` | Update label, provider, default flag, or card tail. |
+| `DELETE` | `/payment-methods/{payment_method_id}` | Delete an unused payment method. |
+
+### Calendar, Exports, and Currency
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/calendar` | Return monthly renewal events. |
+| `GET` | `/exports` | Download CSV, JSON, or iCalendar subscription exports. |
+| `GET` | `/currencies` | List supported currencies. |
+| `GET` | `/currencies/rate` | Convert between supported currencies. |
+
+### Family Sharing
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/family` | Fetch the current household workspace and member roster. |
+| `POST` | `/family` | Create a household workspace. |
+| `POST` | `/family/join` | Join by invite code. |
+| `PATCH` | `/family/privacy` | Toggle sharing privacy for the current member. |
+| `DELETE` | `/family` | Leave the current household workspace. |
+| `GET` | `/family/dashboard` | Shared household metrics and plan recommendations. |
+
+### Notifications
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/notifications` | List notifications. |
+| `POST` | `/notifications/{notification_id}/read` | Mark one notification read. |
+| `POST` | `/notifications/read-all` | Mark all notifications read. |
+| `GET` | `/notifications/preferences` | Fetch reminder and channel preferences. |
+| `PUT` | `/notifications/preferences` | Update reminder and channel preferences. |
+| `POST` | `/notifications/telegram/link-token` | Create a short-lived Telegram link token. |
+| `DELETE` | `/notifications/telegram/link` | Remove a linked Telegram chat. |
+| `POST` | `/notifications/telegram/webhook` | Receive Telegram webhook callbacks. |
+
+## Regenerating the Schema
+
+```bash
+cd backend
+UV_CACHE_DIR=/tmp/uv-cache uv run python - <<'PY'
+import json
+from pathlib import Path
+from src.main import create_app
+
+Path("docs/openapi.json").write_text(
+    json.dumps(create_app().openapi(), indent=2, sort_keys=True) + "\n"
+)
+PY
+```

--- a/backend/docs/openapi.json
+++ b/backend/docs/openapi.json
@@ -1,0 +1,6075 @@
+{
+  "components": {
+    "schemas": {
+      "AnalyticsCategoryItem": {
+        "properties": {
+          "active_subscriptions": {
+            "title": "Active Subscriptions",
+            "type": "integer"
+          },
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "category_name": {
+            "title": "Category Name",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "projected_monthly_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Projected Monthly Savings",
+            "type": "string"
+          },
+          "projected_range_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Projected Range Savings",
+            "type": "string"
+          },
+          "total_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Spend",
+            "type": "string"
+          }
+        },
+        "required": [
+          "category_id",
+          "category_name",
+          "total_spend",
+          "currency",
+          "active_subscriptions",
+          "projected_monthly_savings",
+          "projected_range_savings"
+        ],
+        "title": "AnalyticsCategoryItem",
+        "type": "object"
+      },
+      "AnalyticsFrequencyItem": {
+        "properties": {
+          "cadence": {
+            "title": "Cadence",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "monthly_equivalent": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Monthly Equivalent",
+            "type": "string"
+          },
+          "subscription_count": {
+            "title": "Subscription Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cadence",
+          "label",
+          "subscription_count",
+          "monthly_equivalent",
+          "currency"
+        ],
+        "title": "AnalyticsFrequencyItem",
+        "type": "object"
+      },
+      "AnalyticsPaymentMethodItem": {
+        "properties": {
+          "active_subscriptions": {
+            "title": "Active Subscriptions",
+            "type": "integer"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "payment_method_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Id"
+          },
+          "payment_method_label": {
+            "title": "Payment Method Label",
+            "type": "string"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "total_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Spend",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payment_method_id",
+          "payment_method_label",
+          "total_spend",
+          "currency",
+          "active_subscriptions"
+        ],
+        "title": "AnalyticsPaymentMethodItem",
+        "type": "object"
+      },
+      "AnalyticsResponse": {
+        "properties": {
+          "categories": {
+            "items": {
+              "$ref": "#/components/schemas/AnalyticsCategoryItem"
+            },
+            "title": "Categories",
+            "type": "array"
+          },
+          "frequency_distribution": {
+            "items": {
+              "$ref": "#/components/schemas/AnalyticsFrequencyItem"
+            },
+            "title": "Frequency Distribution",
+            "type": "array"
+          },
+          "payment_methods": {
+            "items": {
+              "$ref": "#/components/schemas/AnalyticsPaymentMethodItem"
+            },
+            "title": "Payment Methods",
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/AnalyticsSummary"
+          },
+          "trend_categories": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Trend Categories",
+            "type": "array"
+          },
+          "trends": {
+            "items": {
+              "$ref": "#/components/schemas/AnalyticsTrendPoint"
+            },
+            "title": "Trends",
+            "type": "array"
+          },
+          "window": {
+            "$ref": "#/components/schemas/AnalyticsWindow"
+          }
+        },
+        "required": [
+          "window",
+          "summary",
+          "categories",
+          "payment_methods",
+          "frequency_distribution",
+          "trends",
+          "trend_categories"
+        ],
+        "title": "AnalyticsResponse",
+        "type": "object"
+      },
+      "AnalyticsSummary": {
+        "properties": {
+          "active_subscriptions": {
+            "title": "Active Subscriptions",
+            "type": "integer"
+          },
+          "average_monthly_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Average Monthly Spend",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "projected_monthly_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Projected Monthly Savings",
+            "type": "string"
+          },
+          "projected_range_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Projected Range Savings",
+            "type": "string"
+          },
+          "total_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Spend",
+            "type": "string"
+          }
+        },
+        "required": [
+          "total_spend",
+          "average_monthly_spend",
+          "currency",
+          "active_subscriptions",
+          "projected_monthly_savings",
+          "projected_range_savings"
+        ],
+        "title": "AnalyticsSummary",
+        "type": "object"
+      },
+      "AnalyticsTrendCategoryItem": {
+        "properties": {
+          "category_name": {
+            "title": "Category Name",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "total_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Spend",
+            "type": "string"
+          }
+        },
+        "required": [
+          "category_name",
+          "total_spend",
+          "currency"
+        ],
+        "title": "AnalyticsTrendCategoryItem",
+        "type": "object"
+      },
+      "AnalyticsTrendPoint": {
+        "properties": {
+          "category_totals": {
+            "items": {
+              "$ref": "#/components/schemas/AnalyticsTrendCategoryItem"
+            },
+            "title": "Category Totals",
+            "type": "array"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "period_start": {
+            "format": "date",
+            "title": "Period Start",
+            "type": "string"
+          },
+          "total_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Spend",
+            "type": "string"
+          }
+        },
+        "required": [
+          "period_start",
+          "label",
+          "total_spend",
+          "currency",
+          "category_totals"
+        ],
+        "title": "AnalyticsTrendPoint",
+        "type": "object"
+      },
+      "AnalyticsWindow": {
+        "properties": {
+          "end_date": {
+            "format": "date",
+            "title": "End Date",
+            "type": "string"
+          },
+          "key": {
+            "enum": [
+              "90d",
+              "180d",
+              "365d"
+            ],
+            "title": "Key",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "label",
+          "start_date",
+          "end_date"
+        ],
+        "title": "AnalyticsWindow",
+        "type": "object"
+      },
+      "Body_create_upload_route_api_v1_uploads_post": {
+        "properties": {
+          "file": {
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_create_upload_route_api_v1_uploads_post",
+        "type": "object"
+      },
+      "CalendarDay": {
+        "properties": {
+          "date": {
+            "format": "date",
+            "title": "Date",
+            "type": "string"
+          },
+          "day": {
+            "title": "Day",
+            "type": "integer"
+          },
+          "renewals": {
+            "items": {
+              "$ref": "#/components/schemas/CalendarRenewalItem"
+            },
+            "title": "Renewals",
+            "type": "array"
+          },
+          "total_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Amount",
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "day",
+          "total_amount",
+          "renewals"
+        ],
+        "title": "CalendarDay",
+        "type": "object"
+      },
+      "CalendarRenewalItem": {
+        "properties": {
+          "amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Amount",
+            "type": "string"
+          },
+          "cadence": {
+            "title": "Cadence",
+            "type": "string"
+          },
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "category_name": {
+            "title": "Category Name",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "payment_method_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Id"
+          },
+          "payment_method_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Label"
+          },
+          "renewal_date": {
+            "format": "date",
+            "title": "Renewal Date",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "subscription_id": {
+            "title": "Subscription Id",
+            "type": "integer"
+          },
+          "vendor": {
+            "title": "Vendor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "name",
+          "vendor",
+          "amount",
+          "currency",
+          "cadence",
+          "status",
+          "renewal_date",
+          "category_id",
+          "category_name",
+          "payment_method_id",
+          "payment_method_label"
+        ],
+        "title": "CalendarRenewalItem",
+        "type": "object"
+      },
+      "CalendarRenewalResponse": {
+        "properties": {
+          "days": {
+            "items": {
+              "$ref": "#/components/schemas/CalendarDay"
+            },
+            "title": "Days",
+            "type": "array"
+          },
+          "month": {
+            "title": "Month",
+            "type": "integer"
+          },
+          "period_end": {
+            "format": "date",
+            "title": "Period End",
+            "type": "string"
+          },
+          "period_start": {
+            "format": "date",
+            "title": "Period Start",
+            "type": "string"
+          },
+          "total_renewals": {
+            "title": "Total Renewals",
+            "type": "integer"
+          },
+          "year": {
+            "title": "Year",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "month",
+          "period_start",
+          "period_end",
+          "total_renewals",
+          "days"
+        ],
+        "title": "CalendarRenewalResponse",
+        "type": "object"
+      },
+      "CategoryCreate": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "CategoryCreate",
+        "type": "object"
+      },
+      "CategoryListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CategoryResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "CategoryListResponse",
+        "type": "object"
+      },
+      "CategoryResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "description",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "CategoryResponse",
+        "type": "object"
+      },
+      "CategoryUpdate": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "CategoryUpdate",
+        "type": "object"
+      },
+      "DashboardActiveSubscriptionItem": {
+        "properties": {
+          "amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Amount",
+            "type": "string"
+          },
+          "cadence": {
+            "title": "Cadence",
+            "type": "string"
+          },
+          "category_name": {
+            "title": "Category Name",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "next_charge_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Charge Date"
+          },
+          "subscription_id": {
+            "title": "Subscription Id",
+            "type": "integer"
+          },
+          "vendor": {
+            "title": "Vendor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "name",
+          "vendor",
+          "amount",
+          "currency",
+          "cadence",
+          "category_name"
+        ],
+        "title": "DashboardActiveSubscriptionItem",
+        "type": "object"
+      },
+      "DashboardCategoryBreakdownItem": {
+        "properties": {
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "category_name": {
+            "title": "Category Name",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "subscriptions": {
+            "title": "Subscriptions",
+            "type": "integer"
+          },
+          "total_monthly_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Monthly Spend",
+            "type": "string"
+          }
+        },
+        "required": [
+          "category_id",
+          "category_name",
+          "subscriptions",
+          "total_monthly_spend",
+          "currency"
+        ],
+        "title": "DashboardCategoryBreakdownItem",
+        "type": "object"
+      },
+      "DashboardDuplicateAlertItem": {
+        "properties": {
+          "confidence": {
+            "enum": [
+              "high",
+              "medium"
+            ],
+            "title": "Confidence",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "left_name": {
+            "title": "Left Name",
+            "type": "string"
+          },
+          "left_subscription_id": {
+            "title": "Left Subscription Id",
+            "type": "integer"
+          },
+          "left_vendor": {
+            "title": "Left Vendor",
+            "type": "string"
+          },
+          "potential_monthly_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Potential Monthly Savings",
+            "type": "string"
+          },
+          "right_name": {
+            "title": "Right Name",
+            "type": "string"
+          },
+          "right_subscription_id": {
+            "title": "Right Subscription Id",
+            "type": "integer"
+          },
+          "right_vendor": {
+            "title": "Right Vendor",
+            "type": "string"
+          },
+          "shared_signal": {
+            "title": "Shared Signal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "left_subscription_id",
+          "left_name",
+          "left_vendor",
+          "right_subscription_id",
+          "right_name",
+          "right_vendor",
+          "shared_signal",
+          "confidence",
+          "potential_monthly_savings",
+          "currency"
+        ],
+        "title": "DashboardDuplicateAlertItem",
+        "type": "object"
+      },
+      "DashboardLayoutResponse": {
+        "properties": {
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          },
+          "widgets": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardLayoutWidget"
+            },
+            "title": "Widgets",
+            "type": "array"
+          }
+        },
+        "required": [
+          "widgets",
+          "version"
+        ],
+        "title": "DashboardLayoutResponse",
+        "type": "object"
+      },
+      "DashboardLayoutUpdate": {
+        "properties": {
+          "widgets": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardLayoutWidget"
+            },
+            "title": "Widgets",
+            "type": "array"
+          }
+        },
+        "required": [
+          "widgets"
+        ],
+        "title": "DashboardLayoutUpdate",
+        "type": "object"
+      },
+      "DashboardLayoutWidget": {
+        "properties": {
+          "column": {
+            "enum": [
+              "primary",
+              "secondary"
+            ],
+            "title": "Column",
+            "type": "string"
+          },
+          "id": {
+            "enum": [
+              "subscription-score",
+              "active-subscriptions",
+              "monthly-spend",
+              "category-breakdown",
+              "upcoming-renewals",
+              "recently-ended",
+              "duplicate-alerts"
+            ],
+            "title": "Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "column"
+        ],
+        "title": "DashboardLayoutWidget",
+        "type": "object"
+      },
+      "DashboardMonthlySpendPoint": {
+        "properties": {
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "month": {
+            "title": "Month",
+            "type": "string"
+          },
+          "total": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total",
+            "type": "string"
+          }
+        },
+        "required": [
+          "month",
+          "label",
+          "total",
+          "currency"
+        ],
+        "title": "DashboardMonthlySpendPoint",
+        "type": "object"
+      },
+      "DashboardRecentlyEndedItem": {
+        "properties": {
+          "amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Amount",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "end_date": {
+            "format": "date",
+            "title": "End Date",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "subscription_id": {
+            "title": "Subscription Id",
+            "type": "integer"
+          },
+          "vendor": {
+            "title": "Vendor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "name",
+          "vendor",
+          "amount",
+          "currency",
+          "end_date"
+        ],
+        "title": "DashboardRecentlyEndedItem",
+        "type": "object"
+      },
+      "DashboardScoreOverview": {
+        "properties": {
+          "band": {
+            "enum": [
+              "excellent",
+              "steady",
+              "attention",
+              "at-risk"
+            ],
+            "title": "Band",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "duplicate_candidates": {
+            "title": "Duplicate Candidates",
+            "type": "integer"
+          },
+          "grade": {
+            "title": "Grade",
+            "type": "string"
+          },
+          "potential_monthly_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Potential Monthly Savings",
+            "type": "string"
+          },
+          "recommendation_count": {
+            "title": "Recommendation Count",
+            "type": "integer"
+          },
+          "score": {
+            "title": "Score",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "score",
+          "grade",
+          "band",
+          "recommendation_count",
+          "duplicate_candidates",
+          "potential_monthly_savings",
+          "currency"
+        ],
+        "title": "DashboardScoreOverview",
+        "type": "object"
+      },
+      "DashboardSummaryResponse": {
+        "properties": {
+          "active_subscriptions": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardActiveSubscriptionItem"
+            },
+            "title": "Active Subscriptions",
+            "type": "array"
+          },
+          "category_breakdown": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardCategoryBreakdownItem"
+            },
+            "title": "Category Breakdown",
+            "type": "array"
+          },
+          "duplicate_alerts": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/DashboardDuplicateAlertItem"
+            },
+            "title": "Duplicate Alerts",
+            "type": "array"
+          },
+          "monthly_spend": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardMonthlySpendPoint"
+            },
+            "title": "Monthly Spend",
+            "type": "array"
+          },
+          "recently_ended": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardRecentlyEndedItem"
+            },
+            "title": "Recently Ended",
+            "type": "array"
+          },
+          "score_overview": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DashboardScoreOverview"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "summary": {
+            "$ref": "#/components/schemas/DashboardSummaryStats"
+          },
+          "upcoming_renewals": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardUpcomingRenewalItem"
+            },
+            "title": "Upcoming Renewals",
+            "type": "array"
+          }
+        },
+        "required": [
+          "summary",
+          "active_subscriptions",
+          "monthly_spend",
+          "category_breakdown",
+          "upcoming_renewals",
+          "recently_ended"
+        ],
+        "title": "DashboardSummaryResponse",
+        "type": "object"
+      },
+      "DashboardSummaryStats": {
+        "properties": {
+          "active_subscriptions": {
+            "title": "Active Subscriptions",
+            "type": "integer"
+          },
+          "cancelled_subscriptions": {
+            "title": "Cancelled Subscriptions",
+            "type": "integer"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "total_monthly_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Monthly Spend",
+            "type": "string"
+          },
+          "upcoming_renewals": {
+            "title": "Upcoming Renewals",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_monthly_spend",
+          "currency",
+          "active_subscriptions",
+          "upcoming_renewals",
+          "cancelled_subscriptions"
+        ],
+        "title": "DashboardSummaryStats",
+        "type": "object"
+      },
+      "DashboardUpcomingRenewalItem": {
+        "properties": {
+          "amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Amount",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "days_until_charge": {
+            "title": "Days Until Charge",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "next_charge_date": {
+            "format": "date",
+            "title": "Next Charge Date",
+            "type": "string"
+          },
+          "subscription_id": {
+            "title": "Subscription Id",
+            "type": "integer"
+          },
+          "vendor": {
+            "title": "Vendor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "name",
+          "vendor",
+          "amount",
+          "currency",
+          "next_charge_date",
+          "days_until_charge"
+        ],
+        "title": "DashboardUpcomingRenewalItem",
+        "type": "object"
+      },
+      "ExchangeRateResponse": {
+        "properties": {
+          "base_currency": {
+            "title": "Base Currency",
+            "type": "string"
+          },
+          "effective_date": {
+            "format": "date",
+            "title": "Effective Date",
+            "type": "string"
+          },
+          "is_fallback": {
+            "default": false,
+            "title": "Is Fallback",
+            "type": "boolean"
+          },
+          "quote_currency": {
+            "title": "Quote Currency",
+            "type": "string"
+          },
+          "rate": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Rate",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "base_currency",
+          "quote_currency",
+          "rate",
+          "effective_date",
+          "source"
+        ],
+        "title": "ExchangeRateResponse",
+        "type": "object"
+      },
+      "ExpenseReportCategoryBreakdownItem": {
+        "properties": {
+          "category_name": {
+            "title": "Category Name",
+            "type": "string"
+          },
+          "total_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Amount",
+            "type": "string"
+          },
+          "transaction_count": {
+            "title": "Transaction Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "category_name",
+          "total_amount",
+          "transaction_count"
+        ],
+        "title": "ExpenseReportCategoryBreakdownItem",
+        "type": "object"
+      },
+      "ExpenseReportListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ExpenseReportResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "ExpenseReportListResponse",
+        "type": "object"
+      },
+      "ExpenseReportMerchantBreakdownItem": {
+        "properties": {
+          "merchant": {
+            "title": "Merchant",
+            "type": "string"
+          },
+          "total_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Amount",
+            "type": "string"
+          },
+          "transaction_count": {
+            "title": "Transaction Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "merchant",
+          "total_amount",
+          "transaction_count"
+        ],
+        "title": "ExpenseReportMerchantBreakdownItem",
+        "type": "object"
+      },
+      "ExpenseReportResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "data_source_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Source Id"
+          },
+          "generated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Generated At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "period_end": {
+            "format": "date",
+            "title": "Period End",
+            "type": "string"
+          },
+          "period_start": {
+            "format": "date",
+            "title": "Period Start",
+            "type": "string"
+          },
+          "report_status": {
+            "title": "Report Status",
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/ExpenseReportSummary"
+          },
+          "total_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Amount",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "data_source_id",
+          "period_start",
+          "period_end",
+          "currency",
+          "total_amount",
+          "report_status",
+          "generated_at",
+          "created_at",
+          "updated_at",
+          "summary"
+        ],
+        "title": "ExpenseReportResponse",
+        "type": "object"
+      },
+      "ExpenseReportSummary": {
+        "properties": {
+          "average_transaction": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Average Transaction",
+            "type": "string"
+          },
+          "category_breakdown": {
+            "items": {
+              "$ref": "#/components/schemas/ExpenseReportCategoryBreakdownItem"
+            },
+            "title": "Category Breakdown",
+            "type": "array"
+          },
+          "largest_transaction": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Largest Transaction",
+            "type": "string"
+          },
+          "merchant_count": {
+            "title": "Merchant Count",
+            "type": "integer"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "recurring_transaction_count": {
+            "title": "Recurring Transaction Count",
+            "type": "integer"
+          },
+          "spend_timeline": {
+            "items": {
+              "$ref": "#/components/schemas/ExpenseReportTimelinePoint"
+            },
+            "title": "Spend Timeline",
+            "type": "array"
+          },
+          "top_merchants": {
+            "items": {
+              "$ref": "#/components/schemas/ExpenseReportMerchantBreakdownItem"
+            },
+            "title": "Top Merchants",
+            "type": "array"
+          },
+          "transaction_count": {
+            "title": "Transaction Count",
+            "type": "integer"
+          },
+          "upload_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Upload Name"
+          }
+        },
+        "required": [
+          "transaction_count",
+          "recurring_transaction_count",
+          "merchant_count",
+          "average_transaction",
+          "largest_transaction",
+          "category_breakdown",
+          "top_merchants",
+          "spend_timeline"
+        ],
+        "title": "ExpenseReportSummary",
+        "type": "object"
+      },
+      "ExpenseReportTimelinePoint": {
+        "properties": {
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "period_start": {
+            "format": "date",
+            "title": "Period Start",
+            "type": "string"
+          },
+          "total_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Amount",
+            "type": "string"
+          }
+        },
+        "required": [
+          "period_start",
+          "label",
+          "total_amount"
+        ],
+        "title": "ExpenseReportTimelinePoint",
+        "type": "object"
+      },
+      "FamilyCreate": {
+        "properties": {
+          "name": {
+            "maxLength": 120,
+            "minLength": 2,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "FamilyCreate",
+        "type": "object"
+      },
+      "FamilyDashboardMemberSpend": {
+        "properties": {
+          "active_subscriptions": {
+            "title": "Active Subscriptions",
+            "type": "integer"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "monthly_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Monthly Spend",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          },
+          "visible": {
+            "title": "Visible",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "user_id",
+          "full_name",
+          "visible",
+          "active_subscriptions",
+          "monthly_spend",
+          "currency"
+        ],
+        "title": "FamilyDashboardMemberSpend",
+        "type": "object"
+      },
+      "FamilyDashboardResponse": {
+        "properties": {
+          "member_spend": {
+            "items": {
+              "$ref": "#/components/schemas/FamilyDashboardMemberSpend"
+            },
+            "title": "Member Spend",
+            "type": "array"
+          },
+          "recommendations": {
+            "items": {
+              "$ref": "#/components/schemas/FamilySharedPlanRecommendation"
+            },
+            "title": "Recommendations",
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/FamilyDashboardSummary"
+          }
+        },
+        "required": [
+          "summary",
+          "member_spend",
+          "recommendations"
+        ],
+        "title": "FamilyDashboardResponse",
+        "type": "object"
+      },
+      "FamilyDashboardSummary": {
+        "properties": {
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "family_name": {
+            "title": "Family Name",
+            "type": "string"
+          },
+          "member_count": {
+            "title": "Member Count",
+            "type": "integer"
+          },
+          "sharing_member_count": {
+            "title": "Sharing Member Count",
+            "type": "integer"
+          },
+          "visible_active_subscriptions": {
+            "title": "Visible Active Subscriptions",
+            "type": "integer"
+          },
+          "visible_monthly_spend": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Visible Monthly Spend",
+            "type": "string"
+          }
+        },
+        "required": [
+          "family_name",
+          "member_count",
+          "sharing_member_count",
+          "visible_active_subscriptions",
+          "visible_monthly_spend",
+          "currency"
+        ],
+        "title": "FamilyDashboardSummary",
+        "type": "object"
+      },
+      "FamilyJoinRequest": {
+        "properties": {
+          "invite_code": {
+            "maxLength": 32,
+            "minLength": 6,
+            "title": "Invite Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "invite_code"
+        ],
+        "title": "FamilyJoinRequest",
+        "type": "object"
+      },
+      "FamilyMemberResponse": {
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_current_user": {
+            "title": "Is Current User",
+            "type": "boolean"
+          },
+          "joined_at": {
+            "format": "date-time",
+            "title": "Joined At",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "share_subscriptions": {
+            "title": "Share Subscriptions",
+            "type": "boolean"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "full_name",
+          "email",
+          "role",
+          "share_subscriptions",
+          "joined_at",
+          "is_current_user"
+        ],
+        "title": "FamilyMemberResponse",
+        "type": "object"
+      },
+      "FamilyPrivacyUpdate": {
+        "properties": {
+          "share_subscriptions": {
+            "title": "Share Subscriptions",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "share_subscriptions"
+        ],
+        "title": "FamilyPrivacyUpdate",
+        "type": "object"
+      },
+      "FamilyResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "invite_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Invite Code"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner_user_id": {
+            "title": "Owner User Id",
+            "type": "integer"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "owner_user_id",
+          "invite_code",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "FamilyResponse",
+        "type": "object"
+      },
+      "FamilySharedPlanRecommendation": {
+        "properties": {
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "estimated_monthly_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Estimated Monthly Savings",
+            "type": "string"
+          },
+          "member_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Member Names",
+            "type": "array"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "subscription_count": {
+            "title": "Subscription Count",
+            "type": "integer"
+          },
+          "vendor": {
+            "title": "Vendor",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vendor",
+          "subscription_count",
+          "member_names",
+          "estimated_monthly_savings",
+          "currency",
+          "reason"
+        ],
+        "title": "FamilySharedPlanRecommendation",
+        "type": "object"
+      },
+      "FamilyStatusResponse": {
+        "properties": {
+          "current_member": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FamilyMemberResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "family": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FamilyResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/FamilyMemberResponse"
+            },
+            "title": "Members",
+            "type": "array"
+          }
+        },
+        "required": [
+          "family",
+          "members",
+          "current_member"
+        ],
+        "title": "FamilyStatusResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "LoginRequest": {
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "LoginRequest",
+        "type": "object"
+      },
+      "NotificationListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "unread_count": {
+            "title": "Unread Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "unread_count",
+          "total"
+        ],
+        "title": "NotificationListResponse",
+        "type": "object"
+      },
+      "NotificationPreferenceResponse": {
+        "properties": {
+          "channel": {
+            "enum": [
+              "email",
+              "telegram"
+            ],
+            "title": "Channel",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "renewal_due",
+            "title": "Event Type",
+            "type": "string"
+          },
+          "is_enabled": {
+            "title": "Is Enabled",
+            "type": "boolean"
+          },
+          "quiet_hours_end": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quiet Hours End"
+          },
+          "quiet_hours_start": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quiet Hours Start"
+          }
+        },
+        "required": [
+          "channel",
+          "event_type",
+          "is_enabled"
+        ],
+        "title": "NotificationPreferenceResponse",
+        "type": "object"
+      },
+      "NotificationPreferenceUpdate": {
+        "properties": {
+          "channel": {
+            "enum": [
+              "email",
+              "telegram"
+            ],
+            "title": "Channel",
+            "type": "string"
+          },
+          "event_type": {
+            "const": "renewal_due",
+            "default": "renewal_due",
+            "title": "Event Type",
+            "type": "string"
+          },
+          "is_enabled": {
+            "title": "Is Enabled",
+            "type": "boolean"
+          },
+          "quiet_hours_end": {
+            "anyOf": [
+              {
+                "maximum": 23.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quiet Hours End"
+          },
+          "quiet_hours_start": {
+            "anyOf": [
+              {
+                "maximum": 23.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quiet Hours Start"
+          }
+        },
+        "required": [
+          "channel",
+          "is_enabled"
+        ],
+        "title": "NotificationPreferenceUpdate",
+        "type": "object"
+      },
+      "NotificationPreferencesResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationPreferenceResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "telegram_linked": {
+            "title": "Telegram Linked",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items",
+          "telegram_linked"
+        ],
+        "title": "NotificationPreferencesResponse",
+        "type": "object"
+      },
+      "NotificationPreferencesUpdate": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationPreferenceUpdate"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "NotificationPreferencesUpdate",
+        "type": "object"
+      },
+      "NotificationReadAllResponse": {
+        "properties": {
+          "updated": {
+            "title": "Updated",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "updated"
+        ],
+        "title": "NotificationReadAllResponse",
+        "type": "object"
+      },
+      "NotificationResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "notification_type": {
+            "title": "Notification Type",
+            "type": "string"
+          },
+          "read_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read At"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "message",
+          "notification_type",
+          "status",
+          "read_at",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "NotificationResponse",
+        "type": "object"
+      },
+      "PaymentMethodCreate": {
+        "properties": {
+          "is_default": {
+            "default": false,
+            "title": "Is Default",
+            "type": "boolean"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "last4": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last4"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "provider"
+        ],
+        "title": "PaymentMethodCreate",
+        "type": "object"
+      },
+      "PaymentMethodListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PaymentMethodResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "PaymentMethodListResponse",
+        "type": "object"
+      },
+      "PaymentMethodResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_default": {
+            "title": "Is Default",
+            "type": "boolean"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "last4": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last4"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "label",
+          "provider",
+          "last4",
+          "is_default",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "PaymentMethodResponse",
+        "type": "object"
+      },
+      "PaymentMethodUpdate": {
+        "properties": {
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Default"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "last4": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last4"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          }
+        },
+        "title": "PaymentMethodUpdate",
+        "type": "object"
+      },
+      "RefreshRequest": {
+        "properties": {
+          "refresh_token": {
+            "title": "Refresh Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "refresh_token"
+        ],
+        "title": "RefreshRequest",
+        "type": "object"
+      },
+      "RegisterRequest": {
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "password"
+        ],
+        "title": "RegisterRequest",
+        "type": "object"
+      },
+      "SubscriptionCreate": {
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              }
+            ],
+            "title": "Amount"
+          },
+          "auto_renew": {
+            "default": true,
+            "title": "Auto Renew",
+            "type": "boolean"
+          },
+          "cadence": {
+            "title": "Cadence",
+            "type": "string"
+          },
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "day_of_month": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Day Of Month"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "next_charge_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Charge Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "payment_method_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Id"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          },
+          "status": {
+            "default": "active",
+            "title": "Status",
+            "type": "string"
+          },
+          "vendor": {
+            "title": "Vendor",
+            "type": "string"
+          },
+          "website_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Website Url"
+          }
+        },
+        "required": [
+          "name",
+          "vendor",
+          "amount",
+          "currency",
+          "cadence",
+          "start_date"
+        ],
+        "title": "SubscriptionCreate",
+        "type": "object"
+      },
+      "SubscriptionDuplicateCandidate": {
+        "properties": {
+          "confidence": {
+            "enum": [
+              "high",
+              "medium"
+            ],
+            "title": "Confidence",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "left_name": {
+            "title": "Left Name",
+            "type": "string"
+          },
+          "left_subscription_id": {
+            "title": "Left Subscription Id",
+            "type": "integer"
+          },
+          "left_vendor": {
+            "title": "Left Vendor",
+            "type": "string"
+          },
+          "potential_monthly_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Potential Monthly Savings",
+            "type": "string"
+          },
+          "right_name": {
+            "title": "Right Name",
+            "type": "string"
+          },
+          "right_subscription_id": {
+            "title": "Right Subscription Id",
+            "type": "integer"
+          },
+          "right_vendor": {
+            "title": "Right Vendor",
+            "type": "string"
+          },
+          "shared_signal": {
+            "title": "Shared Signal",
+            "type": "string"
+          }
+        },
+        "required": [
+          "left_subscription_id",
+          "left_name",
+          "left_vendor",
+          "right_subscription_id",
+          "right_name",
+          "right_vendor",
+          "shared_signal",
+          "confidence",
+          "potential_monthly_savings",
+          "currency"
+        ],
+        "title": "SubscriptionDuplicateCandidate",
+        "type": "object"
+      },
+      "SubscriptionListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "SubscriptionListResponse",
+        "type": "object"
+      },
+      "SubscriptionPaymentHistoryItem": {
+        "properties": {
+          "amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Amount",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "paid_at": {
+            "format": "date-time",
+            "title": "Paid At",
+            "type": "string"
+          },
+          "payment_method_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Id"
+          },
+          "payment_method_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Label"
+          },
+          "payment_status": {
+            "title": "Payment Status",
+            "type": "string"
+          },
+          "reference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference"
+          }
+        },
+        "required": [
+          "id",
+          "payment_method_id",
+          "payment_method_label",
+          "paid_at",
+          "amount",
+          "currency",
+          "payment_status",
+          "reference"
+        ],
+        "title": "SubscriptionPaymentHistoryItem",
+        "type": "object"
+      },
+      "SubscriptionPaymentHistoryResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionPaymentHistoryItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "price_changes": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionPriceChangeResponse"
+            },
+            "title": "Price Changes",
+            "type": "array"
+          },
+          "subscription_id": {
+            "title": "Subscription Id",
+            "type": "integer"
+          },
+          "subscription_name": {
+            "title": "Subscription Name",
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/SubscriptionPaymentHistorySummary"
+          }
+        },
+        "required": [
+          "subscription_id",
+          "subscription_name",
+          "summary",
+          "items",
+          "price_changes"
+        ],
+        "title": "SubscriptionPaymentHistoryResponse",
+        "type": "object"
+      },
+      "SubscriptionPaymentHistorySummary": {
+        "properties": {
+          "average_payment": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Average Payment",
+            "type": "string"
+          },
+          "first_payment_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Payment At"
+          },
+          "latest_payment_amount": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Payment Amount"
+          },
+          "latest_payment_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Payment At"
+          },
+          "payment_count": {
+            "title": "Payment Count",
+            "type": "integer"
+          },
+          "price_change_count": {
+            "title": "Price Change Count",
+            "type": "integer"
+          },
+          "total_paid": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Total Paid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "payment_count",
+          "total_paid",
+          "average_payment",
+          "price_change_count"
+        ],
+        "title": "SubscriptionPaymentHistorySummary",
+        "type": "object"
+      },
+      "SubscriptionPriceChangeResponse": {
+        "properties": {
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "effective_date": {
+            "format": "date",
+            "title": "Effective Date",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "new_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "New Amount",
+            "type": "string"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "previous_amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Previous Amount",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "effective_date",
+          "previous_amount",
+          "new_amount",
+          "currency",
+          "note"
+        ],
+        "title": "SubscriptionPriceChangeResponse",
+        "type": "object"
+      },
+      "SubscriptionRenewalSnapshot": {
+        "properties": {
+          "days_overdue": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days Overdue"
+          },
+          "days_until_charge": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Days Until Charge"
+          },
+          "last_renewed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Renewed At"
+          },
+          "next_charge_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Charge Date"
+          },
+          "state": {
+            "enum": [
+              "inactive",
+              "overdue",
+              "scheduled",
+              "trialing"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "trial_days_remaining": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trial Days Remaining"
+          },
+          "trial_ends_at": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trial Ends At"
+          }
+        },
+        "required": [
+          "state"
+        ],
+        "title": "SubscriptionRenewalSnapshot",
+        "type": "object"
+      },
+      "SubscriptionResponse": {
+        "properties": {
+          "amount": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Amount",
+            "type": "string"
+          },
+          "auto_renew": {
+            "title": "Auto Renew",
+            "type": "boolean"
+          },
+          "cadence": {
+            "title": "Cadence",
+            "type": "string"
+          },
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "day_of_month": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Day Of Month"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "next_charge_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Charge Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "payment_method_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Id"
+          },
+          "renewal": {
+            "$ref": "#/components/schemas/SubscriptionRenewalSnapshot"
+          },
+          "start_date": {
+            "format": "date",
+            "title": "Start Date",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          },
+          "vendor": {
+            "title": "Vendor",
+            "type": "string"
+          },
+          "website_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Website Url"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "category_id",
+          "payment_method_id",
+          "name",
+          "vendor",
+          "description",
+          "website_url",
+          "amount",
+          "currency",
+          "cadence",
+          "status",
+          "start_date",
+          "end_date",
+          "next_charge_date",
+          "day_of_month",
+          "auto_renew",
+          "notes",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "SubscriptionResponse",
+        "type": "object"
+      },
+      "SubscriptionScoreBreakdownItem": {
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "id": {
+            "enum": [
+              "coverage",
+              "renewal",
+              "context",
+              "waste"
+            ],
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "max_score": {
+            "title": "Max Score",
+            "type": "integer"
+          },
+          "score": {
+            "title": "Score",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "label",
+          "detail",
+          "score",
+          "max_score"
+        ],
+        "title": "SubscriptionScoreBreakdownItem",
+        "type": "object"
+      },
+      "SubscriptionScoreRecommendation": {
+        "properties": {
+          "action_href": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Href"
+          },
+          "action_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Label"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "potential_monthly_savings": {
+            "anyOf": [
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Potential Monthly Savings"
+          },
+          "priority": {
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ],
+            "title": "Priority",
+            "type": "string"
+          },
+          "subscriptions_affected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subscriptions Affected"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "description",
+          "priority"
+        ],
+        "title": "SubscriptionScoreRecommendation",
+        "type": "object"
+      },
+      "SubscriptionScoreResponse": {
+        "properties": {
+          "active_subscription_count": {
+            "title": "Active Subscription Count",
+            "type": "integer"
+          },
+          "band": {
+            "enum": [
+              "excellent",
+              "steady",
+              "attention",
+              "at-risk"
+            ],
+            "title": "Band",
+            "type": "string"
+          },
+          "breakdown": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionScoreBreakdownItem"
+            },
+            "title": "Breakdown",
+            "type": "array"
+          },
+          "currency": {
+            "title": "Currency",
+            "type": "string"
+          },
+          "duplicate_candidates": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionDuplicateCandidate"
+            },
+            "title": "Duplicate Candidates",
+            "type": "array"
+          },
+          "grade": {
+            "title": "Grade",
+            "type": "string"
+          },
+          "potential_monthly_savings": {
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Potential Monthly Savings",
+            "type": "string"
+          },
+          "recommendations": {
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionScoreRecommendation"
+            },
+            "title": "Recommendations",
+            "type": "array"
+          },
+          "score": {
+            "title": "Score",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "score",
+          "grade",
+          "band",
+          "active_subscription_count",
+          "potential_monthly_savings",
+          "currency",
+          "breakdown",
+          "recommendations",
+          "duplicate_candidates"
+        ],
+        "title": "SubscriptionScoreResponse",
+        "type": "object"
+      },
+      "SubscriptionUpdate": {
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
+          "auto_renew": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Renew"
+          },
+          "cadence": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cadence"
+          },
+          "category_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Id"
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency"
+          },
+          "day_of_month": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Day Of Month"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "next_charge_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Charge Date"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "payment_method_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Payment Method Id"
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "vendor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vendor"
+          },
+          "website_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Website Url"
+          }
+        },
+        "title": "SubscriptionUpdate",
+        "type": "object"
+      },
+      "SupportedCurrency": {
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "name"
+        ],
+        "title": "SupportedCurrency",
+        "type": "object"
+      },
+      "SupportedCurrencyListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SupportedCurrency"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "SupportedCurrencyListResponse",
+        "type": "object"
+      },
+      "TelegramLinkTokenResponse": {
+        "properties": {
+          "deep_link_hint": {
+            "title": "Deep Link Hint",
+            "type": "string"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "deep_link_hint"
+        ],
+        "title": "TelegramLinkTokenResponse",
+        "type": "object"
+      },
+      "TelegramUnlinkResponse": {
+        "properties": {
+          "telegram_linked": {
+            "title": "Telegram Linked",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "telegram_linked"
+        ],
+        "title": "TelegramUnlinkResponse",
+        "type": "object"
+      },
+      "TelegramWebhookChat": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Id"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "TelegramWebhookChat",
+        "type": "object"
+      },
+      "TelegramWebhookMessage": {
+        "properties": {
+          "chat": {
+            "$ref": "#/components/schemas/TelegramWebhookChat"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          }
+        },
+        "required": [
+          "chat"
+        ],
+        "title": "TelegramWebhookMessage",
+        "type": "object"
+      },
+      "TelegramWebhookPayload": {
+        "properties": {
+          "message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TelegramWebhookMessage"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "TelegramWebhookPayload",
+        "type": "object"
+      },
+      "TelegramWebhookResponse": {
+        "properties": {
+          "action": {
+            "enum": [
+              "ignored",
+              "linked",
+              "unlinked"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "telegram_linked": {
+            "default": false,
+            "title": "Telegram Linked",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "title": "TelegramWebhookResponse",
+        "type": "object"
+      },
+      "TokenResponse": {
+        "properties": {
+          "access_token": {
+            "title": "Access Token",
+            "type": "string"
+          },
+          "access_token_expires_at": {
+            "format": "date-time",
+            "title": "Access Token Expires At",
+            "type": "string"
+          },
+          "refresh_token": {
+            "title": "Refresh Token",
+            "type": "string"
+          },
+          "refresh_token_expires_at": {
+            "format": "date-time",
+            "title": "Refresh Token Expires At",
+            "type": "string"
+          },
+          "token_type": {
+            "default": "bearer",
+            "title": "Token Type",
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserResponse"
+          }
+        },
+        "required": [
+          "access_token",
+          "refresh_token",
+          "access_token_expires_at",
+          "refresh_token_expires_at",
+          "user"
+        ],
+        "title": "TokenResponse",
+        "type": "object"
+      },
+      "UploadListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/UploadResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total"
+        ],
+        "title": "UploadListResponse",
+        "type": "object"
+      },
+      "UploadResponse": {
+        "properties": {
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "file_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Size"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "source_type": {
+            "title": "Source Type",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "transaction_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Transaction Count",
+            "type": "integer"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "file_name",
+          "source_type",
+          "provider",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "UploadResponse",
+        "type": "object"
+      },
+      "UserResponse": {
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_active": {
+            "title": "Is Active",
+            "type": "boolean"
+          },
+          "preferred_currency": {
+            "title": "Preferred Currency",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "full_name",
+          "preferred_currency",
+          "is_active",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "UserResponse",
+        "type": "object"
+      },
+      "UserUpdateRequest": {
+        "properties": {
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "preferred_currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Currency"
+          }
+        },
+        "title": "UserUpdateRequest",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "API for subscription tracking, statement uploads, dashboard summaries, workspace settings, and authenticated operator workflows.",
+    "title": "MySubscription Tracker API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/auth/login": {
+      "post": {
+        "description": "Authenticate an existing user and return new bearer tokens.",
+        "operationId": "login_api_v1_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Log in with email and password",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "operationId": "me_api_v1_auth_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get the current user profile",
+        "tags": [
+          "auth"
+        ]
+      },
+      "patch": {
+        "operationId": "update_me_api_v1_auth_me_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update the current user profile",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/me/data": {
+      "delete": {
+        "operationId": "delete_my_workspace_data_api_v1_auth_me_data_delete",
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete all workspace-owned user data",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "description": "Exchange a valid refresh token for a new access and refresh token pair.",
+        "operationId": "refresh_api_v1_auth_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Refresh an authenticated session",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/register": {
+      "post": {
+        "description": "Create an account and return fresh access and refresh tokens for immediate use.",
+        "operationId": "register_api_v1_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Register a new user",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/calendar": {
+      "get": {
+        "description": "Return projected subscription renewal dates for the authenticated user.",
+        "operationId": "get_calendar_renewals_route_api_v1_calendar_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "year",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 2100,
+                  "minimum": 2000,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Year"
+            }
+          },
+          {
+            "in": "query",
+            "name": "month",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 12,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Month"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarRenewalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get calendar renewals",
+        "tags": [
+          "calendar"
+        ]
+      }
+    },
+    "/api/v1/categories": {
+      "get": {
+        "operationId": "get_categories_api_v1_categories_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List categories",
+        "tags": [
+          "categories"
+        ]
+      },
+      "post": {
+        "operationId": "create_category_route_api_v1_categories_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CategoryCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create a category",
+        "tags": [
+          "categories"
+        ]
+      }
+    },
+    "/api/v1/categories/{category_id}": {
+      "delete": {
+        "operationId": "delete_category_route_api_v1_categories__category_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "category_id",
+            "required": true,
+            "schema": {
+              "title": "Category Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete a category",
+        "tags": [
+          "categories"
+        ]
+      },
+      "get": {
+        "operationId": "get_category_api_v1_categories__category_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "category_id",
+            "required": true,
+            "schema": {
+              "title": "Category Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get a category",
+        "tags": [
+          "categories"
+        ]
+      },
+      "patch": {
+        "operationId": "update_category_route_api_v1_categories__category_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "category_id",
+            "required": true,
+            "schema": {
+              "title": "Category Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CategoryUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update a category",
+        "tags": [
+          "categories"
+        ]
+      }
+    },
+    "/api/v1/currencies": {
+      "get": {
+        "operationId": "list_supported_currencies_api_v1_currencies_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportedCurrencyListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List supported currencies",
+        "tags": [
+          "currencies"
+        ]
+      }
+    },
+    "/api/v1/currencies/rate": {
+      "get": {
+        "operationId": "get_exchange_rate_route_api_v1_currencies_rate_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "base_currency",
+            "required": false,
+            "schema": {
+              "default": "USD",
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Base Currency",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "quote_currency",
+            "required": false,
+            "schema": {
+              "default": "USD",
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Quote Currency",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "effective_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Effective Date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExchangeRateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get an exchange rate",
+        "tags": [
+          "currencies"
+        ]
+      }
+    },
+    "/api/v1/dashboard/layout": {
+      "get": {
+        "operationId": "get_dashboard_layout_route_api_v1_dashboard_layout_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardLayoutResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get the saved dashboard layout",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "update_dashboard_layout_route_api_v1_dashboard_layout_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardLayoutUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardLayoutResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Replace the saved dashboard layout",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/dashboard/score": {
+      "get": {
+        "operationId": "get_dashboard_score_route_api_v1_dashboard_score_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionScoreResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get the subscription score and duplicate candidates",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/dashboard/summary": {
+      "get": {
+        "operationId": "get_dashboard_summary_route_api_v1_dashboard_summary_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSummaryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get dashboard summary metrics",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/expense-reports": {
+      "get": {
+        "operationId": "list_expense_reports_route_api_v1_expense_reports_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExpenseReportListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List expense reports",
+        "tags": [
+          "expense-reports"
+        ]
+      }
+    },
+    "/api/v1/expense-reports/analytics": {
+      "get": {
+        "operationId": "get_expense_analytics_route_api_v1_expense_reports_analytics_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "range",
+            "required": false,
+            "schema": {
+              "default": "180d",
+              "enum": [
+                "90d",
+                "180d",
+                "365d"
+              ],
+              "title": "Range",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get analytics aggregates for the reports workspace",
+        "tags": [
+          "expense-reports"
+        ]
+      }
+    },
+    "/api/v1/expense-reports/{report_id}": {
+      "get": {
+        "operationId": "get_expense_report_route_api_v1_expense_reports__report_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "report_id",
+            "required": true,
+            "schema": {
+              "title": "Report Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExpenseReportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get an expense report",
+        "tags": [
+          "expense-reports"
+        ]
+      }
+    },
+    "/api/v1/exports": {
+      "get": {
+        "description": "Download authenticated subscription data as CSV, JSON, or iCalendar with attachment headers suitable for browser downloads.",
+        "operationId": "export_subscriptions_route_api_v1_exports_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "csv",
+              "enum": [
+                "csv",
+                "json",
+                "ics"
+              ],
+              "title": "Format",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "active_only",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Active Only",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_payment_history",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Include Payment History",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "calendar_months",
+            "required": false,
+            "schema": {
+              "default": 12,
+              "maximum": 24,
+              "minimum": 1,
+              "title": "Calendar Months",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Export subscription data",
+        "tags": [
+          "exports"
+        ]
+      }
+    },
+    "/api/v1/family": {
+      "delete": {
+        "operationId": "leave_family_route_api_v1_family_delete",
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Leave the current family workspace",
+        "tags": [
+          "family"
+        ]
+      },
+      "get": {
+        "operationId": "get_family_route_api_v1_family_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FamilyStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get the current family workspace",
+        "tags": [
+          "family"
+        ]
+      },
+      "post": {
+        "operationId": "create_family_route_api_v1_family_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FamilyCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FamilyStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create a family workspace",
+        "tags": [
+          "family"
+        ]
+      }
+    },
+    "/api/v1/family/dashboard": {
+      "get": {
+        "operationId": "get_family_dashboard_route_api_v1_family_dashboard_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FamilyDashboardResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get family dashboard summary and sharing recommendations",
+        "tags": [
+          "family"
+        ]
+      }
+    },
+    "/api/v1/family/join": {
+      "post": {
+        "operationId": "join_family_route_api_v1_family_join_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FamilyJoinRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FamilyStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Join a family workspace by invite code",
+        "tags": [
+          "family"
+        ]
+      }
+    },
+    "/api/v1/family/privacy": {
+      "patch": {
+        "operationId": "update_family_privacy_route_api_v1_family_privacy_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FamilyPrivacyUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FamilyStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update family sharing privacy",
+        "tags": [
+          "family"
+        ]
+      }
+    },
+    "/api/v1/health": {
+      "get": {
+        "operationId": "health_check_api_v1_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Check Api V1 Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Check API health",
+        "tags": [
+          "health"
+        ]
+      }
+    },
+    "/api/v1/notifications": {
+      "get": {
+        "operationId": "get_notifications_api_v1_notifications_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List notifications",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/preferences": {
+      "get": {
+        "operationId": "get_preferences_api_v1_notifications_preferences_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationPreferencesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get notification preferences",
+        "tags": [
+          "notifications"
+        ]
+      },
+      "put": {
+        "operationId": "update_preferences_api_v1_notifications_preferences_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationPreferencesUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationPreferencesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update notification preferences",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/read-all": {
+      "post": {
+        "operationId": "read_all_notifications_api_v1_notifications_read_all_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationReadAllResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Mark all notifications read",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/telegram/link": {
+      "delete": {
+        "operationId": "delete_telegram_link_api_v1_notifications_telegram_link_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TelegramUnlinkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Unlink Telegram",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/telegram/link-token": {
+      "post": {
+        "operationId": "create_link_token_api_v1_notifications_telegram_link_token_post",
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TelegramLinkTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Telegram link token",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/telegram/webhook": {
+      "post": {
+        "operationId": "telegram_webhook_api_v1_notifications_telegram_webhook_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Telegram-Bot-Api-Secret-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Telegram-Bot-Api-Secret-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TelegramWebhookPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TelegramWebhookResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Receive Telegram webhook",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/notifications/{notification_id}/read": {
+      "post": {
+        "operationId": "read_notification_api_v1_notifications__notification_id__read_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notification_id",
+            "required": true,
+            "schema": {
+              "title": "Notification Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Mark notification read",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/v1/payment-methods": {
+      "get": {
+        "operationId": "get_payment_methods_api_v1_payment_methods_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List payment methods",
+        "tags": [
+          "payment-methods"
+        ]
+      },
+      "post": {
+        "operationId": "create_payment_method_route_api_v1_payment_methods_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentMethodCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create a payment method",
+        "tags": [
+          "payment-methods"
+        ]
+      }
+    },
+    "/api/v1/payment-methods/{payment_method_id}": {
+      "delete": {
+        "operationId": "delete_payment_method_route_api_v1_payment_methods__payment_method_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "payment_method_id",
+            "required": true,
+            "schema": {
+              "title": "Payment Method Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete a payment method",
+        "tags": [
+          "payment-methods"
+        ]
+      },
+      "get": {
+        "operationId": "get_payment_method_api_v1_payment_methods__payment_method_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "payment_method_id",
+            "required": true,
+            "schema": {
+              "title": "Payment Method Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get a payment method",
+        "tags": [
+          "payment-methods"
+        ]
+      },
+      "patch": {
+        "operationId": "update_payment_method_route_api_v1_payment_methods__payment_method_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "payment_method_id",
+            "required": true,
+            "schema": {
+              "title": "Payment Method Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentMethodUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update a payment method",
+        "tags": [
+          "payment-methods"
+        ]
+      }
+    },
+    "/api/v1/subscriptions": {
+      "get": {
+        "description": "Return a paginated, filterable list of subscriptions owned by the authenticated user.",
+        "operationId": "get_subscriptions_api_v1_subscriptions_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "category_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Category Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "payment_method_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Payment Method Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cadence",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cadence"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_amount",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Min Amount"
+            }
+          },
+          {
+            "in": "query",
+            "name": "max_amount",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Max Amount"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List subscriptions",
+        "tags": [
+          "subscriptions"
+        ]
+      },
+      "post": {
+        "operationId": "create_subscription_route_api_v1_subscriptions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create a subscription",
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/api/v1/subscriptions/{subscription_id}": {
+      "delete": {
+        "operationId": "delete_subscription_route_api_v1_subscriptions__subscription_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "subscription_id",
+            "required": true,
+            "schema": {
+              "title": "Subscription Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete a subscription",
+        "tags": [
+          "subscriptions"
+        ]
+      },
+      "get": {
+        "operationId": "get_subscription_api_v1_subscriptions__subscription_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "subscription_id",
+            "required": true,
+            "schema": {
+              "title": "Subscription Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get a subscription",
+        "tags": [
+          "subscriptions"
+        ]
+      },
+      "patch": {
+        "operationId": "update_subscription_route_api_v1_subscriptions__subscription_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "subscription_id",
+            "required": true,
+            "schema": {
+              "title": "Subscription Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update a subscription",
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/api/v1/subscriptions/{subscription_id}/payment-history": {
+      "get": {
+        "operationId": "get_subscription_payment_history_route_api_v1_subscriptions__subscription_id__payment_history_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "subscription_id",
+            "required": true,
+            "schema": {
+              "title": "Subscription Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionPaymentHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get subscription payment history",
+        "tags": [
+          "subscriptions"
+        ]
+      }
+    },
+    "/api/v1/uploads": {
+      "get": {
+        "operationId": "list_uploads_route_api_v1_uploads_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List uploads",
+        "tags": [
+          "uploads"
+        ]
+      },
+      "post": {
+        "operationId": "create_upload_route_api_v1_uploads_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_upload_route_api_v1_uploads_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create an upload",
+        "tags": [
+          "uploads"
+        ]
+      }
+    },
+    "/api/v1/uploads/{upload_id}": {
+      "delete": {
+        "operationId": "delete_upload_route_api_v1_uploads__upload_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "upload_id",
+            "required": true,
+            "schema": {
+              "title": "Upload Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete an upload",
+        "tags": [
+          "uploads"
+        ]
+      }
+    },
+    "/api/v1/uploads/{upload_id}/status": {
+      "get": {
+        "operationId": "get_upload_status_route_api_v1_uploads__upload_id__status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "upload_id",
+            "required": true,
+            "schema": {
+              "title": "Upload Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get upload processing status",
+        "tags": [
+          "uploads"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Service readiness and uptime checks.",
+      "name": "health"
+    },
+    {
+      "description": "Registration, login, token refresh, and workspace reset endpoints.",
+      "name": "auth"
+    },
+    {
+      "description": "User-scoped subscription categories used across forms, filters, and dashboards.",
+      "name": "categories"
+    },
+    {
+      "description": "User-scoped payment rails used by subscriptions and payment history.",
+      "name": "payment-methods"
+    },
+    {
+      "description": "CRUD and filtering for recurring subscription records.",
+      "name": "subscriptions"
+    },
+    {
+      "description": "Dashboard summary metrics and persistent widget layout state.",
+      "name": "dashboard"
+    },
+    {
+      "description": "Generated spend reports from uploaded statements, including stored chart-ready expense summaries.",
+      "name": "expense-reports"
+    },
+    {
+      "description": "Downloadable CSV, JSON, and iCalendar subscription exports.",
+      "name": "exports"
+    },
+    {
+      "description": "Statement file ingestion, upload history, and processing status checks.",
+      "name": "uploads"
+    }
+  ]
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,95 @@
+# MySubscription Tracker Frontend
+
+Next.js App Router frontend for the MySubscription Tracker workspace.
+
+## Requirements
+
+- Node.js 22
+- npm
+- Backend API running on `http://localhost:8000/api/v1`
+
+## Setup
+
+```bash
+cd frontend
+npm ci
+npm run dev
+```
+
+The app runs on `http://localhost:3000`.
+
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | `http://localhost:8000/api/v1` | Browser API base URL |
+
+## Scripts
+
+```bash
+npm run dev             # Next.js development server
+npm run build           # Production build
+npm run build:analyze   # Production build with bundle analyzer
+npm run start           # Serve a production build
+npm run lint            # Next.js lint
+npm run typecheck       # TypeScript check
+npm run test            # Vitest unit tests
+npm run test:watch      # Watch-mode unit tests
+npm run test:coverage   # Unit tests with coverage
+npm run test:e2e        # Playwright E2E suite
+```
+
+## App Routes
+
+Public routes:
+
+- `/` landing page
+- `/login`
+- `/register`
+- `/privacy`
+
+Authenticated workspace routes:
+
+- `/dashboard` snapshot bar, onboarding, widgets, layout persistence
+- `/uploads` CSV/PDF intake, processing status, history, delete actions
+- `/subscriptions` searchable subscription management and manual entry
+- `/subscriptions/[subscriptionId]` subscription detail and payment history
+- `/reports` expense reports and analytics charts
+- `/exports` CSV, JSON, and iCalendar downloads
+- `/score` subscription health score and duplicate candidates
+- `/family` household sharing, invite, member privacy, recommendations
+- `/calendar` renewal calendar
+- `/payments` payment rail placeholder and billing navigation
+- `/settings` profile, currency, categories, payment methods, theme, destructive reset
+
+## Component Guide
+
+- Route pages in `src/app` should stay thin and compose workspace components from
+  `src/components`.
+- API access lives in `src/lib/api-client.ts`; feature hooks in `src/hooks` wrap React Query
+  mutations and queries.
+- Shared UI primitives live in `src/components/ui`. Prefer these before adding route-local
+  button, dialog, empty-state, skeleton, or page-header patterns.
+- Authenticated pages render inside `src/components/app-shell/app-shell.tsx`, which owns
+  navigation, route metadata, workspace search labels, notification access, and sign-out.
+- Domain components live in feature folders: `dashboard`, `uploads`, `subscriptions`,
+  `reports`, `exports`, `family`, `notifications`, `onboarding`.
+- Form validation should use local Zod schemas or shared validators from `src/lib/validators.ts`.
+- Currency formatting should use `CurrencyDisplay` or helpers from `src/lib/currency.ts`.
+
+## Testing
+
+Unit tests:
+
+```bash
+npm run test
+```
+
+E2E tests:
+
+```bash
+PLAYWRIGHT_BROWSERS_PATH=/tmp/ms-playwright npm run test:e2e
+```
+
+The E2E suite starts the Next.js app and backend test server through Playwright config and
+shared setup helpers. CI installs Chromium, Firefox, and WebKit before running the matrix.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -75,6 +75,9 @@ export default function Home() {
 
             <div className="flex items-center gap-3">
               <Button asChild className="rounded-full px-5" variant="ghost">
+                <Link href="/privacy">Privacy</Link>
+              </Button>
+              <Button asChild className="rounded-full px-5" variant="ghost">
                 <Link href="/login">Sign in</Link>
               </Button>
               <Button asChild className="rounded-full px-5">
@@ -283,6 +286,13 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      <footer className="mx-auto flex max-w-7xl flex-col gap-3 border-t border-black/10 px-6 py-8 text-sm text-black/58 dark:border-white/10 dark:text-white/58 sm:flex-row sm:items-center sm:justify-between sm:px-10 lg:px-12">
+        <span>MySubscription Tracker</span>
+        <Link className="transition hover:text-ink dark:hover:text-white" href="/privacy">
+          Privacy policy
+        </Link>
+      </footer>
     </main>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -288,7 +288,7 @@ export default function Home() {
       </section>
 
       <footer className="mx-auto flex max-w-7xl flex-col gap-3 border-t border-black/10 px-6 py-8 text-sm text-black/58 dark:border-white/10 dark:text-white/58 sm:flex-row sm:items-center sm:justify-between sm:px-10 lg:px-12">
-        <span>MySubscription Tracker</span>
+        <span>Recurring spend workspace</span>
         <Link className="transition hover:text-ink dark:hover:text-white" href="/privacy">
           Privacy policy
         </Link>

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ArrowLeft, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "How MySubscription Tracker handles account, subscription, upload, notification, and household data.",
+};
+
+const sections = [
+  {
+    body: "We collect account details, subscription records, uploaded statement files, parsed transaction data, settings, notification preferences, and family sharing choices that you provide while using the workspace.",
+    title: "Information we handle",
+  },
+  {
+    body: "We use workspace data to authenticate access, detect recurring charges, show renewal and analytics views, generate exports, deliver reminders, and keep household sharing controls working.",
+    title: "How the product uses data",
+  },
+  {
+    body: "Uploaded files are used for parsing and detection. Parsed transaction data stays scoped to the authenticated user and powers reports, dashboards, and subscription suggestions.",
+    title: "Uploads and parsing",
+  },
+  {
+    body: "Security controls include authenticated access, refreshable sessions, CSRF checks for browser state changes, request size limits, rate limiting, private cache headers, and encrypted sensitive notification fields.",
+    title: "Security controls",
+  },
+  {
+    body: "Family features only share household metrics according to membership and privacy settings. Members can leave a family workspace, and privacy controls can limit shared plan visibility.",
+    title: "Family sharing",
+  },
+  {
+    body: "You can export subscription data from the exports workspace and delete workspace-owned data from settings. Some operational logs and required security records may remain for service integrity.",
+    title: "Choices and deletion",
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,rgba(255,255,255,0.88),rgba(231,237,242,0.72)),hsl(var(--background))] px-6 py-8 text-ink dark:bg-[linear-gradient(180deg,rgba(10,16,24,0.98),rgba(17,24,33,0.96))] dark:text-white sm:px-10 lg:px-12">
+      <div className="mx-auto max-w-5xl">
+        <header className="flex items-center justify-between gap-4">
+          <Link className="font-serif text-2xl tracking-tight" href="/">
+            MySubscription Tracker
+          </Link>
+          <Button asChild className="rounded-full px-5" variant="outline">
+            <Link href="/">
+              <ArrowLeft className="mr-2 size-4" />
+              Back home
+            </Link>
+          </Button>
+        </header>
+
+        <section className="py-16 sm:py-20">
+          <div className="inline-flex size-14 items-center justify-center rounded-[1.25rem] border border-black/10 bg-white/70 shadow-line dark:border-white/10 dark:bg-white/10">
+            <ShieldCheck className="size-6" />
+          </div>
+          <p className="mt-8 text-xs uppercase tracking-[0.32em] text-black/45 dark:text-white/45">
+            Privacy policy
+          </p>
+          <h1 className="mt-5 max-w-3xl font-serif text-5xl leading-[0.96] sm:text-6xl">
+            Workspace data stays scoped to the subscription work you ask the product to do.
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-8 text-black/66 dark:text-white/66">
+            This policy summarizes the data handled by the current product surface. It is written
+            for the application in this repository and should be reviewed before production launch
+            with the final hosting, support, and legal ownership details.
+          </p>
+        </section>
+
+        <section className="grid gap-5 pb-16 md:grid-cols-2">
+          {sections.map((section) => (
+            <article
+              className="border-t border-black/10 py-6 dark:border-white/10"
+              key={section.title}
+            >
+              <h2 className="text-2xl font-semibold tracking-tight">{section.title}</h2>
+              <p className="mt-3 text-sm leading-7 text-black/64 dark:text-white/64">
+                {section.body}
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <footer className="border-t border-black/10 py-8 text-sm text-black/58 dark:border-white/10 dark:text-white/58">
+          Last updated: April 30, 2026
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/frontend/tests/unit/app/privacy.test.tsx
+++ b/frontend/tests/unit/app/privacy.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import PrivacyPage from "@/app/privacy/page";
+
+describe("PrivacyPage", () => {
+  it("renders the privacy policy sections", () => {
+    render(<PrivacyPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /Workspace data stays scoped/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Uploads and parsing/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Back home/i })).toHaveAttribute("href", "/");
+  });
+});


### PR DESCRIPTION
Day 29 is complete and closed.

Implemented and pushed `origin/day-29/documentation` at `bf25812` with 10 per-file commits. Covered [`README.md`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/README.md), [`backend/README.md`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/README.md), [`backend/docs/api.md`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/docs/api.md), [`backend/docs/openapi.json`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/docs/openapi.json), [`frontend/README.md`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/README.md), [`CHANGELOG.md`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/CHANGELOG.md), and the new privacy page/test.

Verification passed locally: lockfile guard, backend pytest/ruff/mypy, frontend unit tests, lint, typecheck, and build. GitHub CI also passed: Backend CI `25176156946`; Frontend CI `25176489529` including Playwright E2E.

GitHub issues `#101`, `#102`, and umbrella `#100` are closed, and milestone 29 is closed with `open_issues = 0`. Next scheduled run should advance to Day 30 on `day-30/final-qa`.

::inbox-item{title="Day 29 documentation complete" summary="Milestone closed; next run advances to Day 30"}