### PR TITLE
Day 30/final qa

### DIFF
--- a/backend/tests/api/test_analytics.py
+++ b/backend/tests/api/test_analytics.py
@@ -197,16 +197,9 @@ def test_expense_analytics_returns_category_method_frequency_and_trend_data(clie
         start_date=str(today - timedelta(days=400)),
     )
 
-    _seed_payment_history(
-        netflix_id,
-        datetime.combine(current_month_start + timedelta(days=2), datetime.min.time(), tzinfo=UTC),
-        Decimal("15.00"),
-    )
-    _seed_payment_history(
-        spotify_id,
-        datetime.combine(current_month_start + timedelta(days=4), datetime.min.time(), tzinfo=UTC),
-        Decimal("10.00"),
-    )
+    current_month_paid_at = datetime.combine(today, datetime.min.time(), tzinfo=UTC)
+    _seed_payment_history(netflix_id, current_month_paid_at, Decimal("15.00"))
+    _seed_payment_history(spotify_id, current_month_paid_at, Decimal("10.00"))
     _seed_payment_history(
         electric_id,
         datetime.combine(previous_month_start + timedelta(days=5), datetime.min.time(), tzinfo=UTC),
@@ -331,7 +324,7 @@ def test_expense_analytics_converts_observed_and_projected_totals(client) -> Non
     )
     _seed_payment_history(
         subscription_id,
-        datetime.combine(current_month_start + timedelta(days=2), datetime.min.time(), tzinfo=UTC),
+        datetime.combine(today, datetime.min.time(), tzinfo=UTC),
         Decimal("20.00"),
     )
 

--- a/backend/tests/test_final_qa.py
+++ b/backend/tests/test_final_qa.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from src.core.logging import configure_logging, get_logger
+from src.jobs import csv_processing, pdf_processing
+from src.worker import WorkerSettings
+
+
+def test_worker_registers_upload_jobs_and_daily_cron_jobs() -> None:
+    function_names = {function.__name__ for function in WorkerSettings.functions}
+    assert function_names == {
+        "process_csv_upload_job",
+        "process_pdf_upload_job",
+        "refresh_exchange_rates_job",
+        "dispatch_renewal_notifications_job",
+    }
+
+    cron_jobs = {job.name: job for job in WorkerSettings.cron_jobs}
+    assert cron_jobs["daily_exchange_rate_refresh"].hour == 6
+    assert cron_jobs["daily_exchange_rate_refresh"].minute == 0
+    assert cron_jobs["daily_renewal_notifications"].hour == 9
+    assert cron_jobs["daily_renewal_notifications"].minute == 0
+
+
+@pytest.mark.asyncio
+async def test_upload_background_jobs_dispatch_to_stored_upload_processor(monkeypatch: Any) -> None:
+    processed: list[int] = []
+
+    async def fake_process_stored_upload(upload_id: int) -> None:
+        processed.append(upload_id)
+
+    monkeypatch.setattr(csv_processing, "process_stored_upload", fake_process_stored_upload)
+    monkeypatch.setattr(pdf_processing, "process_stored_upload", fake_process_stored_upload)
+
+    await csv_processing.process_csv_upload_job({}, 101)
+    await pdf_processing.process_pdf_upload_job({}, 202)
+
+    assert processed == [101, 202]
+
+
+def test_json_logging_includes_structured_context() -> None:
+    configure_logging(json_logs=True, log_level="INFO")
+    processors = structlog.get_config()["processors"]
+    assert isinstance(processors[-1], structlog.processors.JSONRenderer)
+
+    with capture_logs() as logs:
+        get_logger("final_qa").info(
+            "final_qa.logging_verified",
+            component="backend",
+            route="/api/v1/health",
+        )
+
+    [log_record] = logs
+    assert log_record["event"] == "final_qa.logging_verified"
+    assert log_record["log_level"] == "info"
+    assert log_record["component"] == "backend"
+    assert log_record["route"] == "/api/v1/health"

--- a/frontend/tests/unit/playwright-config.test.ts
+++ b/frontend/tests/unit/playwright-config.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import config from "../../playwright.config";
+
+describe("Playwright final QA configuration", () => {
+  it("runs the regression suite across desktop and mobile browser projects", () => {
+    const projectNames = config.projects?.map((project) => project.name) ?? [];
+
+    expect(projectNames).toEqual(
+      expect.arrayContaining(["chromium", "firefox", "webkit", "mobile-chrome"]),
+    );
+  });
+});


### PR DESCRIPTION
Day 30 is complete and closed in GitHub.

Implemented and pushed `origin/day-30/final-qa` at `a36f919` with 3 commits:
- Fixed the first-of-month analytics test flake in [`/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/tests/api/test_analytics.py`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/tests/api/test_analytics.py)
- Added backend final-QA coverage in [`/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/tests/test_final_qa.py`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/backend/tests/test_final_qa.py)
- Added frontend Playwright matrix coverage in [`/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/tests/unit/playwright-config.test.ts`](/Users/work/.codex/automations/daily-milestone-worker-2/repo/frontend/tests/unit/playwright-config.test.ts)

Checks passed locally: lockfile guard, backend pytest/ruff/mypy, frontend lint/typecheck/unit/build. Local Playwright remained sandbox-blocked, but GitHub Frontend CI `25223308145` passed including E2E across Chromium, Firefox, WebKit, and mobile Chrome. Backend CI `25223244806` passed.

Closed child issues `#104` and `#105`, then umbrella `#103`, and closed milestone 30 with `open_issues = 0`. All numbered milestones are now closed.

::inbox-item{title="Day 30 final QA complete" summary="All milestones closed; CI browser matrix passed"}